### PR TITLE
Add `ruff` as formatter and linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -283,3 +283,12 @@ lib/
 benchmark/level2/audit.log
 logs/
 tmp/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[project]
+name = "tlaps-bench"
+version = "0.1.0"
+description = "A benchmark for evaluating AI's ability to write TLAPS proofs"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = []
+
+[tool.black]
+line-length = 120
+target-version = ["py312"]
+
+[tool.isort]
+profile = "black"
+line_length = 120
+
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+src = ["src", "scripts", "tests"]
+exclude = [
+    ".venv",
+    "build",
+    "dist",
+    "*.egg-info",
+]
+
+[tool.ruff.lint]
+fixable = ["ALL"]
+select = [
+    "E",    # pycodestyle errors
+    "F",    # Pyflakes
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+    "I",    # isort
+]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+    "SIM102", # nested if statements
+]
+
+[tool.ruff.lint.per-file-ignores]
+# These files manipulate sys.path before importing project modules
+"tests/**/*.py" = ["E402"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["common", "tlacheck", "tlacore", "evaluator", "dataset"]
+
+[tool.ruff.format]
+quote-style = "double"
+docstring-code-format = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 description = "A benchmark for evaluating AI's ability to write TLAPS proofs"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "pyinstaller>=6.21.0",
+]
 
 [tool.black]
 line-length = 120

--- a/scripts/import_tlaps_example.py
+++ b/scripts/import_tlaps_example.py
@@ -37,9 +37,7 @@ from pathlib import Path
 # Single source of truth for module classification lives in the L1 generator.
 sys.path.insert(
     0,
-    os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "..", "src", "dataset", "level1"
-    ),
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src", "dataset", "level1"),
 )
 from generate import RESOLVABLE_MODULES  # noqa: E402
 
@@ -118,9 +116,7 @@ def parse_instances(text: str):
 def classify(mod: str) -> str:
     if mod in RESOLVABLE_MODULES:
         return "resolvable"  # stdlib or vendored community — tlapm finds it, don't copy
-    return (
-        "local"  # assume local until proven otherwise (file presence checked by caller)
-    )
+    return "local"  # assume local until proven otherwise (file presence checked by caller)
 
 
 def proof_modules_from_manifest(spec_dir: Path):
@@ -274,9 +270,7 @@ def resolve_unit(unit_dir: Path, proof_basenames):
                 "missing": set(),
                 "ok": False,
             }
-            result["skipped_modules"][base] = (
-                f"module-name-mismatch: file {base} declares MODULE {nm}"
-            )
+            result["skipped_modules"][base] = f"module-name-mismatch: file {base} declares MODULE {nm}"
             continue
         to_copy, missing = _resolve_one(nm, local_by_name)
         ok = not missing
@@ -284,15 +278,11 @@ def resolve_unit(unit_dir: Path, proof_basenames):
         if ok:
             result["to_copy"] |= to_copy
         else:
-            result["skipped_modules"][base] = "missing-deps: " + ",".join(
-                sorted(missing)
-            )
+            result["skipped_modules"][base] = "missing-deps: " + ",".join(sorted(missing))
     return result
 
 
-def import_unit(
-    unit_name, unit_dir, proof_basenames, dry_run=False, include_unvalidatable=False
-):
+def import_unit(unit_name, unit_dir, proof_basenames, dry_run=False, include_unvalidatable=False):
     """Import one unit (a spec, or a subdir of a spec) into
     source/<unit_name>/. Returns a report dict."""
     res = resolve_unit(unit_dir, proof_basenames)
@@ -343,28 +333,15 @@ def import_spec(spec, examples_root, dry_run=False, include_unvalidatable=False)
     units, err = spec_units(spec, examples_root)
     if err:
         return [{"spec": spec, "error": err}]
-    return [
-        import_unit(name, d, bases, dry_run, include_unvalidatable)
-        for (name, d, bases) in units
-    ]
+    return [import_unit(name, d, bases, dry_run, include_unvalidatable) for (name, d, bases) in units]
 
 
 def main():
-    ap = argparse.ArgumentParser(
-        description="Import proven Examples specs into source/"
-    )
-    ap.add_argument(
-        "--examples", required=True, help="path to tlaplus/Examples checkout"
-    )
-    ap.add_argument(
-        "--spec", action="append", default=[], help="spec name (repeatable)"
-    )
-    ap.add_argument(
-        "--all", action="store_true", help="import every spec with a proof-keyed module"
-    )
-    ap.add_argument(
-        "--dry-run", action="store_true", help="resolve + report, do not copy"
-    )
+    ap = argparse.ArgumentParser(description="Import proven Examples specs into source/")
+    ap.add_argument("--examples", required=True, help="path to tlaplus/Examples checkout")
+    ap.add_argument("--spec", action="append", default=[], help="spec name (repeatable)")
+    ap.add_argument("--all", action="store_true", help="import every spec with a proof-keyed module")
+    ap.add_argument("--dry-run", action="store_true", help="resolve + report, do not copy")
     ap.add_argument(
         "--include-unvalidatable",
         action="store_true",
@@ -422,9 +399,7 @@ def main():
         n_ok += 1
         if nskipmod:
             partial.append(r)
-            print(
-                f"{r['spec']:<32} {nproof:<6} {len(r['copied']):<7} ok ({nskipmod} module(s) skipped)"
-            )
+            print(f"{r['spec']:<32} {nproof:<6} {len(r['copied']):<7} ok ({nskipmod} module(s) skipped)")
         else:
             print(f"{r['spec']:<32} {nproof:<6} {len(r['copied']):<7} ok")
     print()

--- a/src/common/cheating_detection.py
+++ b/src/common/cheating_detection.py
@@ -11,70 +11,65 @@ from dataclasses import dataclass
 
 @dataclass
 class CheatingIssue:
-    kind: str          # e.g. "PROOF_OMITTED", "EXTRA_AXIOM", "STATEMENT_MODIFIED"
+    kind: str  # e.g. "PROOF_OMITTED", "EXTRA_AXIOM", "STATEMENT_MODIFIED"
     description: str
     line: int | None = None
 
 
 def strip_comments(text: str) -> str:
     """Remove both block comments (* ... *) and line comments \\* ..."""
-    text = re.sub(r'\(\*.*?\*\)', '', text, flags=re.DOTALL)
-    text = re.sub(r'\\\*.*$', '', text, flags=re.MULTILINE)
+    text = re.sub(r"\(\*.*?\*\)", "", text, flags=re.DOTALL)
+    text = re.sub(r"\\\*.*$", "", text, flags=re.MULTILINE)
     return text
 
 
 def detect_proof_omitted(proof_text: str) -> list[CheatingIssue]:
     """Check for PROOF OMITTED or bare OMITTED in proof text."""
     issues = []
-    if re.search(r'\bPROOF\s+OMITTED\b', proof_text):
-        issues.append(CheatingIssue(
-            "PROOF_OMITTED",
-            "Proof uses PROOF OMITTED to skip obligations"
-        ))
+    if re.search(r"\bPROOF\s+OMITTED\b", proof_text):
+        issues.append(CheatingIssue("PROOF_OMITTED", "Proof uses PROOF OMITTED to skip obligations"))
 
     clean = strip_comments(proof_text)
-    for i, line in enumerate(clean.split('\n')):
-        if line.strip() == 'OMITTED':
-            issues.append(CheatingIssue(
-                "OMITTED",
-                "Bare OMITTED used as proof step",
-                line=i + 1
-            ))
+    for i, line in enumerate(clean.split("\n")):
+        if line.strip() == "OMITTED":
+            issues.append(CheatingIssue("OMITTED", "Bare OMITTED used as proof step", line=i + 1))
     return issues
 
 
 def detect_extra_axioms(original_content: str, current_content: str) -> list[CheatingIssue]:
     """Check if new AXIOM/ASSUME/ASSUMPTION declarations were added."""
     issues = []
-    orig_axioms = set(re.findall(r'^(AXIOM|ASSUME|ASSUMPTION)\b.*', original_content, re.MULTILINE))
-    new_axioms = set(re.findall(r'^(AXIOM|ASSUME|ASSUMPTION)\b.*', current_content, re.MULTILINE))
+    orig_axioms = set(re.findall(r"^(AXIOM|ASSUME|ASSUMPTION)\b.*", original_content, re.MULTILINE))
+    new_axioms = set(re.findall(r"^(AXIOM|ASSUME|ASSUMPTION)\b.*", current_content, re.MULTILINE))
 
     for ax in new_axioms - orig_axioms:
         keyword = ax.split()[0]
-        issues.append(CheatingIssue(
-            "EXTRA_AXIOM",
-            f"New {keyword} declaration added — bypasses proof obligation"
-        ))
+        issues.append(CheatingIssue("EXTRA_AXIOM", f"New {keyword} declaration added — bypasses proof obligation"))
     return issues
 
 
-def detect_preamble_modification(original_lines: list[str], current_lines: list[str],
-                                  proof_obvious_line: int) -> list[CheatingIssue]:
+def detect_preamble_modification(
+    original_lines: list[str], current_lines: list[str], proof_obvious_line: int
+) -> list[CheatingIssue]:
     """Check that everything before PROOF OBVIOUS is unchanged."""
     issues = []
     for i in range(proof_obvious_line):
         if i >= len(current_lines):
-            issues.append(CheatingIssue(
-                "PREAMBLE_MODIFIED",
-                f"Line {i+1} deleted from preamble (was: {original_lines[i].rstrip()})",
-                line=i + 1
-            ))
+            issues.append(
+                CheatingIssue(
+                    "PREAMBLE_MODIFIED",
+                    f"Line {i + 1} deleted from preamble (was: {original_lines[i].rstrip()})",
+                    line=i + 1,
+                )
+            )
         elif original_lines[i] != current_lines[i]:
-            issues.append(CheatingIssue(
-                "PREAMBLE_MODIFIED",
-                f"Preamble modified at line {i+1}: was [{original_lines[i].rstrip()}], now [{current_lines[i].rstrip()}]",
-                line=i + 1
-            ))
+            issues.append(
+                CheatingIssue(
+                    "PREAMBLE_MODIFIED",
+                    f"Preamble modified at line {i + 1}: was [{original_lines[i].rstrip()}], now [{current_lines[i].rstrip()}]",
+                    line=i + 1,
+                )
+            )
     return issues
 
 
@@ -82,12 +77,9 @@ def detect_zero_total_obligations(tlapm_output: str) -> list[CheatingIssue]:
     """Check if tlapm passed with 0 total obligations — nothing was actually proved."""
     issues = []
     # Find the LAST obligation count (the target file's, not TLAPS.tla's)
-    all_matches = re.findall(r'(\d+)\s+obligation', tlapm_output)
+    all_matches = re.findall(r"(\d+)\s+obligation", tlapm_output)
     if all_matches and int(all_matches[-1]) == 0:
-        issues.append(CheatingIssue(
-            "ZERO_OBLIGATION",
-            "tlapm passed with 0 obligations — nothing was actually proved"
-        ))
+        issues.append(CheatingIssue("ZERO_OBLIGATION", "tlapm passed with 0 obligations — nothing was actually proved"))
     return issues
 
 
@@ -99,11 +91,11 @@ def detect_empty_proof(proof_text_clean: str) -> list[CheatingIssue]:
     A PROOF followed by <n> steps or QED is a normal hierarchical proof.
     """
     issues = []
-    lines = proof_text_clean.split('\n')
+    lines = proof_text_clean.split("\n")
     for i, line in enumerate(lines):
         stripped = line.strip()
         # Match a line that is exactly "PROOF" (not PROOF OBVIOUS, PROOF OMITTED, PROOF BY ...)
-        if stripped == 'PROOF':
+        if stripped == "PROOF":
             # Look at what follows: skip blank lines
             is_empty = True
             for j in range(i + 1, len(lines)):
@@ -111,43 +103,44 @@ def detect_empty_proof(proof_text_clean: str) -> list[CheatingIssue]:
                 if not next_stripped:
                     continue
                 # Only empty if next non-blank line is ==== (module end)
-                is_empty = bool(re.match(r'^={3,}', next_stripped))
+                is_empty = bool(re.match(r"^={3,}", next_stripped))
                 break
             # Also empty if nothing follows at all (EOF)
             if is_empty:
-                issues.append(CheatingIssue(
-                    "EMPTY_PROOF",
-                    f"Empty PROOF keyword at line {i+1} — produces 0 obligations for this step",
-                    line=i + 1
-                ))
+                issues.append(
+                    CheatingIssue(
+                        "EMPTY_PROOF",
+                        f"Empty PROOF keyword at line {i + 1} — produces 0 obligations for this step",
+                        line=i + 1,
+                    )
+                )
     return issues
 
 
-def detect_statement_modification(original_content: str, current_content: str,
-                                   parse_theorems_fn) -> list[CheatingIssue]:
+def detect_statement_modification(
+    original_content: str, current_content: str, parse_theorems_fn
+) -> list[CheatingIssue]:
     """Check if the target theorem statement was modified."""
     issues = []
 
     def get_last_stmt(content):
-        lines = content.split('\n')
+        lines = content.split("\n")
         thms = parse_theorems_fn(lines)
         if thms:
             last = thms[-1]
-            return '\n'.join(lines[last.statement_start:last.statement_end + 1]).strip()
+            return "\n".join(lines[last.statement_start : last.statement_end + 1]).strip()
         return None
 
     orig_stmt = get_last_stmt(original_content)
     new_stmt = get_last_stmt(current_content)
     if orig_stmt and new_stmt and orig_stmt != new_stmt:
-        issues.append(CheatingIssue(
-            "STATEMENT_MODIFIED",
-            "Theorem statement was modified from the original"
-        ))
+        issues.append(CheatingIssue("STATEMENT_MODIFIED", "Theorem statement was modified from the original"))
     return issues
 
 
-def detect_missing_proof(original_lines: list[str], current_lines: list[str],
-                         proof_obvious_line: int) -> list[CheatingIssue]:
+def detect_missing_proof(
+    original_lines: list[str], current_lines: list[str], proof_obvious_line: int
+) -> list[CheatingIssue]:
     """Check that the target theorem still has a PROOF block in the current file.
 
     Catches the cheat where PROOF OBVIOUS is simply deleted (leaving a bare
@@ -160,37 +153,38 @@ def detect_missing_proof(original_lines: list[str], current_lines: list[str],
     # appear BEFORE any new THEOREM/LEMMA/COROLLARY/PROPOSITION declaration.
     # If a new theorem appears first, it means the target theorem was left as a
     # bare declaration (0 obligations) and a fake theorem was added.
-    clean = strip_comments('\n'.join(current_lines[proof_obvious_line:]))
+    clean = strip_comments("\n".join(current_lines[proof_obvious_line:]))
     found_proof = False
-    for line in clean.split('\n'):
+    for line in clean.split("\n"):
         stripped = line.strip()
         if not stripped:
             continue
         # Check if we hit a PROOF keyword
-        if re.match(r'^PROOF\b', stripped) or re.search(r'\bPROOF\b', stripped):
+        if re.match(r"^PROOF\b", stripped) or re.search(r"\bPROOF\b", stripped):
             found_proof = True
             break
         # Check if we hit proof steps directly (valid TLAPS syntax without explicit PROOF keyword)
-        if re.match(r'^<\d+>', stripped):
+        if re.match(r"^<\d+>", stripped):
             found_proof = True
             break
         # Check if we hit a new theorem declaration before finding PROOF
-        if re.match(r'^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\b', stripped):
+        if re.match(r"^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\b", stripped):
             break
         # Check for module end
-        if re.match(r'^={3,}', stripped):
+        if re.match(r"^={3,}", stripped):
             break
     if not found_proof:
-        issues.append(CheatingIssue(
-            "MISSING_PROOF",
-            "Target theorem has no PROOF block — bare declaration generates 0 obligations",
-            line=proof_obvious_line + 1
-        ))
+        issues.append(
+            CheatingIssue(
+                "MISSING_PROOF",
+                "Target theorem has no PROOF block — bare declaration generates 0 obligations",
+                line=proof_obvious_line + 1,
+            )
+        )
     return issues
 
 
-def detect_missing_proofs_summary(summary_output: str,
-                                   target_theorem_line: int | None = None) -> list[CheatingIssue]:
+def detect_missing_proofs_summary(summary_output: str, target_theorem_line: int | None = None) -> list[CheatingIssue]:
     """Check tlapm --summary output for missing proofs in the target theorem.
 
     tlapm treats a bare QED (without BY/OBVIOUS) as an implicit omission,
@@ -214,25 +208,27 @@ def detect_missing_proofs_summary(summary_output: str,
 
     # Find the section for the target theorem by line number
     # Format: "---- incomplete proof of theorem at line N, character M ----"
-    pattern = rf'----\s+incomplete proof of theorem at line {target_theorem_line}\b'
+    pattern = rf"----\s+incomplete proof of theorem at line {target_theorem_line}\b"
     m = re.search(pattern, summary_output)
     if not m:
         return issues  # target theorem not in incomplete list — good
 
     # Extract this section (until next "----" section or "====")
     start = m.end()
-    end_m = re.search(r'\n\s*====', summary_output[start:])
-    section = summary_output[start:start + end_m.start()] if end_m else summary_output[start:]
+    end_m = re.search(r"\n\s*====", summary_output[start:])
+    section = summary_output[start : start + end_m.start()] if end_m else summary_output[start:]
 
-    m2 = re.search(r'missing_proofs_count\s*=\s*(\d+)', section)
+    m2 = re.search(r"missing_proofs_count\s*=\s*(\d+)", section)
     if m2 and int(m2.group(1)) > 0:
         count = int(m2.group(1))
-        locations = re.findall(r'missing_proof_\d+\s+at\s+line\s+(\d+)', section)
+        locations = re.findall(r"missing_proof_\d+\s+at\s+line\s+(\d+)", section)
         loc_str = f" (at line(s) {', '.join(locations)})" if locations else ""
-        issues.append(CheatingIssue(
-            "MISSING_PROOF_STEPS",
-            f"tlapm --summary reports {count} missing proof(s){loc_str} in target theorem — proof is incomplete"
-        ))
+        issues.append(
+            CheatingIssue(
+                "MISSING_PROOF_STEPS",
+                f"tlapm --summary reports {count} missing proof(s){loc_str} in target theorem — proof is incomplete",
+            )
+        )
     return issues
 
 
@@ -245,17 +241,21 @@ def detect_dependency_modification(dep_files: dict[str, tuple[str, str]]) -> lis
     issues = []
     for filename, (original, current) in dep_files.items():
         if original != current:
-            issues.append(CheatingIssue(
-                "DEPENDENCY_MODIFIED",
-                f"Dependency file {filename} was modified — not allowed"
-            ))
+            issues.append(
+                CheatingIssue("DEPENDENCY_MODIFIED", f"Dependency file {filename} was modified — not allowed")
+            )
     return issues
 
 
-def detect_cheating_full(proof_text: str, original_content: str, current_content: str,
-                         tlapm_output: str = "", tlapm_passed: bool = False,
-                         parse_theorems_fn=None,
-                         dep_files: dict[str, tuple[str, str]] | None = None) -> list[CheatingIssue]:
+def detect_cheating_full(
+    proof_text: str,
+    original_content: str,
+    current_content: str,
+    tlapm_output: str = "",
+    tlapm_passed: bool = False,
+    parse_theorems_fn=None,
+    dep_files: dict[str, tuple[str, str]] | None = None,
+) -> list[CheatingIssue]:
     """Run all cheating checks. This is the main entry point.
 
     Args:

--- a/src/common/cheating_detection.py
+++ b/src/common/cheating_detection.py
@@ -7,14 +7,13 @@ Used by both check_proof.py (AI agent feedback) and validate_benchmarks.py (batc
 
 import re
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
 
 
 @dataclass
 class CheatingIssue:
     kind: str          # e.g. "PROOF_OMITTED", "EXTRA_AXIOM", "STATEMENT_MODIFIED"
     description: str
-    line: Optional[int] = None
+    line: int | None = None
 
 
 def strip_comments(text: str) -> str:
@@ -24,7 +23,7 @@ def strip_comments(text: str) -> str:
     return text
 
 
-def detect_proof_omitted(proof_text: str) -> List[CheatingIssue]:
+def detect_proof_omitted(proof_text: str) -> list[CheatingIssue]:
     """Check for PROOF OMITTED or bare OMITTED in proof text."""
     issues = []
     if re.search(r'\bPROOF\s+OMITTED\b', proof_text):
@@ -44,7 +43,7 @@ def detect_proof_omitted(proof_text: str) -> List[CheatingIssue]:
     return issues
 
 
-def detect_extra_axioms(original_content: str, current_content: str) -> List[CheatingIssue]:
+def detect_extra_axioms(original_content: str, current_content: str) -> list[CheatingIssue]:
     """Check if new AXIOM/ASSUME/ASSUMPTION declarations were added."""
     issues = []
     orig_axioms = set(re.findall(r'^(AXIOM|ASSUME|ASSUMPTION)\b.*', original_content, re.MULTILINE))
@@ -59,8 +58,8 @@ def detect_extra_axioms(original_content: str, current_content: str) -> List[Che
     return issues
 
 
-def detect_preamble_modification(original_lines: List[str], current_lines: List[str],
-                                  proof_obvious_line: int) -> List[CheatingIssue]:
+def detect_preamble_modification(original_lines: list[str], current_lines: list[str],
+                                  proof_obvious_line: int) -> list[CheatingIssue]:
     """Check that everything before PROOF OBVIOUS is unchanged."""
     issues = []
     for i in range(proof_obvious_line):
@@ -79,7 +78,7 @@ def detect_preamble_modification(original_lines: List[str], current_lines: List[
     return issues
 
 
-def detect_zero_total_obligations(tlapm_output: str) -> List[CheatingIssue]:
+def detect_zero_total_obligations(tlapm_output: str) -> list[CheatingIssue]:
     """Check if tlapm passed with 0 total obligations — nothing was actually proved."""
     issues = []
     # Find the LAST obligation count (the target file's, not TLAPS.tla's)
@@ -92,7 +91,7 @@ def detect_zero_total_obligations(tlapm_output: str) -> List[CheatingIssue]:
     return issues
 
 
-def detect_empty_proof(proof_text_clean: str) -> List[CheatingIssue]:
+def detect_empty_proof(proof_text_clean: str) -> list[CheatingIssue]:
     """Check for empty PROOF blocks: 'PROOF' followed by nothing before
     module end (====) or end of file.
 
@@ -128,7 +127,7 @@ def detect_empty_proof(proof_text_clean: str) -> List[CheatingIssue]:
 
 
 def detect_statement_modification(original_content: str, current_content: str,
-                                   parse_theorems_fn) -> List[CheatingIssue]:
+                                   parse_theorems_fn) -> list[CheatingIssue]:
     """Check if the target theorem statement was modified."""
     issues = []
 
@@ -150,8 +149,8 @@ def detect_statement_modification(original_content: str, current_content: str,
     return issues
 
 
-def detect_missing_proof(original_lines: List[str], current_lines: List[str],
-                         proof_obvious_line: int) -> List[CheatingIssue]:
+def detect_missing_proof(original_lines: list[str], current_lines: list[str],
+                         proof_obvious_line: int) -> list[CheatingIssue]:
     """Check that the target theorem still has a PROOF block in the current file.
 
     Catches the cheat where PROOF OBVIOUS is simply deleted (leaving a bare
@@ -194,7 +193,7 @@ def detect_missing_proof(original_lines: List[str], current_lines: List[str],
 
 
 def detect_missing_proofs_summary(summary_output: str,
-                                   target_theorem_line: Optional[int] = None) -> List[CheatingIssue]:
+                                   target_theorem_line: int | None = None) -> list[CheatingIssue]:
     """Check tlapm --summary output for missing proofs in the target theorem.
 
     tlapm treats a bare QED (without BY/OBVIOUS) as an implicit omission,
@@ -240,7 +239,7 @@ def detect_missing_proofs_summary(summary_output: str,
     return issues
 
 
-def detect_dependency_modification(dep_files: Dict[str, Tuple[str, str]]) -> List[CheatingIssue]:
+def detect_dependency_modification(dep_files: dict[str, tuple[str, str]]) -> list[CheatingIssue]:
     """Check if dependency .tla files were modified.
 
     Args:
@@ -259,7 +258,7 @@ def detect_dependency_modification(dep_files: Dict[str, Tuple[str, str]]) -> Lis
 def detect_cheating_full(proof_text: str, original_content: str, current_content: str,
                          tlapm_output: str = "", tlapm_passed: bool = False,
                          parse_theorems_fn=None,
-                         dep_files: Optional[Dict[str, Tuple[str, str]]] = None) -> List[CheatingIssue]:
+                         dep_files: dict[str, tuple[str, str]] | None = None) -> list[CheatingIssue]:
     """Run all cheating checks. This is the main entry point.
 
     Args:

--- a/src/common/cheating_detection.py
+++ b/src/common/cheating_detection.py
@@ -111,10 +111,7 @@ def detect_empty_proof(proof_text_clean: str) -> list[CheatingIssue]:
                 if not next_stripped:
                     continue
                 # Only empty if next non-blank line is ==== (module end)
-                if re.match(r'^={3,}', next_stripped):
-                    is_empty = True
-                else:
-                    is_empty = False
+                is_empty = bool(re.match(r'^={3,}', next_stripped))
                 break
             # Also empty if nothing follows at all (EOF)
             if is_empty:

--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -28,25 +28,30 @@ Exit codes:
     3 = ERROR (could not run check)
 """
 
+import argparse
+import glob
 import os
-import sys
 import re
 import shutil
 import signal
 import subprocess
+import sys
 import tempfile
-import argparse
-import glob
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # Also expose the repo `src/` so the SANY gate can `import tlacheck`/`tlacore`
 # when running from source (frozen builds bundle them directly).
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from cheating_detection import (
-    detect_proof_omitted, detect_extra_axioms,
-    detect_preamble_modification, detect_empty_proof,
-    detect_zero_total_obligations, detect_dependency_modification,
-    detect_missing_proof, detect_missing_proofs_summary, strip_comments,
+    detect_dependency_modification,
+    detect_empty_proof,
+    detect_extra_axioms,
+    detect_missing_proof,
+    detect_missing_proofs_summary,
+    detect_preamble_modification,
+    detect_proof_omitted,
+    detect_zero_total_obligations,
+    strip_comments,
 )
 
 
@@ -232,7 +237,7 @@ def check_cheating(filepath, level: int = 1):
         return issues
 
     main_lines = main_content.split('\n')
-    with open(filepath, 'r') as f:
+    with open(filepath) as f:
         current_content = f.read()
     current_lines = current_content.split('\n')
 
@@ -293,7 +298,7 @@ def check_cheating(filepath, level: int = 1):
                     break
             if dep_main is None:
                 continue
-            with open(dep_file, 'r') as f:
+            with open(dep_file) as f:
                 dep_current = f.read()
             dep_files[dep_basename] = (dep_main, dep_current)
 
@@ -527,7 +532,7 @@ def main():
 
     # Check for empty PROOF blocks and 0-obligation (independent of git comparison)
     if tlapm_passed:
-        with open(filepath, 'r') as f:
+        with open(filepath) as f:
             cur_lines = f.read().split('\n')
 
         if args.level == 1:

--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -41,7 +41,7 @@ import tempfile
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # Also expose the repo `src/` so the SANY gate can `import tlacheck`/`tlacore`
 # when running from source (frozen builds bundle them directly).
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import contextlib
 
 from cheating_detection import (
@@ -66,13 +66,13 @@ def _descendant_pids(root_pid):
     matters, which holds as long as we snapshot before any kills land.
     """
     parents = {}
-    for entry in os.listdir('/proc'):
+    for entry in os.listdir("/proc"):
         if not entry.isdigit():
             continue
         try:
-            with open(f'/proc/{entry}/status') as f:
+            with open(f"/proc/{entry}/status") as f:
                 for line in f:
-                    if line.startswith('PPid:'):
+                    if line.startswith("PPid:"):
                         parents[int(entry)] = int(line.split()[1])
                         break
         except (FileNotFoundError, PermissionError, ProcessLookupError):
@@ -109,8 +109,12 @@ def run_killgroup(cmd, timeout, cwd):
     `bash_process` wrapper, and any z3 they hold.
     """
     proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
-        cwd=cwd, start_new_session=True,
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=cwd,
+        start_new_session=True,
     )
     try:
         out, err = proc.communicate(timeout=timeout)
@@ -130,10 +134,10 @@ def run_killgroup(cmd, timeout, cwd):
 def find_tlapm():
     """Find tlapm binary."""
     candidates = [
-        '/opt/tlapm/bin/tlapm',
-        os.path.expanduser('~/.tlapm/bin/tlapm'),
-        '/tmp/tlapm/bin/tlapm',
-        shutil.which('tlapm'),
+        "/opt/tlapm/bin/tlapm",
+        os.path.expanduser("~/.tlapm/bin/tlapm"),
+        "/tmp/tlapm/bin/tlapm",
+        shutil.which("tlapm"),
     ]
     for candidate in candidates:
         if candidate and os.path.isfile(candidate):
@@ -149,7 +153,7 @@ def find_tlapm_lib(tlapm_path):
     does NOT directly contain the .tla files.
     """
     base = os.path.dirname(os.path.dirname(tlapm_path))
-    for sub in ['lib/tlapm/stdlib', 'lib/tlaps', 'lib/tlapm', 'lib']:
+    for sub in ["lib/tlapm/stdlib", "lib/tlaps", "lib/tlapm", "lib"]:
         path = os.path.join(base, sub)
         if os.path.isdir(path):
             return path
@@ -185,8 +189,7 @@ def find_community_lib(filepath):
 def get_main_version(filepath):
     """Get the file content from the main/master branch."""
     repo_root = subprocess.run(
-        ['git', 'rev-parse', '--show-toplevel'],
-        capture_output=True, text=True, cwd=os.path.dirname(filepath) or '.'
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, cwd=os.path.dirname(filepath) or "."
     ).stdout.strip()
 
     if not repo_root:
@@ -194,11 +197,8 @@ def get_main_version(filepath):
 
     rel_path = os.path.relpath(filepath, repo_root)
 
-    for branch in ['main', 'master']:
-        result = subprocess.run(
-            ['git', 'show', f'{branch}:{rel_path}'],
-            capture_output=True, text=True, cwd=repo_root
-        )
+    for branch in ["main", "master"]:
+        result = subprocess.run(["git", "show", f"{branch}:{rel_path}"], capture_output=True, text=True, cwd=repo_root)
         if result.returncode == 0:
             return result.stdout
 
@@ -208,7 +208,7 @@ def get_main_version(filepath):
 def find_proof_obvious_line(lines):
     """Find the line number (0-indexed) of 'PROOF OBVIOUS' in the file."""
     for i in range(len(lines) - 1, -1, -1):
-        if lines[i].strip() == 'PROOF OBVIOUS':
+        if lines[i].strip() == "PROOF OBVIOUS":
             return i
     return None
 
@@ -232,10 +232,10 @@ def check_cheating(filepath, level: int = 1):
         issues.append((0, "WARNING: Could not retrieve main branch version for comparison"))
         return issues
 
-    main_lines = main_content.split('\n')
+    main_lines = main_content.split("\n")
     with open(filepath) as f:
         current_content = f.read()
-    current_lines = current_content.split('\n')
+    current_lines = current_content.split("\n")
 
     # Find PROOF OBVIOUS in main version - this is the boundary
     po_line = find_proof_obvious_line(main_lines)
@@ -244,7 +244,9 @@ def check_cheating(filepath, level: int = 1):
         return issues
 
     if level == 1 and len(current_lines) < po_line:
-        issues.append((len(current_lines), f"File truncated: preamble had {po_line} lines, file has {len(current_lines)}"))
+        issues.append(
+            (len(current_lines), f"File truncated: preamble had {po_line} lines, file has {len(current_lines)}")
+        )
         return issues
 
     # 1. Preamble modification — L1 only.
@@ -258,7 +260,7 @@ def check_cheating(filepath, level: int = 1):
     # L1: only the proof section can plausibly contain it (and must not).
     # L2: scan the whole current file — the agent may add proofs anywhere.
     if level == 1:
-        proof_section = '\n'.join(current_lines[po_line:])
+        proof_section = "\n".join(current_lines[po_line:])
         for ci in detect_proof_omitted(proof_section):
             issues.append((po_line + (ci.line or 0), ci.description))
     else:
@@ -272,22 +274,20 @@ def check_cheating(filepath, level: int = 1):
     # 4. Dependency file modification (shared module)
     bench_dir = os.path.dirname(filepath)
     repo_root = subprocess.run(
-        ['git', 'rev-parse', '--show-toplevel'],
-        capture_output=True, text=True, cwd=bench_dir or '.'
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, cwd=bench_dir or "."
     ).stdout.strip()
 
     if repo_root:
         dep_files = {}
-        for dep_file in glob.glob(os.path.join(bench_dir, '*.tla')):
+        for dep_file in glob.glob(os.path.join(bench_dir, "*.tla")):
             if os.path.abspath(dep_file) == os.path.abspath(filepath):
                 continue
             dep_basename = os.path.basename(dep_file)
             dep_rel = os.path.relpath(dep_file, repo_root)
             dep_main = None
-            for branch in ['main', 'master']:
+            for branch in ["main", "master"]:
                 r = subprocess.run(
-                    ['git', 'show', f'{branch}:{dep_rel}'],
-                    capture_output=True, text=True, cwd=repo_root
+                    ["git", "show", f"{branch}:{dep_rel}"], capture_output=True, text=True, cwd=repo_root
                 )
                 if r.returncode == 0:
                     dep_main = r.stdout
@@ -305,17 +305,19 @@ def check_cheating(filepath, level: int = 1):
 
 
 def _git_root(path):
-    r = subprocess.run(['git', 'rev-parse', '--show-toplevel'],
-                       capture_output=True, text=True,
-                       cwd=os.path.dirname(os.path.abspath(path)) or '.')
+    r = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        cwd=os.path.dirname(os.path.abspath(path)) or ".",
+    )
     return r.stdout.strip() if r.returncode == 0 else None
 
 
 def _git_root_commit(repo_root):
     """The earliest (root) commit — the runner seeds it with the pristine
     benchmark, so it is a tamper-resistant baseline even if the agent commits."""
-    r = subprocess.run(['git', 'rev-list', '--max-parents=0', 'HEAD'],
-                       capture_output=True, text=True, cwd=repo_root)
+    r = subprocess.run(["git", "rev-list", "--max-parents=0", "HEAD"], capture_output=True, text=True, cwd=repo_root)
     if r.returncode != 0:
         return None
     commits = r.stdout.split()
@@ -341,39 +343,38 @@ def _reconstruct_from_git(filepath, target_name):
         return None, None, []
     bench_dir = os.path.dirname(os.path.abspath(filepath))
     rel_dir = os.path.relpath(bench_dir, repo_root)
-    tree = '' if rel_dir == '.' else rel_dir
-    spec = f'{root_commit}:{tree}' if tree else f'{root_commit}:'
-    ls = subprocess.run(['git', 'ls-tree', '--name-only', spec],
-                        capture_output=True, text=True, cwd=repo_root)
+    tree = "" if rel_dir == "." else rel_dir
+    spec = f"{root_commit}:{tree}" if tree else f"{root_commit}:"
+    ls = subprocess.run(["git", "ls-tree", "--name-only", spec], capture_output=True, text=True, cwd=repo_root)
     if ls.returncode != 0:
         return None, None, []
-    orig_tlas = [n for n in ls.stdout.split('\n') if n.endswith('.tla')]
+    orig_tlas = [n for n in ls.stdout.split("\n") if n.endswith(".tla")]
     if not orig_tlas:
         return None, None, []
 
-    sol_dir = tempfile.mkdtemp(prefix='tlck_sol_')
-    bench_canon = tempfile.mkdtemp(prefix='tlck_bench_')
+    sol_dir = tempfile.mkdtemp(prefix="tlck_sol_")
+    bench_canon = tempfile.mkdtemp(prefix="tlck_bench_")
     cleanup = [sol_dir, bench_canon]
 
     for name in orig_tlas:
-        path_in_tree = f'{tree}/{name}' if tree else name
-        show = subprocess.run(['git', 'show', f'{root_commit}:{path_in_tree}'],
-                              capture_output=True, text=True, cwd=repo_root)
+        path_in_tree = f"{tree}/{name}" if tree else name
+        show = subprocess.run(
+            ["git", "show", f"{root_commit}:{path_in_tree}"], capture_output=True, text=True, cwd=repo_root
+        )
         if show.returncode == 0:
-            with open(os.path.join(bench_canon, name), 'w') as f:
+            with open(os.path.join(bench_canon, name), "w") as f:
                 f.write(show.stdout)
 
-    for dep in glob.glob(os.path.join(bench_dir, '*.tla')):
+    for dep in glob.glob(os.path.join(bench_dir, "*.tla")):
         shutil.copy2(dep, os.path.join(sol_dir, os.path.basename(dep)))
-    orig_target = os.path.join(bench_canon, target_name + '.tla')
+    orig_target = os.path.join(bench_canon, target_name + ".tla")
     if os.path.exists(orig_target):
-        shutil.copy2(orig_target, os.path.join(sol_dir, 'benchmark.tla'))
+        shutil.copy2(orig_target, os.path.join(sol_dir, "benchmark.tla"))
 
     return sol_dir, bench_canon, cleanup
 
 
-def run_tlacheck_engine(filepath, target_name, summary_output, tlapm_passed,
-                        benchmark_dir=None):
+def run_tlacheck_engine(filepath, target_name, summary_output, tlapm_passed, benchmark_dir=None):
     """Run the compiled-in SANY + incomplete-proof cheat engine.
 
     Folds CHEATING and INCOMPLETE findings into one list — any of them must fail
@@ -398,10 +399,15 @@ def run_tlacheck_engine(filepath, target_name, summary_output, tlapm_passed,
                 return [], "no git baseline available"
             sol_dir = os.path.dirname(os.path.abspath(filepath))
         summary = parse_summary(summary_output) if summary_output else None
-        ctx = build_context(sol_dir, target_name, benchmark_dir=bench,
-                            summary=summary, tlapm_passed=tlapm_passed,
-                            tlapm_fallback=True,
-                            compute_summary=(summary is None))
+        ctx = build_context(
+            sol_dir,
+            target_name,
+            benchmark_dir=bench,
+            summary=summary,
+            tlapm_passed=tlapm_passed,
+            tlapm_fallback=True,
+            compute_summary=(summary is None),
+        )
         res = evaluate(ctx)
     except Exception as e:
         return [], f"tlacheck error: {e}"
@@ -409,22 +415,24 @@ def run_tlacheck_engine(filepath, target_name, summary_output, tlapm_passed,
         for d in cleanup:
             shutil.rmtree(d, ignore_errors=True)
 
-    return ([str(i) for i in res.cheating_issues]
-            + [str(i) for i in res.incomplete_issues]), ""
+    return ([str(i) for i in res.cheating_issues] + [str(i) for i in res.incomplete_issues]), ""
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Check a single TLAPS benchmark proof')
-    parser.add_argument('file', help='Path to the benchmark .tla file')
-    parser.add_argument('--level', type=int, default=1, choices=[1, 2],
-                        help='Benchmark level — controls cheating rules (default: 1)')
-    parser.add_argument('--tlapm', default=None, help='Path to tlapm binary')
-    parser.add_argument('--tlapm-lib', default=None, help='Path to tlapm lib directory')
-    parser.add_argument('--timeout', type=int, default=600, help='Timeout in seconds')
-    parser.add_argument('--output', '-o', default=None, help='Write results to this file (default: <input>.result)')
-    parser.add_argument('--benchmark-dir', default=None,
-                        help='Canonical benchmark/<level>/<module>/ dir (provenance '
-                             'oracle; defaults to git-root reconstruction)')
+    parser = argparse.ArgumentParser(description="Check a single TLAPS benchmark proof")
+    parser.add_argument("file", help="Path to the benchmark .tla file")
+    parser.add_argument(
+        "--level", type=int, default=1, choices=[1, 2], help="Benchmark level — controls cheating rules (default: 1)"
+    )
+    parser.add_argument("--tlapm", default=None, help="Path to tlapm binary")
+    parser.add_argument("--tlapm-lib", default=None, help="Path to tlapm lib directory")
+    parser.add_argument("--timeout", type=int, default=600, help="Timeout in seconds")
+    parser.add_argument("--output", "-o", default=None, help="Write results to this file (default: <input>.result)")
+    parser.add_argument(
+        "--benchmark-dir",
+        default=None,
+        help="Canonical benchmark/<level>/<module>/ dir (provenance oracle; defaults to git-root reconstruction)",
+    )
     args = parser.parse_args()
 
     filepath = os.path.abspath(args.file)
@@ -435,7 +443,7 @@ def main():
     # Set up output: write to file and stdout
     output_path = args.output
     if output_path is None:
-        output_path = os.path.splitext(filepath)[0] + '.result'
+        output_path = os.path.splitext(filepath)[0] + ".result"
 
     # Collect all output lines, print at end and write to file
     output_lines = []
@@ -448,15 +456,15 @@ def main():
     tlapm_path = args.tlapm or find_tlapm()
     if not tlapm_path:
         emit("ERROR: tlapm not found. Use --tlapm to specify path.")
-        with open(output_path, 'w') as f:
-            f.write('\n'.join(output_lines) + '\n')
+        with open(output_path, "w") as f:
+            f.write("\n".join(output_lines) + "\n")
         sys.exit(3)
 
     tlapm_lib = args.tlapm_lib or find_tlapm_lib(tlapm_path)
     if not tlapm_lib:
         emit("ERROR: tlapm lib not found. Use --tlapm-lib to specify path.")
-        with open(output_path, 'w') as f:
-            f.write('\n'.join(output_lines) + '\n')
+        with open(output_path, "w") as f:
+            f.write("\n".join(output_lines) + "\n")
         sys.exit(3)
 
     emit(f"Checking: {os.path.relpath(filepath)}")
@@ -468,7 +476,7 @@ def main():
     emit("TLAPM OUTPUT")
     emit("=" * 60)
 
-    tmp_dir = tempfile.mkdtemp(prefix='tlaps_check_')
+    tmp_dir = tempfile.mkdtemp(prefix="tlaps_check_")
     try:
         basename = os.path.basename(filepath)
         tmp_file = os.path.join(tmp_dir, basename)
@@ -476,7 +484,7 @@ def main():
 
         # Copy dependency files from the same directory
         bench_dir = os.path.dirname(filepath)
-        for dep_file in glob.glob(os.path.join(bench_dir, '*.tla')):
+        for dep_file in glob.glob(os.path.join(bench_dir, "*.tla")):
             dep_basename = os.path.basename(dep_file)
             if dep_basename != basename:
                 shutil.copy2(dep_file, os.path.join(tmp_dir, dep_basename))
@@ -497,9 +505,9 @@ def main():
             tlapm_output = f"ERROR: {e}"
             tlapm_exit = -2
 
-        for line in tlapm_output.split('\n'):
+        for line in tlapm_output.split("\n"):
             emit(line)
-        tlapm_passed = (tlapm_exit == 0)
+        tlapm_passed = tlapm_exit == 0
 
         # Run --summary to detect missing proofs (e.g. bare QED)
         summary_output = ""
@@ -529,17 +537,17 @@ def main():
     # Check for empty PROOF blocks and 0-obligation (independent of git comparison)
     if tlapm_passed:
         with open(filepath) as f:
-            cur_lines = f.read().split('\n')
+            cur_lines = f.read().split("\n")
 
         if args.level == 1:
             # L1: PROOF OBVIOUS in main is the boundary; slice current at the
             # same index because the preamble is required to be unchanged.
             main_content = get_main_version(filepath)
             if main_content:
-                main_lines = main_content.split('\n')
+                main_lines = main_content.split("\n")
                 po_line = find_proof_obvious_line(main_lines)
                 if po_line is not None:
-                    proof_section = '\n'.join(cur_lines[po_line:])
+                    proof_section = "\n".join(cur_lines[po_line:])
                     clean = strip_comments(proof_section)
                     for ci in detect_empty_proof(clean):
                         real_issues.append((po_line + (ci.line or 0), ci.description))
@@ -551,7 +559,7 @@ def main():
             # L2: the agent may grow the preamble (new lemmas above target),
             # so there's no stable boundary. Scan the whole file; the bare-QED
             # check via --summary below catches what detect_missing_proof did.
-            clean = strip_comments('\n'.join(cur_lines))
+            clean = strip_comments("\n".join(cur_lines))
             for ci in detect_empty_proof(clean):
                 real_issues.append((ci.line or 0, ci.description))
             for ci in detect_zero_total_obligations(tlapm_output):
@@ -561,8 +569,8 @@ def main():
         # the last THEOREM/LEMMA in the file for both levels).
         if summary_output:
             target_line = None
-            for li, l in enumerate(cur_lines):
-                if re.match(r'^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\b', l.strip()):
+            for li, line in enumerate(cur_lines):
+                if re.match(r"^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\b", line.strip()):
                     target_line = li + 1  # 1-indexed
             for ci in detect_missing_proofs_summary(summary_output, target_line):
                 real_issues.append((0, ci.description))
@@ -573,14 +581,14 @@ def main():
     # gets the same verdict the grader does. Any finding fails the run.
     target_name = os.path.splitext(os.path.basename(filepath))[0]
     engine_issues, engine_reason = run_tlacheck_engine(
-        filepath, target_name, summary_output, tlapm_passed,
-        benchmark_dir=args.benchmark_dir)
+        filepath, target_name, summary_output, tlapm_passed, benchmark_dir=args.benchmark_dir
+    )
     if engine_reason:
         warnings.append((0, f"semantic engine skipped ({engine_reason})"))
     for desc in engine_issues:
         real_issues.append((0, desc))
 
-    for line_num, desc in warnings:
+    for _line_num, desc in warnings:
         emit(f"  WARNING: {desc}")
 
     if real_issues:
@@ -604,7 +612,7 @@ def main():
     else:
         exit_code = 1
         # Extract obligation summary
-        m = re.search(r'(\d+)/(\d+) obligation', tlapm_output)
+        m = re.search(r"(\d+)/(\d+) obligation", tlapm_output)
         if m:
             emit(f"  ❌ FAIL — {m.group(1)}/{m.group(2)} obligations failed")
         elif "TIMEOUT" in tlapm_output:
@@ -613,12 +621,12 @@ def main():
             emit(f"  ❌ FAIL — tlapm exit code {tlapm_exit}")
 
     # Write result file
-    with open(output_path, 'w') as f:
-        f.write('\n'.join(output_lines) + '\n')
+    with open(output_path, "w") as f:
+        f.write("\n".join(output_lines) + "\n")
     emit(f"\nResult written to: {output_path}")
 
     sys.exit(exit_code)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -42,6 +42,8 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # Also expose the repo `src/` so the SANY gate can `import tlacheck`/`tlacore`
 # when running from source (frozen builds bundle them directly).
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import contextlib
+
 from cheating_detection import (
     detect_dependency_modification,
     detect_empty_proof,
@@ -115,19 +117,13 @@ def run_killgroup(cmd, timeout, cwd):
         return out, err, proc.returncode
     except subprocess.TimeoutExpired:
         escapees = _descendant_pids(proc.pid)
-        try:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            pass
         for pid in escapees:
-            try:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.kill(pid, signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
-                pass
-        try:
+        with contextlib.suppress(Exception):
             proc.communicate(timeout=10)
-        except Exception:
-            pass
         raise
 
 
@@ -600,15 +596,12 @@ def main():
     emit("=" * 60)
 
     if real_issues:
-        verdict = "CHEATING"
         exit_code = 2
         emit(f"  ⚠️  CHEATING — {len(real_issues)} issue(s) found")
     elif tlapm_passed:
-        verdict = "PASS"
         exit_code = 0
         emit("  ✅ PASS — all obligations proved")
     else:
-        verdict = "FAIL"
         exit_code = 1
         # Extract obligation summary
         m = re.search(r'(\d+)/(\d+) obligation', tlapm_output)

--- a/src/common/validate.py
+++ b/src/common/validate.py
@@ -13,34 +13,33 @@ Usage:
     python3 validate_benchmarks.py [--tlapm PATH] [--tlapm-lib PATH] [--timeout SECS] [--jobs N]
 """
 
+import argparse
+import glob
 import os
 import re
-import sys
-import glob
 import shutil
 import subprocess
-import argparse
+import sys
 import tempfile
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple, Dict
 
 # Internal imports — generate.py is in ../dataset/level1, cheating_detection here.
 _HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _HERE)
 sys.path.insert(0, os.path.join(_HERE, '..', 'dataset', 'level1'))
+from cheating_detection import CheatingIssue
 from generate import (
-    parse_theorems,
-    parse_module_name,
-    find_tla_files,
-    get_theorem_proof_lines,
-    SOURCE_ROOT,
     BENCHMARK_DIR,
     PROJECT_ROOT,
+    SOURCE_ROOT,
     find_source_dirs,
+    find_tla_files,
+    get_theorem_proof_lines,
+    parse_module_name,
+    parse_theorems,
 )
-from cheating_detection import CheatingIssue
 
 
 @dataclass
@@ -59,7 +58,7 @@ class ValidationResult:
     # Proof metrics
     proof_lines_count: int = 0  # non-empty, non-comment proof lines
     # Cheating
-    cheating_issues: List[CheatingIssue] = field(default_factory=list)
+    cheating_issues: list[CheatingIssue] = field(default_factory=list)
     # Error
     error: str = ""
 
@@ -76,7 +75,7 @@ class ValidationResult:
         return "FAIL"
 
 
-def _derive_tlapm_lib(tlapm_path: str) -> Optional[str]:
+def _derive_tlapm_lib(tlapm_path: str) -> str | None:
     """Pick the stdlib dir based on tlapm install layout.
 
     tlapm 1.6 stores .tla files at lib/tlapm/stdlib; tlapm 1.5 at lib/tlaps.
@@ -89,8 +88,8 @@ def _derive_tlapm_lib(tlapm_path: str) -> Optional[str]:
     return None
 
 
-def find_original_proof(source_files_by_module: Dict, theorem_name: str,
-                        source_basename: str) -> Optional[Tuple[str, List[str], int, int]]:
+def find_original_proof(source_files_by_module: dict, theorem_name: str,
+                        source_basename: str) -> tuple[str, list[str], int, int] | None:
     """Find the original proof for a theorem from source files.
 
     Returns (source_file, proof_lines, stmt_start, proof_end) or None.
@@ -101,7 +100,7 @@ def find_original_proof(source_files_by_module: Dict, theorem_name: str,
         if os.path.splitext(os.path.basename(filepath))[0] != source_basename:
             continue
 
-        with open(filepath, 'r') as f:
+        with open(filepath) as f:
             content = f.read()
         lines = content.split('\n')
         theorems = parse_theorems(lines)
@@ -114,7 +113,7 @@ def find_original_proof(source_files_by_module: Dict, theorem_name: str,
     return None
 
 
-def count_proof_lines(proof_lines: List[str]) -> int:
+def count_proof_lines(proof_lines: list[str]) -> int:
     """Count non-empty, non-comment lines in proof."""
     count = 0
     in_comment = False
@@ -149,12 +148,12 @@ def count_proof_lines(proof_lines: List[str]) -> int:
     return count
 
 
-def port_proof_to_benchmark(benchmark_path: str, proof_lines: List[str]) -> str:
+def port_proof_to_benchmark(benchmark_path: str, proof_lines: list[str]) -> str:
     """Replace PROOF OBVIOUS in the benchmark file with the original proof.
 
     Returns the new content.
     """
-    with open(benchmark_path, 'r') as f:
+    with open(benchmark_path) as f:
         content = f.read()
 
     lines = content.split('\n')
@@ -176,7 +175,7 @@ def port_proof_to_benchmark(benchmark_path: str, proof_lines: List[str]) -> str:
 
 
 def run_tlapm(tla_file: str, tlapm_path: str, tlapm_lib: str,
-              timeout: int = 120) -> Tuple[int, str, float]:
+              timeout: int = 120) -> tuple[int, str, float]:
     """Run tlapm on a TLA+ file. Returns (exit_code, output, elapsed_secs)."""
     cmd = [tlapm_path, "-I", tlapm_lib]
     community_lib = os.path.join(PROJECT_ROOT, "lib", "community")
@@ -219,7 +218,7 @@ def validate_single_benchmark(args_tuple):
     )
 
     # Try to find the theorem by parsing the benchmark file itself
-    with open(benchmark_path, 'r') as f:
+    with open(benchmark_path) as f:
         benchmark_content = f.read()
 
     bench_lines = benchmark_content.split('\n')
@@ -261,7 +260,7 @@ def validate_single_benchmark(args_tuple):
             candidates.append((source_basename, src_file))
 
     for source_basename, src_file in candidates:
-        with open(src_file, 'r') as f:
+        with open(src_file) as f:
             src_content = f.read()
         src_lines = src_content.split('\n')
         src_theorems = parse_theorems(src_lines)
@@ -327,7 +326,7 @@ def validate_single_benchmark(args_tuple):
     return result
 
 
-def generate_report(results: List[ValidationResult], output_path: str):
+def generate_report(results: list[ValidationResult], output_path: str):
     """Generate a markdown report of validation results."""
     total = len(results)
     passed = sum(1 for r in results if r.status == "PASS")
@@ -472,7 +471,7 @@ def main():
     for mod_dir in find_source_dirs():
         module_path = os.path.join(SOURCE_ROOT, mod_dir)
         for f in find_tla_files(module_path):
-            with open(f, 'r') as fh:
+            with open(f) as fh:
                 content = fh.read()
             mod_name = parse_module_name(content)
             if mod_name:

--- a/src/common/validate.py
+++ b/src/common/validate.py
@@ -28,9 +28,9 @@ from dataclasses import dataclass, field
 # Internal imports — generate.py is in ../dataset/level1, cheating_detection here.
 _HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _HERE)
-sys.path.insert(0, os.path.join(_HERE, '..', 'dataset', 'level1'))
-from cheating_detection import CheatingIssue
-from generate import (
+sys.path.insert(0, os.path.join(_HERE, "..", "dataset", "level1"))
+from cheating_detection import CheatingIssue  # noqa: E402
+from generate import (  # noqa: E402
     BENCHMARK_DIR,
     PROJECT_ROOT,
     SOURCE_ROOT,
@@ -81,15 +81,16 @@ def _derive_tlapm_lib(tlapm_path: str) -> str | None:
     tlapm 1.6 stores .tla files at lib/tlapm/stdlib; tlapm 1.5 at lib/tlaps.
     """
     base = os.path.dirname(os.path.dirname(tlapm_path))
-    for sub in ['lib/tlapm/stdlib', 'lib/tlaps', 'lib/tlapm', 'lib']:
+    for sub in ["lib/tlapm/stdlib", "lib/tlaps", "lib/tlapm", "lib"]:
         cand = os.path.join(base, sub)
         if os.path.isdir(cand):
             return cand
     return None
 
 
-def find_original_proof(source_files_by_module: dict, theorem_name: str,
-                        source_basename: str) -> tuple[str, list[str], int, int] | None:
+def find_original_proof(
+    source_files_by_module: dict, theorem_name: str, source_basename: str
+) -> tuple[str, list[str], int, int] | None:
     """Find the original proof for a theorem from source files.
 
     Returns (source_file, proof_lines, stmt_start, proof_end) or None.
@@ -102,12 +103,12 @@ def find_original_proof(source_files_by_module: dict, theorem_name: str,
 
         with open(filepath) as f:
             content = f.read()
-        lines = content.split('\n')
+        lines = content.split("\n")
         theorems = parse_theorems(lines)
 
         for thm in theorems:
             if thm.name == theorem_name and thm.has_proof:
-                proof_lines = lines[thm.proof_start:thm.proof_end + 1]
+                proof_lines = lines[thm.proof_start : thm.proof_end + 1]
                 return filepath, proof_lines, thm.statement_start, thm.proof_end
 
     return None
@@ -124,13 +125,13 @@ def count_proof_lines(proof_lines: list[str]) -> int:
         # Handle block comments
         while stripped:
             if in_comment:
-                end = stripped.find('*)')
+                end = stripped.find("*)")
                 if end == -1:
                     break  # entire line is inside comment
-                stripped = stripped[end + 2:].strip()
+                stripped = stripped[end + 2 :].strip()
                 in_comment = False
             else:
-                start = stripped.find('(*')
+                start = stripped.find("(*")
                 if start == -1:
                     # No comment on this line, it's a real line
                     count += 1
@@ -138,7 +139,7 @@ def count_proof_lines(proof_lines: list[str]) -> int:
                 elif start > 0:
                     # Some content before comment
                     count += 1
-                    stripped = stripped[start + 2:]
+                    stripped = stripped[start + 2 :]
                     in_comment = True
                     break
                 else:
@@ -156,26 +157,25 @@ def port_proof_to_benchmark(benchmark_path: str, proof_lines: list[str]) -> str:
     with open(benchmark_path) as f:
         content = f.read()
 
-    lines = content.split('\n')
+    lines = content.split("\n")
 
     # Find the PROOF OBVIOUS line (should be the last theorem's proof)
     for i in range(len(lines) - 1, -1, -1):
-        if lines[i].strip() == 'PROOF OBVIOUS':
+        if lines[i].strip() == "PROOF OBVIOUS":
             # Replace this line with the original proof
-            new_lines = lines[:i] + proof_lines + lines[i + 1:]
-            return '\n'.join(new_lines)
+            new_lines = lines[:i] + proof_lines + lines[i + 1 :]
+            return "\n".join(new_lines)
 
     # Fallback: if no PROOF OBVIOUS found, try appending proof before ====
     for i in range(len(lines) - 1, -1, -1):
-        if re.match(r'^={3,}', lines[i].strip()):
+        if re.match(r"^={3,}", lines[i].strip()):
             new_lines = lines[:i] + proof_lines + [lines[i]]
-            return '\n'.join(new_lines)
+            return "\n".join(new_lines)
 
     return content  # unchanged
 
 
-def run_tlapm(tla_file: str, tlapm_path: str, tlapm_lib: str,
-              timeout: int = 120) -> tuple[int, str, float]:
+def run_tlapm(tla_file: str, tlapm_path: str, tlapm_lib: str, timeout: int = 120) -> tuple[int, str, float]:
     """Run tlapm on a TLA+ file. Returns (exit_code, output, elapsed_secs)."""
     cmd = [tlapm_path, "-I", tlapm_lib]
     community_lib = os.path.join(PROJECT_ROOT, "lib", "community")
@@ -185,11 +185,10 @@ def run_tlapm(tla_file: str, tlapm_path: str, tlapm_lib: str,
     start = time.time()
     try:
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout,
-            cwd=os.path.dirname(tla_file) or '.'
+            cmd, capture_output=True, text=True, timeout=timeout, cwd=os.path.dirname(tla_file) or "."
         )
         elapsed = time.time() - start
-        output = result.stdout + '\n' + result.stderr
+        output = result.stdout + "\n" + result.stderr
         return result.returncode, output.strip(), elapsed
     except subprocess.TimeoutExpired:
         elapsed = time.time() - start
@@ -221,11 +220,11 @@ def validate_single_benchmark(args_tuple):
     with open(benchmark_path) as f:
         benchmark_content = f.read()
 
-    bench_lines = benchmark_content.split('\n')
+    bench_lines = benchmark_content.split("\n")
     # Find the target theorem - it's the last named THEOREM/LEMMA in the file
     target_thm_name = None
     for line in reversed(bench_lines):
-        m = re.match(r'^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\s+(\w+)\s*==', line.strip())
+        m = re.match(r"^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\s+(\w+)\s*==", line.strip())
         if m:
             target_thm_name = m.group(2)
             break
@@ -254,15 +253,15 @@ def validate_single_benchmark(args_tuple):
         if rel.split(os.sep)[0] != module_dir:
             continue
         src_basename_noext = os.path.splitext(os.path.basename(src_file))[0]
-        if name_no_ext.startswith(src_basename_noext + '_'):
+        if name_no_ext.startswith(src_basename_noext + "_"):
             candidates.insert(0, (source_basename, src_file))  # primary match first
         else:
             candidates.append((source_basename, src_file))
 
-    for source_basename, src_file in candidates:
+    for _source_basename, src_file in candidates:
         with open(src_file) as f:
             src_content = f.read()
-        src_lines = src_content.split('\n')
+        src_lines = src_content.split("\n")
         src_theorems = parse_theorems(src_lines)
 
         for sthm in src_theorems:
@@ -271,7 +270,7 @@ def validate_single_benchmark(args_tuple):
                 # 'LEMMA Foo == x  BY DEF y' without re-declaring the theorem).
                 proof_lines = get_theorem_proof_lines(src_lines, sthm)
                 # Trim trailing empty lines and comment-only lines
-                while proof_lines and (not proof_lines[-1].strip() or proof_lines[-1].strip().startswith('(*')):
+                while proof_lines and (not proof_lines[-1].strip() or proof_lines[-1].strip().startswith("(*")):
                     proof_lines.pop()
                 found_proof = (src_file, proof_lines)
                 result.source_file = os.path.relpath(src_file, SOURCE_ROOT)
@@ -295,30 +294,31 @@ def validate_single_benchmark(args_tuple):
     ported_content = port_proof_to_benchmark(benchmark_path, proof_lines)
     result.proof_ported = True
 
-    proof_text = '\n'.join(proof_lines)
+    proof_text = "\n".join(proof_lines)
 
     # Write ported content to a temp file and run tlapm
-    tmp_dir = tempfile.mkdtemp(prefix='tlaps_validate_')
+    tmp_dir = tempfile.mkdtemp(prefix="tlaps_validate_")
     try:
         tmp_file = os.path.join(tmp_dir, basename)
-        with open(tmp_file, 'w') as f:
+        with open(tmp_file, "w") as f:
             f.write(ported_content)
 
         # Copy dependency files (non-benchmark .tla files in the same directory)
         bench_dir = os.path.dirname(benchmark_path)
-        for dep_file in glob.glob(os.path.join(bench_dir, '*.tla')):
+        for dep_file in glob.glob(os.path.join(bench_dir, "*.tla")):
             dep_basename = os.path.basename(dep_file)
-            if dep_basename != basename and '_' not in os.path.splitext(dep_basename)[0]:
+            if dep_basename != basename and "_" not in os.path.splitext(dep_basename)[0]:
                 shutil.copy2(dep_file, os.path.join(tmp_dir, dep_basename))
 
         exit_code, output, elapsed = run_tlapm(tmp_file, tlapm_path, tlapm_lib, timeout)
         result.tlapm_exit_code = exit_code
         result.tlapm_output = output
         result.tlapm_time_secs = elapsed
-        result.tlapm_passed = (exit_code == 0)
+        result.tlapm_passed = exit_code == 0
 
         # Only check if source proof uses PROOF OMITTED (placeholder, not a real proof)
         from cheating_detection import detect_proof_omitted
+
         result.cheating_issues = detect_proof_omitted(proof_text)
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
@@ -385,7 +385,7 @@ def generate_report(results: list[ValidationResult], output_path: str):
                 notes = r.error
             elif r.status == "FAIL":
                 # Extract failure summary from tlapm output
-                fail_match = re.search(r'(\d+)/(\d+) obligation', r.tlapm_output)
+                fail_match = re.search(r"(\d+)/(\d+) obligation", r.tlapm_output)
                 if fail_match:
                     notes = f"{fail_match.group(1)}/{fail_match.group(2)} obligations failed"
                 elif "TIMEOUT" in r.tlapm_output:
@@ -394,7 +394,9 @@ def generate_report(results: list[ValidationResult], output_path: str):
             time_str = f"{r.tlapm_time_secs:.1f}s" if r.tlapm_time_secs > 0 else "-"
             source = r.source_file if r.source_file else "-"
 
-            lines.append(f"| `{r.theorem_name}` | `{source}` | {status_icon} {r.status} | {r.proof_lines_count} | {time_str} | {notes} |")
+            lines.append(
+                f"| `{r.theorem_name}` | `{source}` | {status_icon} {r.status} | {r.proof_lines_count} | {time_str} | {notes} |"
+            )
 
         lines.append("")
 
@@ -411,7 +413,7 @@ def generate_report(results: list[ValidationResult], output_path: str):
         for r in failed_results:
             lines.append(f"### `{r.benchmark_file}`\n")
             # Show relevant tlapm output (last few error lines)
-            error_lines = [l for l in r.tlapm_output.split('\n') if 'ERROR' in l or 'obligation' in l]
+            error_lines = [ln for ln in r.tlapm_output.split("\n") if "ERROR" in ln or "obligation" in ln]
             if error_lines:
                 lines.append("```")
                 for el in error_lines[-5:]:
@@ -419,25 +421,25 @@ def generate_report(results: list[ValidationResult], output_path: str):
                 lines.append("```")
             lines.append("")
 
-    report = '\n'.join(lines)
-    with open(output_path, 'w') as f:
+    report = "\n".join(lines)
+    with open(output_path, "w") as f:
         f.write(report)
 
     return report
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Validate TLAPS benchmarks')
-    parser.add_argument('--tlapm', default=None, help='Path to tlapm binary')
-    parser.add_argument('--tlapm-lib', default=None, help='Path to tlapm lib directory')
-    parser.add_argument('--timeout', type=int, default=120, help='Timeout per benchmark (seconds)')
-    parser.add_argument('--jobs', type=int, default=4, help='Parallel jobs')
-    parser.add_argument('--output', default='benchmark_report.md', help='Output report path')
-    parser.add_argument('--filter', default=None, help='Only run benchmarks matching this pattern')
-    parser.add_argument('--rerun-timeout', type=int, default=300, help='Timeout for rerun of failed benchmarks')
-    parser.add_argument('--rerun-tlapm', default=None, help='Path to alternative tlapm for rerun (e.g. tlapm 1.6)')
-    parser.add_argument('--rerun-tlapm-lib', default=None, help='Path to alternative tlapm lib for rerun')
-    parser.add_argument('--rerun', action='store_true', help='Rerun failed benchmarks (optionally with --rerun-tlapm)')
+    parser = argparse.ArgumentParser(description="Validate TLAPS benchmarks")
+    parser.add_argument("--tlapm", default=None, help="Path to tlapm binary")
+    parser.add_argument("--tlapm-lib", default=None, help="Path to tlapm lib directory")
+    parser.add_argument("--timeout", type=int, default=120, help="Timeout per benchmark (seconds)")
+    parser.add_argument("--jobs", type=int, default=4, help="Parallel jobs")
+    parser.add_argument("--output", default="benchmark_report.md", help="Output report path")
+    parser.add_argument("--filter", default=None, help="Only run benchmarks matching this pattern")
+    parser.add_argument("--rerun-timeout", type=int, default=300, help="Timeout for rerun of failed benchmarks")
+    parser.add_argument("--rerun-tlapm", default=None, help="Path to alternative tlapm for rerun (e.g. tlapm 1.6)")
+    parser.add_argument("--rerun-tlapm-lib", default=None, help="Path to alternative tlapm lib for rerun")
+    parser.add_argument("--rerun", action="store_true", help="Rerun failed benchmarks (optionally with --rerun-tlapm)")
     args = parser.parse_args()
 
     # Find tlapm
@@ -445,10 +447,10 @@ def main():
     if not tlapm_path:
         # Try common locations
         candidates = [
-            '/opt/tlapm/bin/tlapm',
-            os.path.expanduser('~/.tlapm/bin/tlapm'),
-            '/tmp/tlapm/bin/tlapm',
-            shutil.which('tlapm'),
+            "/opt/tlapm/bin/tlapm",
+            os.path.expanduser("~/.tlapm/bin/tlapm"),
+            "/tmp/tlapm/bin/tlapm",
+            shutil.which("tlapm"),
         ]
         for candidate in candidates:
             if candidate and os.path.isfile(candidate):
@@ -478,21 +480,17 @@ def main():
                 source_files.append((mod_name, f))
 
     # Find all benchmark files (exclude dependency copies that don't have '_' in name)
-    benchmark_files = sorted(glob.glob(os.path.join(BENCHMARK_DIR, '**', '*.tla'), recursive=True))
+    benchmark_files = sorted(glob.glob(os.path.join(BENCHMARK_DIR, "**", "*.tla"), recursive=True))
     # Benchmark files have format SourceFile_TheoremName.tla (contain underscore)
     # Dependency copies are plain module names like Consensus.tla, VoteProof.tla
-    benchmark_files = [f for f in benchmark_files
-                       if '_' in os.path.splitext(os.path.basename(f))[0]]
+    benchmark_files = [f for f in benchmark_files if "_" in os.path.splitext(os.path.basename(f))[0]]
     if args.filter:
         benchmark_files = [f for f in benchmark_files if args.filter in f]
 
     print(f"Found {len(benchmark_files)} benchmark files to validate")
 
     # Prepare work items
-    work_items = [
-        (bf, source_files, tlapm_path, tlapm_lib, args.timeout)
-        for bf in benchmark_files
-    ]
+    work_items = [(bf, source_files, tlapm_path, tlapm_lib, args.timeout) for bf in benchmark_files]
 
     # Run validation
     results = []
@@ -513,9 +511,7 @@ def main():
     else:
         with ProcessPoolExecutor(max_workers=args.jobs) as executor:
             futures = {executor.submit(validate_single_benchmark, item): item for item in work_items}
-            done_count = 0
-            for future in as_completed(futures):
-                done_count += 1
+            for done_count, future in enumerate(as_completed(futures), start=1):
                 r = future.result()
                 results.append(r)
                 on_result(r, done_count, len(work_items))
@@ -534,9 +530,9 @@ def main():
     if failed_results and args.rerun:
         using_alt = rerun_tlapm != tlapm_path
         label = f"rerun with {rerun_tlapm}" if using_alt else "rerun"
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"Parallel {label} of {len(failed_results)} failed benchmarks (timeout={args.rerun_timeout}s)")
-        print(f"{'='*60}", flush=True)
+        print(f"{'=' * 60}", flush=True)
 
         rerun_items = []
         for r in failed_results:
@@ -561,7 +557,10 @@ def main():
         rerun_results.sort(key=lambda x: x[1].tlapm_time_secs)
         for idx, (r_orig, r2) in enumerate(rerun_results):
             now_icon = {"PASS": "✅", "FAIL": "❌", "OMITTED": "⏭️", "ERROR": "💥"}.get(r2.status, "❓")
-            print(f"  [{idx+1}/{len(rerun_results)}] ❌→{now_icon} {r2.benchmark_file} ({r2.tlapm_time_secs:.1f}s)", flush=True)
+            print(
+                f"  [{idx + 1}/{len(rerun_results)}] ❌→{now_icon} {r2.benchmark_file} ({r2.tlapm_time_secs:.1f}s)",
+                flush=True,
+            )
             if r2.status != r_orig.status:
                 results[results.index(r_orig)] = r2
                 if r2.status == "PASS":
@@ -577,7 +576,7 @@ def main():
     report_path = os.path.join(PROJECT_ROOT, args.output)
     generate_report(results, report_path)
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Validation complete in {total_time:.1f}s")
     print(f"Report written to: {report_path}")
 
@@ -589,5 +588,5 @@ def main():
     print(f"\n✅ Passed: {passed}  ❌ Failed: {failed}  ⏭️ Placeholder: {cheating}  💥 Error: {errors}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/common/validate.py
+++ b/src/common/validate.py
@@ -96,7 +96,7 @@ def find_original_proof(source_files_by_module: dict, theorem_name: str,
     """
     # source_basename is like "Cantor1", "Voting", etc.
     # Try to find in all source files
-    for mod_name, filepath in source_files_by_module.items():
+    for _mod_name, filepath in source_files_by_module.items():
         if os.path.splitext(os.path.basename(filepath))[0] != source_basename:
             continue
 
@@ -575,7 +575,7 @@ def main():
 
     # Generate report
     report_path = os.path.join(PROJECT_ROOT, args.output)
-    report = generate_report(results, report_path)
+    generate_report(results, report_path)
 
     print(f"\n{'='*60}")
     print(f"Validation complete in {total_time:.1f}s")

--- a/src/dataset/level1/generate.py
+++ b/src/dataset/level1/generate.py
@@ -11,9 +11,9 @@ generate a standalone .tla file where:
 - Each benchmark file works standalone (with its dependency files)
 """
 
+import glob
 import os
 import re
-import glob
 
 # Modules that tlapm resolves via an -I path, so they should NOT be merged/copied
 # as local dependency modules. Two groups:
@@ -192,7 +192,7 @@ def get_all_instance_deps(mod, files_by_module, visited=None):
     filepath = files_by_module.get(mod)
     if not filepath:
         return visited
-    with open(filepath, 'r') as f:
+    with open(filepath) as f:
         content = f.read()
     available = set(files_by_module.keys())
     # All dependencies of INSTANCE'd modules (both EXTENDS and INSTANCE) need to be copied
@@ -211,7 +211,7 @@ def get_all_file_deps(mod, files_by_module, visited=None):
     filepath = files_by_module.get(mod)
     if not filepath:
         return visited
-    with open(filepath, 'r') as f:
+    with open(filepath) as f:
         content = f.read()
     available = set(files_by_module.keys())
     for dep in get_local_dependencies(content, available):
@@ -226,7 +226,7 @@ def build_dependency_graph(files_by_module):
     available = set(files_by_module.keys())
     graph = {}
     for mod, filepath in files_by_module.items():
-        with open(filepath, 'r') as f:
+        with open(filepath) as f:
             content = f.read()
         graph[mod] = get_local_dependencies(content, available)
     return graph
@@ -386,10 +386,7 @@ def parse_theorems(lines):
         if re.search(r'\bBY\s', first_line) or re.search(r'\bPROOF\s+BY\s', first_line):
             proof_start = i
             has_proof = True
-        elif re.search(r'\bOBVIOUS\s*$', first_line):
-            proof_start = i
-            has_proof = False
-        elif re.search(r'\bOMITTED\s*$', first_line) or re.search(r'\bPROOF\s+OMITTED\s*$', first_line):
+        elif re.search(r'\bOBVIOUS\s*$', first_line) or re.search(r'\bOMITTED\s*$', first_line) or re.search(r'\bPROOF\s+OMITTED\s*$', first_line):
             proof_start = i
             has_proof = False
 
@@ -571,7 +568,7 @@ def merge_files(files_by_module, dep_graph, target_module):
 
     if not all_deps:
         # No local dependencies, just return the file content
-        with open(files_by_module[target_module], 'r') as f:
+        with open(files_by_module[target_module]) as f:
             return f.readlines(), target_module
 
     # Topological order of all deps + target
@@ -583,7 +580,7 @@ def merge_files(files_by_module, dep_graph, target_module):
     merged_body_lines = []
 
     for mod in relevant:
-        with open(files_by_module[mod], 'r') as f:
+        with open(files_by_module[mod]) as f:
             content = f.read()
 
         mod_lines = content.split('\n')
@@ -869,7 +866,7 @@ def process_module_dir(module_dir_name):
     # Build module -> filepath mapping
     files_by_module = {}
     for f in tla_files:
-        with open(f, 'r') as fh:
+        with open(f) as fh:
             content = fh.read()
         mod_name = parse_module_name(content)
         if mod_name:
@@ -883,7 +880,7 @@ def process_module_dir(module_dir_name):
     out_dir = os.path.join(BENCHMARK_DIR, module_dir_name)
 
     for mod_name, filepath in files_by_module.items():
-        with open(filepath, 'r') as f:
+        with open(filepath) as f:
             content = f.read()
 
         raw_lines = content.split('\n')
@@ -903,7 +900,7 @@ def process_module_dir(module_dir_name):
             # Get transitive EXTENDS-only deps
             ed_filepath = files_by_module.get(ed)
             if ed_filepath:
-                with open(ed_filepath, 'r') as f:
+                with open(ed_filepath) as f:
                     ed_content = f.read()
                 all_extends_deps |= get_extends_dependencies(ed_content, available)
 
@@ -918,7 +915,7 @@ def process_module_dir(module_dir_name):
         for ed in all_extends_deps:
             ed_filepath = files_by_module.get(ed)
             if ed_filepath:
-                with open(ed_filepath, 'r') as f:
+                with open(ed_filepath) as f:
                     ed_content = f.read()
                 for _, inst_mod in parse_instances(ed_content):
                     if inst_mod in available and inst_mod not in all_extends_deps:
@@ -943,7 +940,7 @@ def process_module_dir(module_dir_name):
             for ed in all_extends_deps:
                 ed_filepath = files_by_module.get(ed)
                 if ed_filepath:
-                    with open(ed_filepath, 'r') as f:
+                    with open(ed_filepath) as f:
                         ed_content = f.read()
                     extends_graph[ed] = get_extends_dependencies(ed_content, available) & all_extends_deps
             extends_graph[mod_name] = all_extends_deps
@@ -993,7 +990,7 @@ def process_module_dir(module_dir_name):
                     dest = os.path.join(out_dir, os.path.basename(dep_filepath))
                     if not os.path.exists(dest):
                         # Read, strip proofs, write
-                        with open(dep_filepath, 'r') as df:
+                        with open(dep_filepath) as df:
                             dep_content = df.read()
                         dep_lines = dep_content.split('\n')
                         dep_theorems = parse_theorems(dep_lines)
@@ -1022,8 +1019,8 @@ def _load_l2_engine():
     """Load the L2 generator as the shared-model engine. L2 does
     `from generate import ...` expecting THIS module's helpers, so alias us as
     `generate` first."""
-    import sys
     import importlib.util
+    import sys
     sys.modules.setdefault('generate', sys.modules.get('__main__', sys.modules[__name__]))
     path = os.path.join(os.path.dirname(__file__), '..', 'level2', 'generate.py')
     spec = importlib.util.spec_from_file_location('l2_sm_engine', path)
@@ -1099,8 +1096,8 @@ def build_l1_task(sm, source_lines, dump, target_thm, bench_module_name,
 def generate_shared_model_l1(output_root=None):
     """Dump-based L1 generation: one shared `<Module>.tla` per output dir +
     EXTENDS-based L1 tasks. Mirrors the L2 shared-model layout."""
-    import sys
     import shutil
+    import sys
     sm = _load_l2_engine()
     output_root = output_root or BENCHMARK_DIR
 

--- a/src/dataset/level1/generate.py
+++ b/src/dataset/level1/generate.py
@@ -80,16 +80,16 @@ RESOLVABLE_MODULES = STDLIB_MODULES | COMMUNITY_MODULES
 
 # Directories to process (top-level module dirs).
 # File lives at <repo>/src/dataset/level1/generate.py; ascend three levels for the repo root.
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-SOURCE_ROOT = os.path.join(PROJECT_ROOT, 'source')
-BENCHMARK_DIR = os.path.join(PROJECT_ROOT, 'benchmark', 'level1')
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+SOURCE_ROOT = os.path.join(PROJECT_ROOT, "source")
+BENCHMARK_DIR = os.path.join(PROJECT_ROOT, "benchmark", "level1")
 
 
 def find_source_dirs():
     """Find all top-level module directories under source/ containing .tla files."""
     dirs = set()
-    for f in glob.glob(os.path.join(SOURCE_ROOT, '**', '*.tla'), recursive=True):
-        if '.tlaps' in f:
+    for f in glob.glob(os.path.join(SOURCE_ROOT, "**", "*.tla"), recursive=True):
+        if ".tlaps" in f:
             continue
         rel = os.path.relpath(f, SOURCE_ROOT)
         parts = rel.split(os.sep)
@@ -101,8 +101,8 @@ def find_source_dirs():
 def find_tla_files(module_dir):
     """Find all .tla files in a module directory (excluding .tlaps subdirs)."""
     files = []
-    for f in glob.glob(os.path.join(module_dir, '**', '*.tla'), recursive=True):
-        if '.tlaps' in f:
+    for f in glob.glob(os.path.join(module_dir, "**", "*.tla"), recursive=True):
+        if ".tlaps" in f:
             continue
         files.append(f)
     return files
@@ -110,7 +110,7 @@ def find_tla_files(module_dir):
 
 def parse_module_name(content):
     """Extract the MODULE name from TLA+ content."""
-    m = re.search(r'-+\s*MODULE\s+(\w+)\s*-+', content)
+    m = re.search(r"-+\s*MODULE\s+(\w+)\s*-+", content)
     return m.group(1) if m else None
 
 
@@ -147,7 +147,7 @@ def parse_extends(content):
 def parse_instances(content):
     """Extract INSTANCE references (local module references, not stdlib)."""
     instances = []
-    for m in re.finditer(r'(?:(\w+)\s*==\s*)?INSTANCE\s+(\w+)', content):
+    for m in re.finditer(r"(?:(\w+)\s*==\s*)?INSTANCE\s+(\w+)", content):
         alias = m.group(1)
         mod = m.group(2)
         if mod not in RESOLVABLE_MODULES:
@@ -268,14 +268,15 @@ def find_all_deps(mod, graph, visited=None):
 
 class TheoremInfo:
     """Represents a theorem/lemma found in the source."""
+
     def __init__(self, keyword, name, statement_start, statement_end, proof_start, proof_end, has_proof):
         self.keyword = keyword  # THEOREM, LEMMA, etc.
         self.name = name
         self.statement_start = statement_start  # line index of the keyword line
-        self.statement_end = statement_end      # line index of last line of statement (before PROOF/BY/OBVIOUS/OMITTED)
-        self.proof_start = proof_start          # line index of first proof line (None if no proof)
-        self.proof_end = proof_end              # line index of last proof line
-        self.has_proof = has_proof              # True if has a non-trivial proof
+        self.statement_end = statement_end  # line index of last line of statement (before PROOF/BY/OBVIOUS/OMITTED)
+        self.proof_start = proof_start  # line index of first proof line (None if no proof)
+        self.proof_end = proof_end  # line index of last proof line
+        self.has_proof = has_proof  # True if has a non-trivial proof
 
 
 def find_proof_end(lines, start_idx):
@@ -291,15 +292,15 @@ def find_proof_end(lines, start_idx):
         line = lines[i].strip()
 
         # End of module
-        if re.match(r'^={3,}', line):
+        if re.match(r"^={3,}", line):
             return i - 1
 
         if i > start_idx:
             # A new top-level theorem/lemma (these only appear at column 0)
-            if re.match(r'^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\s', line):
+            if re.match(r"^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\s", line):
                 return i - 1
             # Separator line
-            if re.match(r'^-{3,}', line):
+            if re.match(r"^-{3,}", line):
                 return i - 1
             # New top-level operator definition: must start at column 0 with a name
             # and == but NOT be a proof step. Also exclude lines that are indented
@@ -307,10 +308,10 @@ def find_proof_end(lines, start_idx):
             orig_line = lines[i]
             if orig_line and not orig_line[0].isspace():
                 # At column 0, not indented
-                if re.match(r'^\w+(\(.*?\))?\s*==(\s|$)', line) and not re.match(r'^<\d+>', line):
+                if re.match(r"^\w+(\(.*?\))?\s*==(\s|$)", line) and not re.match(r"^<\d+>", line):
                     return i - 1
                 # Top-level CONSTANT/VARIABLE/AXIOM/ASSUME declarations (at column 0 only)
-                if re.match(r'^(CONSTANT|CONSTANTS|VARIABLE|VARIABLES|AXIOM|ASSUME|ASSUMPTION)\s', line):
+                if re.match(r"^(CONSTANT|CONSTANTS|VARIABLE|VARIABLES|AXIOM|ASSUME|ASSUMPTION)\s", line):
                     return i - 1
 
         i += 1
@@ -333,9 +334,9 @@ def parse_theorems(lines):
         # Skip lines inside block comments
         if comment_depth > 0:
             for j in range(len(lines[i]) - 1):
-                if lines[i][j:j+2] == '(*':
+                if lines[i][j : j + 2] == "(*":
                     comment_depth += 1
-                elif lines[i][j:j+2] == '*)':
+                elif lines[i][j : j + 2] == "*)":
                     comment_depth -= 1
             i += 1
             continue
@@ -343,9 +344,9 @@ def parse_theorems(lines):
         # Track comment opens on this line
         line_depth = 0
         for j in range(len(lines[i]) - 1):
-            if lines[i][j:j+2] == '(*':
+            if lines[i][j : j + 2] == "(*":
                 line_depth += 1
-            elif lines[i][j:j+2] == '*)':
+            elif lines[i][j : j + 2] == "*)":
                 line_depth -= 1
         if line_depth > 0:
             comment_depth = line_depth
@@ -353,11 +354,11 @@ def parse_theorems(lines):
             continue
 
         # Match theorem/lemma declaration with a name
-        m = re.match(r'^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\s+(\w+)\s*==', line)
+        m = re.match(r"^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\s+(\w+)\s*==", line)
         if not m:
             # Also match unnamed theorems like "THEOREM Spec => []Inv"
-            m2 = re.match(r'^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\s+(.+)', line)
-            if m2 and '==' not in line:
+            m2 = re.match(r"^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\s+(.+)", line)
+            if m2 and "==" not in line:
                 m = m2  # treat as unnamed theorem, fall through
             if not m:
                 i += 1
@@ -380,10 +381,14 @@ def parse_theorems(lines):
         first_line = lines[i]
         # Check for trailing BY/OBVIOUS/OMITTED on the declaration line
         # Only if the entire theorem is on one line (has == and then proof keyword)
-        if re.search(r'\bBY\s', first_line) or re.search(r'\bPROOF\s+BY\s', first_line):
+        if re.search(r"\bBY\s", first_line) or re.search(r"\bPROOF\s+BY\s", first_line):
             proof_start = i
             has_proof = True
-        elif re.search(r'\bOBVIOUS\s*$', first_line) or re.search(r'\bOMITTED\s*$', first_line) or re.search(r'\bPROOF\s+OMITTED\s*$', first_line):
+        elif (
+            re.search(r"\bOBVIOUS\s*$", first_line)
+            or re.search(r"\bOMITTED\s*$", first_line)
+            or re.search(r"\bPROOF\s+OMITTED\s*$", first_line)
+        ):
             proof_start = i
             has_proof = False
 
@@ -397,9 +402,9 @@ def parse_theorems(lines):
                 # Track comment depth
                 line_cd = 0
                 for ci in range(len(orig) - 1):
-                    if orig[ci:ci+2] == '(*':
+                    if orig[ci : ci + 2] == "(*":
                         line_cd += 1
-                    elif orig[ci:ci+2] == '*)':
+                    elif orig[ci : ci + 2] == "*)":
                         line_cd -= 1
                 inner_comment_depth += line_cd
                 if inner_comment_depth > 0:
@@ -407,46 +412,46 @@ def parse_theorems(lines):
                     continue
 
                 # End of module
-                if re.match(r'^={3,}', sline):
+                if re.match(r"^={3,}", sline):
                     break
 
                 # Another top-level theorem/lemma (not indented)
-                if re.match(r'^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\s', sline) and (not orig or not orig[0].isspace()):
+                if re.match(r"^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\s", sline) and (not orig or not orig[0].isspace()):
                     break
 
                 # Separator
-                if re.match(r'^-{3,}', sline):
+                if re.match(r"^-{3,}", sline):
                     break
 
                 # Top-level definitions (not indented, at column 0)
                 if orig and not orig[0].isspace():
-                    if re.match(r'^[A-Z]\w*(\(.*?\))?\s*==(\s|$)', sline) and not re.match(r'^<\d+>', sline):
+                    if re.match(r"^[A-Z]\w*(\(.*?\))?\s*==(\s|$)", sline) and not re.match(r"^<\d+>", sline):
                         break
                     # Definitions starting with digits (e.g., 1bOr2bMsgs ==)
-                    if re.match(r'^\d\w*\s*==(\s|$)', sline) and not re.match(r'^<\d+>', sline):
+                    if re.match(r"^\d\w*\s*==(\s|$)", sline) and not re.match(r"^<\d+>", sline):
                         break
-                    if re.match(r'^(CONSTANT|CONSTANTS|VARIABLE|VARIABLES)\s', sline):
+                    if re.match(r"^(CONSTANT|CONSTANTS|VARIABLE|VARIABLES)\s", sline):
                         break
 
                 # Proof indicators
-                if sline == 'PROOF' or re.match(r'^PROOF\s+BY\s', sline):
+                if sline == "PROOF" or re.match(r"^PROOF\s+BY\s", sline):
                     proof_start = j
                     has_proof = True
                     break
-                if sline == 'OBVIOUS' or sline.startswith('OBVIOUS '):
+                if sline == "OBVIOUS" or sline.startswith("OBVIOUS "):
                     proof_start = j
                     has_proof = False
                     break
-                if sline == 'OMITTED' or sline == 'PROOF OMITTED' or sline.startswith('PROOF OMITTED '):
+                if sline == "OMITTED" or sline == "PROOF OMITTED" or sline.startswith("PROOF OMITTED "):
                     proof_start = j
                     has_proof = False
                     break
-                if re.match(r'^<\d+>', sline):
+                if re.match(r"^<\d+>", sline):
                     proof_start = j
                     has_proof = True
                     break
                 # BY at start of line (possibly indented)
-                if re.match(r'^\s*BY\s', orig) or sline.startswith('BY ') or sline == 'BY':
+                if re.match(r"^\s*BY\s", orig) or sline.startswith("BY ") or sline == "BY":
                     proof_start = j
                     has_proof = True
                     break
@@ -487,7 +492,7 @@ def extract_preamble(lines, theorems):
     """Extract everything before the first theorem - the preamble (module header, extends, constants, vars, defs)."""
     if not theorems:
         return lines[:]
-    return lines[:theorems[0].statement_start]
+    return lines[: theorems[0].statement_start]
 
 
 def get_theorem_statement_lines(lines, thm):
@@ -497,19 +502,19 @@ def get_theorem_statement_lines(lines, thm):
         line = lines[thm.statement_start]
         # Remove the BY/OBVIOUS/OMITTED part
         # Find the theorem body by removing proof
-        for pat in [r'\s+BY\s+.*$', r'\s+OBVIOUS\s*$', r'\s+OMITTED\s*$', r'\s+PROOF\s+OMITTED\s*$']:
-            line = re.sub(pat, '', line)
+        for pat in [r"\s+BY\s+.*$", r"\s+OBVIOUS\s*$", r"\s+OMITTED\s*$", r"\s+PROOF\s+OMITTED\s*$"]:
+            line = re.sub(pat, "", line)
         return [line]
 
-    result = lines[thm.statement_start:thm.statement_end + 1]
+    result = lines[thm.statement_start : thm.statement_end + 1]
     # Clean trailing empty lines
-    while result and result[-1].strip() == '':
+    while result and result[-1].strip() == "":
         result.pop()
     # Remove trailing comment blocks that contain proof steps (e.g. <1>2.)
     # Properly handle nested/inline comments like (* PTL *)
     while result:
         last = len(result) - 1
-        if result[last].strip().endswith('*)'):
+        if result[last].strip().endswith("*)"):
             # Scan backward tracking comment depth to find the matching opener
             depth = 0
             comment_start = None
@@ -519,19 +524,19 @@ def get_theorem_statement_lines(lines, thm):
                 opens = 0
                 closes = 0
                 for k in range(len(line_text) - 1):
-                    if line_text[k:k+2] == '(*':
+                    if line_text[k : k + 2] == "(*":
                         opens += 1
-                    elif line_text[k:k+2] == '*)':
+                    elif line_text[k : k + 2] == "*)":
                         closes += 1
                 depth += closes - opens  # going backward: closes add depth, opens reduce
                 if depth <= 0 and opens > 0:
                     comment_start = j
                     break
             if comment_start is not None and comment_start > 0:
-                comment_text = '\n'.join(result[comment_start:last+1])
-                if re.search(r'<\d+>', comment_text):
+                comment_text = "\n".join(result[comment_start : last + 1])
+                if re.search(r"<\d+>", comment_text):
                     result = result[:comment_start]
-                    while result and result[-1].strip() == '':
+                    while result and result[-1].strip() == "":
                         result.pop()
                     continue
         break
@@ -551,9 +556,9 @@ def get_theorem_proof_lines(lines, thm):
         return []
     if thm.proof_start == thm.statement_start:
         line = lines[thm.statement_start]
-        m = re.search(r'\s+(PROOF\s+BY\b.*|BY\b.*)$', line)
+        m = re.search(r"\s+(PROOF\s+BY\b.*|BY\b.*)$", line)
         return [m.group(1)] if m else [line]
-    return lines[thm.proof_start:thm.proof_end + 1]
+    return lines[thm.proof_start : thm.proof_end + 1]
 
 
 def merge_files(files_by_module, dep_graph, target_module):
@@ -580,7 +585,7 @@ def merge_files(files_by_module, dep_graph, target_module):
         with open(files_by_module[mod]) as f:
             content = f.read()
 
-        mod_lines = content.split('\n')
+        mod_lines = content.split("\n")
 
         # Collect resolvable extends
         for ext in parse_extends(content):
@@ -591,9 +596,9 @@ def merge_files(files_by_module, dep_graph, target_module):
         body_start = None
         body_end = None
         for idx, line in enumerate(mod_lines):
-            if body_start is None and re.match(r'^-+\s*MODULE\s+\w+\s*-+', line.strip()):
+            if body_start is None and re.match(r"^-+\s*MODULE\s+\w+\s*-+", line.strip()):
                 body_start = idx + 1
-            if re.match(r'^={3,}', line.strip()):
+            if re.match(r"^={3,}", line.strip()):
                 body_end = idx
 
         if body_start is None:
@@ -616,28 +621,28 @@ def merge_files(files_by_module, dep_graph, target_module):
                 code = re.split(r"\\\*", line)[0].rstrip()
                 in_extends = code.endswith(",")
                 continue
-            if re.match(r'^EXTENDS\s', line.strip()):
+            if re.match(r"^EXTENDS\s", line.strip()):
                 code = re.split(r"\\\*", line)[0].rstrip()
                 in_extends = code.endswith(",")  # multi-line if trailing comma
                 continue
             filtered_body.append(line)
 
         if mod != target_module:
-            merged_body_lines.append(f'(* ---- Content from module {mod} ---- *)')
+            merged_body_lines.append(f"(* ---- Content from module {mod} ---- *)")
         merged_body_lines.extend(filtered_body)
         if mod != target_module:
-            merged_body_lines.append('')
+            merged_body_lines.append("")
 
     # Build final content
     header_lines = []
-    extends_str = ', '.join(sorted(all_extends)) if all_extends else ''
+    extends_str = ", ".join(sorted(all_extends)) if all_extends else ""
 
     # We'll use a placeholder module name; caller will set it
     header_lines.append("---- MODULE __PLACEHOLDER__ ----")
     if extends_str:
-        header_lines.append(f'EXTENDS {extends_str}')
+        header_lines.append(f"EXTENDS {extends_str}")
 
-    result_lines = header_lines + merged_body_lines + ['=' * 40]
+    result_lines = header_lines + merged_body_lines + ["=" * 40]
     return [ln + "\n" for ln in result_lines], target_module
 
 
@@ -669,8 +674,8 @@ def strip_all_proofs(lines, theorems):
                 # checker to either accept or reject it).
                 stmt_lines = get_theorem_statement_lines(lines, thm)
                 result.extend(stmt_lines)
-                result.append('  PROOF OMITTED')
-                result.append('')
+                result.append("  PROOF OMITTED")
+                result.append("")
             i = end + 1
             continue
 
@@ -689,7 +694,7 @@ def strip_all_proofs(lines, theorems):
         result.append(lines[i])
         i += 1
 
-    return '\n'.join(result)
+    return "\n".join(result)
 
 
 def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name, benchmark_name):
@@ -700,7 +705,7 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
     - All theorems after target_idx: removed entirely
     """
     if isinstance(lines_or_content, str):
-        lines = lines_or_content.split('\n')
+        lines = lines_or_content.split("\n")
     else:
         lines = [ln.rstrip("\n") for ln in lines_or_content]
 
@@ -736,13 +741,13 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
                         result.append(lines[li])
                 else:
                     result.extend(stmt_lines)
-                    result.append('  PROOF OMITTED')
-                    result.append('')
+                    result.append("  PROOF OMITTED")
+                    result.append("")
             elif found_thm == target_idx:
                 # Target theorem: replace proof with OBVIOUS (will fail for non-trivial theorems)
                 result.extend(stmt_lines)
-                result.append('PROOF OBVIOUS')
-                result.append('')
+                result.append("PROOF OBVIOUS")
+                result.append("")
             else:
                 # Theorems after target: skip entirely
                 pass
@@ -771,7 +776,7 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
             # Check if we're past the target theorem
             if target_idx < len(theorems) and i > theorems[target_idx].statement_start:
                 # Only keep the module end line (====)
-                if re.match(r'^={3,}', lines[i].strip()):
+                if re.match(r"^={3,}", lines[i].strip()):
                     result.append(lines[i])
                 i += 1
                 continue
@@ -781,7 +786,7 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
 
     # Ensure module ends with ====
     if not any(re.match(r"^={3,}", ln.strip()) for ln in result[-3:] if ln.strip()):
-        result.append('=' * 40)
+        result.append("=" * 40)
 
     # Remove comment blocks containing proof steps (e.g. <1>2.)
     # Must properly track nested comment depth
@@ -793,9 +798,9 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
         line_opens = 0
         line_closes = 0
         for k in range(len(line) - 1):
-            if line[k:k+2] == '(*':
+            if line[k : k + 2] == "(*":
                 line_opens += 1
-            elif line[k:k+2] == '*)':
+            elif line[k : k + 2] == "*)":
                 line_closes += 1
 
         if comment_depth == 0 and line_opens > 0:
@@ -805,7 +810,7 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
                 comment_buf = [line]
             elif comment_depth == 0:
                 # Single-line comment (opens and closes on same line)
-                if not re.search(r'<\d+>\d+\.', line):
+                if not re.search(r"<\d+>\d+\.", line):
                     cleaned.append(line)
             # comment_depth < 0 shouldn't happen
         elif comment_depth > 0:
@@ -813,8 +818,8 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
             comment_depth += line_opens - line_closes
             if comment_depth <= 0:
                 # Comment block closed
-                comment_text = '\n'.join(comment_buf)
-                if not re.search(r'<\d+>\d+\.', comment_text):
+                comment_text = "\n".join(comment_buf)
+                if not re.search(r"<\d+>\d+\.", comment_text):
                     cleaned.extend(comment_buf)
                 comment_buf = []
                 comment_depth = 0
@@ -828,26 +833,28 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
     depth = 0
     for line in result:
         for j in range(len(line) - 1):
-            if line[j:j+2] == '(*':
+            if line[j : j + 2] == "(*":
                 depth += 1
-            elif line[j:j+2] == '*)':
+            elif line[j : j + 2] == "*)":
                 depth -= 1
     # Insert closing comments before the ==== line
     if depth > 0:
-        eq_idx = next((i for i in range(len(result)-1, -1, -1) if re.match(r'^={3,}', result[i].strip())), len(result))
+        eq_idx = next(
+            (i for i in range(len(result) - 1, -1, -1) if re.match(r"^={3,}", result[i].strip())), len(result)
+        )
         for _ in range(depth):
-            result.insert(eq_idx, '*)')
+            result.insert(eq_idx, "*)")
 
     # Replace module name in header
     final = []
     for line in result:
-        if re.match(r'^-+\s*MODULE\s+\w+\s*-+', line.strip()):
-            line = re.sub(r'MODULE\s+\w+', f'MODULE {benchmark_name}', line)
-        if '__PLACEHOLDER__' in line:
-            line = line.replace('__PLACEHOLDER__', benchmark_name)
+        if re.match(r"^-+\s*MODULE\s+\w+\s*-+", line.strip()):
+            line = re.sub(r"MODULE\s+\w+", f"MODULE {benchmark_name}", line)
+        if "__PLACEHOLDER__" in line:
+            line = line.replace("__PLACEHOLDER__", benchmark_name)
         final.append(line)
 
-    return '\n'.join(final)
+    return "\n".join(final)
 
 
 def process_module_dir(module_dir_name):
@@ -878,7 +885,7 @@ def process_module_dir(module_dir_name):
         with open(filepath) as f:
             content = f.read()
 
-        raw_lines = content.split('\n')
+        raw_lines = content.split("\n")
         theorems = parse_theorems(raw_lines)
 
         if not theorems or not any(t.has_proof for t in theorems):
@@ -955,25 +962,25 @@ def process_module_dir(module_dir_name):
         name_counts = {}
         for idx, thm in enumerate(theorems):
             # Skip unnamed theorems as benchmark targets (they still get PROOF OMITTED as preceding theorems)
-            if thm.name.startswith('__unnamed_'):
+            if thm.name.startswith("__unnamed_"):
                 continue
             # Skip theorems without real proofs (PROOF OMITTED / OBVIOUS only)
             if not thm.has_proof:
                 continue
-            base_name = f'{source_basename}_{thm.name}'
+            base_name = f"{source_basename}_{thm.name}"
             if base_name in name_counts:
                 name_counts[base_name] += 1
-                benchmark_name = f'{base_name}_{name_counts[base_name]}'
+                benchmark_name = f"{base_name}_{name_counts[base_name]}"
             else:
                 name_counts[base_name] = 0
                 benchmark_name = base_name
-            benchmark_file = os.path.join(out_dir, f'{benchmark_name}.tla')
+            benchmark_file = os.path.join(out_dir, f"{benchmark_name}.tla")
 
             os.makedirs(out_dir, exist_ok=True)
 
             content = generate_benchmark_file(work_lines, theorems, idx, mod_name, benchmark_name)
 
-            with open(benchmark_file, 'w') as f:
+            with open(benchmark_file, "w") as f:
                 f.write(content)
 
             # Copy INSTANCE dependency files alongside the benchmark
@@ -987,20 +994,21 @@ def process_module_dir(module_dir_name):
                         # Read, strip proofs, write
                         with open(dep_filepath) as df:
                             dep_content = df.read()
-                        dep_lines = dep_content.split('\n')
+                        dep_lines = dep_content.split("\n")
                         dep_theorems = parse_theorems(dep_lines)
                         if dep_theorems:
                             # Use generate_benchmark_file logic but admit ALL theorems
                             stripped = strip_all_proofs(dep_lines, dep_theorems)
-                            with open(dest, 'w') as df:
+                            with open(dest, "w") as df:
                                 df.write(stripped)
                         else:
                             # No theorems, just copy as-is
                             import shutil
+
                             shutil.copy2(dep_filepath, dest)
 
             benchmark_count += 1
-            print(f'  Generated: {os.path.relpath(benchmark_file, SOURCE_ROOT)}')
+            print(f"  Generated: {os.path.relpath(benchmark_file, SOURCE_ROOT)}")
 
     return benchmark_count
 
@@ -1016,11 +1024,12 @@ def _load_l2_engine():
     `generate` first."""
     import importlib.util
     import sys
-    sys.modules.setdefault('generate', sys.modules.get('__main__', sys.modules[__name__]))
-    path = os.path.join(os.path.dirname(__file__), '..', 'level2', 'generate.py')
-    spec = importlib.util.spec_from_file_location('l2_sm_engine', path)
+
+    sys.modules.setdefault("generate", sys.modules.get("__main__", sys.modules[__name__]))
+    path = os.path.join(os.path.dirname(__file__), "..", "level2", "generate.py")
+    spec = importlib.util.spec_from_file_location("l2_sm_engine", path)
     mod = importlib.util.module_from_spec(spec)
-    sys.modules['l2_sm_engine'] = mod
+    sys.modules["l2_sm_engine"] = mod
     spec.loader.exec_module(mod)
     return mod
 
@@ -1028,14 +1037,14 @@ def _load_l2_engine():
 def _is_structured_proof(sm, t, lines):
     """True iff the proof is a real structured/BY proof (not OBVIOUS/OMITTED).
     Strips comments first so `OBVIOUS (*{hint}*)` is seen as OBVIOUS."""
-    ploc = t.get('proof_loc')
-    if not (ploc and ploc.get('line_start', -1) > 0):
+    ploc = t.get("proof_loc")
+    if not (ploc and ploc.get("line_start", -1) > 0):
         return False
-    body = ''.join(lines[ploc['line_start'] - 1: ploc['line_end']])
+    body = "".join(lines[ploc["line_start"] - 1 : ploc["line_end"]])
     body = sm.strip_comments(body).strip()
-    if body.startswith('PROOF'):
+    if body.startswith("PROOF"):
         body = body[5:].lstrip()
-    return body not in ('OMITTED', 'OBVIOUS', '')
+    return body not in ("OMITTED", "OBVIOUS", "")
 
 
 def _proof_edit(source_lines, ploc, keyword):
@@ -1044,15 +1053,14 @@ def _proof_edit(source_lines, ploc, keyword):
     `LEMMA X == s  BY DEF Y` put the proof (col 41) on the statement line (cols
     1-40); a whole-line replace would delete the statement and leave a stray
     `PROOF OMITTED`."""
-    line = source_lines[ploc['line_start'] - 1]
-    col = ploc.get('column_start', 1)
-    prefix = line[:col - 1].rstrip()
-    repl = (prefix + '\n  ' + keyword + '\n') if prefix else (keyword + '\n')
-    return (ploc['line_start'], ploc['line_end'], repl)
+    line = source_lines[ploc["line_start"] - 1]
+    col = ploc.get("column_start", 1)
+    prefix = line[: col - 1].rstrip()
+    repl = (prefix + "\n  " + keyword + "\n") if prefix else (keyword + "\n")
+    return (ploc["line_start"], ploc["line_end"], repl)
 
 
-def build_l1_task(sm, source_lines, dump, target_thm, bench_module_name,
-                  model_set, module):
+def build_l1_task(sm, source_lines, dump, target_thm, bench_module_name, model_set, module):
     """L1 task: keep ALL scaffolding (Inv etc.), admit STRUCTURED preceding
     proofs as PROOF OMITTED (keep OBVIOUS verbatim → it still emits an
     obligation), stub the target PROOF OBVIOUS, drop later theorems, keep
@@ -1061,25 +1069,25 @@ def build_l1_task(sm, source_lines, dump, target_thm, bench_module_name,
     use_model = bool(model_set)
     edits = list(sm._decl_edits(dump)) if use_model else []
     tid = id(target_thm)
-    tstart = target_thm['loc']['line_start']
-    for t in dump['theorems']:
-        loc, ploc = t['loc'], t.get('proof_loc')
-        has_body = ploc and ploc.get('line_start', -1) > 0
+    tstart = target_thm["loc"]["line_start"]
+    for t in dump["theorems"]:
+        loc, ploc = t["loc"], t.get("proof_loc")
+        has_body = ploc and ploc.get("line_start", -1) > 0
         if id(t) == tid:
             if has_body:
-                edits.append(_proof_edit(source_lines, ploc, 'PROOF OBVIOUS'))
-        elif loc['line_start'] < tstart:
+                edits.append(_proof_edit(source_lines, ploc, "PROOF OBVIOUS"))
+        elif loc["line_start"] < tstart:
             if has_body and _is_structured_proof(sm, t, source_lines):
-                edits.append(_proof_edit(source_lines, ploc, 'PROOF OMITTED'))
+                edits.append(_proof_edit(source_lines, ploc, "PROOF OMITTED"))
         else:
-            edits.append((loc['line_start'], loc['line_end'], ''))
+            edits.append((loc["line_start"], loc["line_end"], ""))
     if use_model:
-        for o in dump['operators']:
-            if o['name'] in model_set:
-                edits.append((o['loc']['line_start'], o['loc']['line_end'], ''))
-        for inst in dump['instances']:
-            if inst.get('name') and inst['name'] in model_set:
-                edits.append((inst['loc']['line_start'], inst['loc']['line_end'], ''))
+        for o in dump["operators"]:
+            if o["name"] in model_set:
+                edits.append((o["loc"]["line_start"], o["loc"]["line_end"], ""))
+        for inst in dump["instances"]:
+            if inst.get("name") and inst["name"] in model_set:
+                edits.append((inst["loc"]["line_start"], inst["loc"]["line_end"], ""))
     text = sm.apply_edits(source_lines, edits)
     if use_model:
         text = sm._strip_bare_decls(text)
@@ -1093,6 +1101,7 @@ def generate_shared_model_l1(output_root=None):
     EXTENDS-based L1 tasks. Mirrors the L2 shared-model layout."""
     import shutil
     import sys
+
     sm = _load_l2_engine()
     output_root = output_root or BENCHMARK_DIR
 
@@ -1101,8 +1110,8 @@ def generate_shared_model_l1(output_root=None):
     os.makedirs(output_root, exist_ok=True)
 
     targets = []
-    for f in sorted(glob.glob(os.path.join(SOURCE_ROOT, '**', '*.tla'), recursive=True)):
-        if '.tlaps' in f:
+    for f in sorted(glob.glob(os.path.join(SOURCE_ROOT, "**", "*.tla"), recursive=True)):
+        if ".tlaps" in f:
             continue
         subdir = os.path.relpath(f, SOURCE_ROOT).split(os.sep)[0]
         targets.append((f, subdir))
@@ -1115,12 +1124,11 @@ def generate_shared_model_l1(output_root=None):
         except Exception as e:
             print(f"  SANY failed on {path}: {e}", file=sys.stderr)
             continue
-        module = dump['module']
-        with open(path, encoding='utf-8') as fh:
+        module = dump["module"]
+        with open(path, encoding="utf-8") as fh:
             lines = fh.readlines()
         # L1 targets: NAMED theorems with a structured proof.
-        l1_targets = [t for t in dump['theorems']
-                      if t.get('name') and _is_structured_proof(sm, t, lines)]
+        l1_targets = [t for t in dump["theorems"] if t.get("name") and _is_structured_proof(sm, t, lines)]
         if not l1_targets:
             continue
         out_dir = os.path.join(output_root, subdir)
@@ -1131,12 +1139,12 @@ def generate_shared_model_l1(output_root=None):
             model_set, _ = sm.compute_model_set(dump, l1_targets)
             if model_set:
                 model_text = sm.build_model(lines, dump, model_set)
-                with open(os.path.join(out_dir, f"{module}.tla"), 'w') as f:
+                with open(os.path.join(out_dir, f"{module}.tla"), "w") as f:
                     f.write(model_text)
 
         base = os.path.splitext(os.path.basename(path))[0]
         used = {}
-        reachable_all = {i['name'] for i in dump['instances'] if i.get('name')}
+        reachable_all = {i["name"] for i in dump["instances"] if i.get("name")}
         for t in l1_targets:
             name = f"{base}_{t['name']}"
             if name in used:
@@ -1146,10 +1154,10 @@ def generate_shared_model_l1(output_root=None):
                 used[name] = 0
                 bench = name
             text = build_l1_task(sm, lines, dump, t, bench, model_set, module)
-            with open(os.path.join(out_dir, f"{bench}.tla"), 'w') as f:
+            with open(os.path.join(out_dir, f"{bench}.tla"), "w") as f:
                 f.write(text)
             total += 1
-            print(f"  generated: {os.path.relpath(os.path.join(out_dir, bench+'.tla'), PROJECT_ROOT)}")
+            print(f"  generated: {os.path.relpath(os.path.join(out_dir, bench + '.tla'), PROJECT_ROOT)}")
         sm.copy_deps(dump, path, out_dir, reachable_all)
     print(f"\nTotal L1 benchmarks (shared-model): {total}")
     return total
@@ -1157,12 +1165,15 @@ def generate_shared_model_l1(output_root=None):
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(description='Generate L1 benchmarks.')
-    parser.add_argument('--shared-model', action='store_true',
-                        help='Emit one proof-free <Module>.tla model per output dir '
-                             'and have tasks EXTEND it instead of inlining the spec.')
-    parser.add_argument('--output-dir', default=None,
-                        help='Output directory (default: benchmark/level1)')
+
+    parser = argparse.ArgumentParser(description="Generate L1 benchmarks.")
+    parser.add_argument(
+        "--shared-model",
+        action="store_true",
+        help="Emit one proof-free <Module>.tla model per output dir "
+        "and have tasks EXTEND it instead of inlining the spec.",
+    )
+    parser.add_argument("--output-dir", default=None, help="Output directory (default: benchmark/level1)")
     args = parser.parse_args()
 
     if args.shared_model:
@@ -1172,6 +1183,7 @@ def main():
     # Clean benchmark dir
     if os.path.exists(BENCHMARK_DIR):
         import shutil
+
         shutil.rmtree(BENCHMARK_DIR)
     os.makedirs(BENCHMARK_DIR, exist_ok=True)
 
@@ -1179,14 +1191,14 @@ def main():
     total = 0
 
     for mod_dir in module_dirs:
-        print(f'\nProcessing {mod_dir}/')
+        print(f"\nProcessing {mod_dir}/")
         count = process_module_dir(mod_dir)
         total += count
         if count:
-            print(f'  -> {count} benchmarks')
+            print(f"  -> {count} benchmarks")
 
-    print(f'\nTotal benchmarks generated: {total}')
+    print(f"\nTotal benchmarks generated: {total}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/dataset/level1/generate.py
+++ b/src/dataset/level1/generate.py
@@ -364,10 +364,7 @@ def parse_theorems(lines):
                 continue
 
         keyword = m.group(1)
-        if '==' not in line:
-            name = f'__unnamed_{i}'
-        else:
-            name = m.group(2)
+        name = f"__unnamed_{i}" if "==" not in line else m.group(2)
         stmt_start = i
 
         # Scan forward to find where the proof starts (or where the theorem ends)
@@ -707,8 +704,6 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
     else:
         lines = [l.rstrip('\n') for l in lines_or_content]
 
-    target_thm = theorems[target_idx]
-
     # We'll rebuild the file by going through lines and replacing theorem sections
     result = []
 
@@ -873,7 +868,7 @@ def process_module_dir(module_dir_name):
             files_by_module[mod_name] = f
 
     # Build dependency graph
-    dep_graph = build_dependency_graph(files_by_module)
+    build_dependency_graph(files_by_module)
     available = set(files_by_module.keys())
 
     benchmark_count = 0

--- a/src/dataset/level1/generate.py
+++ b/src/dataset/level1/generate.py
@@ -638,7 +638,7 @@ def merge_files(files_by_module, dep_graph, target_module):
         header_lines.append(f'EXTENDS {extends_str}')
 
     result_lines = header_lines + merged_body_lines + ['=' * 40]
-    return [l + '\n' for l in result_lines], target_module
+    return [ln + "\n" for ln in result_lines], target_module
 
 
 def strip_all_proofs(lines, theorems):
@@ -702,7 +702,7 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
     if isinstance(lines_or_content, str):
         lines = lines_or_content.split('\n')
     else:
-        lines = [l.rstrip('\n') for l in lines_or_content]
+        lines = [ln.rstrip("\n") for ln in lines_or_content]
 
     # We'll rebuild the file by going through lines and replacing theorem sections
     result = []
@@ -754,7 +754,7 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
 
         # Check if this line is inside a theorem range (shouldn't happen, but safety)
         inside = False
-        for idx, (start, end) in thm_ranges.items():
+        for _idx, (start, end) in thm_ranges.items():
             if start < i <= end:
                 inside = True
                 break
@@ -780,7 +780,7 @@ def generate_benchmark_file(lines_or_content, theorems, target_idx, module_name,
         i += 1
 
     # Ensure module ends with ====
-    if not any(re.match(r'^={3,}', l.strip()) for l in result[-3:] if l.strip()):
+    if not any(re.match(r"^={3,}", ln.strip()) for ln in result[-3:] if ln.strip()):
         result.append('=' * 40)
 
     # Remove comment blocks containing proof steps (e.g. <1>2.)
@@ -941,7 +941,7 @@ def process_module_dir(module_dir_name):
             extends_graph[mod_name] = all_extends_deps
 
             merged_lines, _ = merge_files(files_by_module, extends_graph, mod_name)
-            work_lines = [l.rstrip('\n') for l in merged_lines]
+            work_lines = [ln.rstrip("\n") for ln in merged_lines]
             theorems = parse_theorems(work_lines)
             if not theorems or not any(t.has_proof for t in theorems):
                 continue

--- a/src/dataset/level2/generate.py
+++ b/src/dataset/level2/generate.py
@@ -78,13 +78,13 @@ import re
 import subprocess
 import sys
 
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-SOURCE_ROOT = os.path.join(PROJECT_ROOT, 'source')
-BENCHMARK_DIR = os.path.join(PROJECT_ROOT, 'benchmark', 'level2')
-SANY_DUMP = os.path.join(PROJECT_ROOT, 'src', 'dataset', 'sany-dump', 'run.sh')
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+SOURCE_ROOT = os.path.join(PROJECT_ROOT, "source")
+BENCHMARK_DIR = os.path.join(PROJECT_ROOT, "benchmark", "level2")
+SANY_DUMP = os.path.join(PROJECT_ROOT, "src", "dataset", "sany-dump", "run.sh")
 
 # Reuse L1's proof-stripping logic for dependency .tla copies.
-sys.path.insert(0, os.path.join(PROJECT_ROOT, 'src', 'dataset', 'level1'))
+sys.path.insert(0, os.path.join(PROJECT_ROOT, "src", "dataset", "level1"))
 from generate import (  # noqa: E402
     STDLIB_MODULES,
     parse_extends,
@@ -93,8 +93,8 @@ from generate import (  # noqa: E402
     strip_all_proofs,
 )
 
-KEYWORD_PATTERN = re.compile(r'^\s*(THEOREM|LEMMA|AXIOM|COROLLARY|PROPOSITION)\b')
-MODULE_HEADER = re.compile(r'^(-+\s*MODULE\s+)(\w+)(\s*-+)')
+KEYWORD_PATTERN = re.compile(r"^\s*(THEOREM|LEMMA|AXIOM|COROLLARY|PROPOSITION)\b")
+MODULE_HEADER = re.compile(r"^(-+\s*MODULE\s+)(\w+)(\s*-+)")
 
 # Top-level theorems whose goal is actually FALSE — TLC finds a counterexample —
 # even though the source "proves" them with an OMITTED sub-step that papers over
@@ -104,29 +104,26 @@ MODULE_HEADER = re.compile(r'^(-+\s*MODULE\s+)(\w+)(\s*-+)')
 # This is the *only* reason filter A' now drops an OMITTED-sub-step theorem —
 # every other such theorem is a published, verified result and is kept.
 KNOWN_FALSE_TARGETS = {
-    ("PaxosProof", "StructOK3"):
-        "TLC counterexample: PaxosTuple.tla Phase2a's uniqueness guard tests "
-        "m[3] (the value field) instead of m[2] (the ballot), so a single ballot "
-        "can carry two distinct 2a values, violating StructOK3's one-value-per-"
-        "ballot conjunct. The author commented StructOK3 out of the proven "
-        "StructOK and left its inductive step PROOF OMITTED.",
+    ("PaxosProof", "StructOK3"): "TLC counterexample: PaxosTuple.tla Phase2a's uniqueness guard tests "
+    "m[3] (the value field) instead of m[2] (the ballot), so a single ballot "
+    "can carry two distinct 2a values, violating StructOK3's one-value-per-"
+    "ballot conjunct. The author commented StructOK3 out of the proven "
+    "StructOK and left its inductive step PROOF OMITTED.",
 }
 
 
 def dump_sany(tla_path):
     res = subprocess.run([SANY_DUMP, tla_path], capture_output=True, text=True)
     if res.returncode != 0:
-        raise RuntimeError(
-            f"SANY dump failed for {tla_path}:\n--stdout--\n{res.stdout}\n--stderr--\n{res.stderr}"
-        )
+        raise RuntimeError(f"SANY dump failed for {tla_path}:\n--stdout--\n{res.stdout}\n--stderr--\n{res.stderr}")
     # SANY's PlusCal label-adder and parse-error reporter print to System.out
     # from inside frontEndMain. Skip past the sentinel marker we print in
     # DumpSemantics.java to find the actual JSON.
-    marker = '--- BEGIN SANY-DUMP JSON ---'
+    marker = "--- BEGIN SANY-DUMP JSON ---"
     idx = res.stdout.find(marker)
     if idx < 0:
         raise RuntimeError(f"SANY produced no JSON for {tla_path}:\n{res.stdout!r}\nstderr:\n{res.stderr}")
-    return json.loads(res.stdout[idx + len(marker):])
+    return json.loads(res.stdout[idx + len(marker) :])
 
 
 def determine_keyword(lines, line_start):
@@ -148,21 +145,19 @@ def find_top_level(theorems, spec_formulas):
     """
     incoming = {}
     for t in theorems:
-        if t['name']:
-            incoming.setdefault(t['name'], set())
+        if t["name"]:
+            incoming.setdefault(t["name"], set())
     for t in theorems:
-        src_name = t['name'] or f"__unnamed_{t['loc']['line_start']}"
-        for ref in t['references']:
+        src_name = t["name"] or f"__unnamed_{t['loc']['line_start']}"
+        for ref in t["references"]:
             if ref in incoming:
                 incoming[ref].add(src_name)
 
     out = []
     for t in theorems:
-        unnamed_match = not t['name']
-        shape_match = (t['shape']['kind'] == 'implies'
-                       and t['shape']['lhs_spec_ref'] in spec_formulas)
-        graph_match = (not unnamed_match
-                       and len(incoming.get(t['name'], set())) == 0)
+        unnamed_match = not t["name"]
+        shape_match = t["shape"]["kind"] == "implies" and t["shape"]["lhs_spec_ref"] in spec_formulas
+        graph_match = not unnamed_match and len(incoming.get(t["name"], set())) == 0
         if unnamed_match or shape_match or graph_match:
             out.append((t, unnamed_match, shape_match, graph_match))
     return out
@@ -176,10 +171,10 @@ def _statement_text(target_thm, source_lines):
     proof, the statement runs to `loc.line_end`. Returned text is the joined
     source lines, stripped of surrounding whitespace.
     """
-    loc = target_thm['loc']
-    ploc = target_thm.get('proof_loc')
-    end_line = ploc['line_start'] - 1 if ploc and ploc.get('line_start', -1) > 0 else loc['line_end']
-    return ''.join(source_lines[loc['line_start'] - 1 : end_line]).strip()
+    loc = target_thm["loc"]
+    ploc = target_thm.get("proof_loc")
+    end_line = ploc["line_start"] - 1 if ploc and ploc.get("line_start", -1) > 0 else loc["line_end"]
+    return "".join(source_lines[loc["line_start"] - 1 : end_line]).strip()
 
 
 def _has_manual_proof(target_thm, source_lines):
@@ -193,13 +188,13 @@ def _has_manual_proof(target_thm, source_lines):
     All other proof bodies (a `<N>` proof tree, a `BY ...` leaf, a `PROOF BY`
     line, etc.) count as manual proofs.
     """
-    ploc = target_thm.get('proof_loc')
-    if not (ploc and ploc.get('line_start', -1) > 0):
+    ploc = target_thm.get("proof_loc")
+    if not (ploc and ploc.get("line_start", -1) > 0):
         return False
-    body = ''.join(source_lines[ploc['line_start'] - 1 : ploc['line_end']]).strip()
-    if body.startswith('PROOF'):
+    body = "".join(source_lines[ploc["line_start"] - 1 : ploc["line_end"]]).strip()
+    if body.startswith("PROOF"):
         body = body[5:].lstrip()
-    return body not in ('OMITTED', 'OBVIOUS')
+    return body not in ("OMITTED", "OBVIOUS")
 
 
 def _proof_has_omitted_substep(target_thm, source_lines):
@@ -218,11 +213,11 @@ def _proof_has_omitted_substep(target_thm, source_lines):
     catches the subtler case of an OMITTED leaf inside an otherwise-structured
     proof. Matches the OMITTED keyword on word boundaries.
     """
-    ploc = target_thm.get('proof_loc')
-    if not (ploc and ploc.get('line_start', -1) > 0):
+    ploc = target_thm.get("proof_loc")
+    if not (ploc and ploc.get("line_start", -1) > 0):
         return False
-    body = ''.join(source_lines[ploc['line_start'] - 1 : ploc['line_end']])
-    return re.search(r'\bOMITTED\b', body) is not None
+    body = "".join(source_lines[ploc["line_start"] - 1 : ploc["line_end"]])
+    return re.search(r"\bOMITTED\b", body) is not None
 
 
 def target_theorem_name(theorem):
@@ -232,11 +227,11 @@ def target_theorem_name(theorem):
     namespace separator `!` (e.g. `V!Spec`), it is replaced with `_` because
     `!` is not legal in a TLA+ module identifier.
     """
-    if theorem['name']:
-        return theorem['name'], False
-    rhs = theorem['shape'].get('rhs_primary_name')
+    if theorem["name"]:
+        return theorem["name"], False
+    rhs = theorem["shape"].get("rhs_primary_name")
     if rhs:
-        sanitized = rhs.replace('!', '_')
+        sanitized = rhs.replace("!", "_")
         return sanitized, sanitized != rhs
     return f"line{theorem['loc']['line_start']}", False
 
@@ -256,15 +251,15 @@ def compute_reachable(dump, target_thm):
     decomposition) is reachable and kept — the goal cannot be hidden.
     """
     adj = {}
-    for o in dump['operators']:
-        adj.setdefault(o['name'], set()).update(o.get('references', []))
-    for i in dump['instances']:
-        if i.get('name'):
-            adj.setdefault(i['name'], set()).update(i.get('references', []))
+    for o in dump["operators"]:
+        adj.setdefault(o["name"], set()).update(o.get("references", []))
+    for i in dump["instances"]:
+        if i.get("name"):
+            adj.setdefault(i["name"], set()).update(i.get("references", []))
 
-    seed = set(target_thm.get('statement_references', []))
-    for a in dump['assumes']:
-        seed.update(a.get('references', []))
+    seed = set(target_thm.get("statement_references", []))
+    for a in dump["assumes"]:
+        seed.update(a.get("references", []))
 
     reachable = set()
     stack = list(seed)
@@ -290,32 +285,32 @@ def strip_comments(text):
     out = []
     i = 0
     n = len(text)
-    depth = 0          # block-comment nesting depth
-    in_line = False    # inside a \* line comment
-    in_str = False     # inside a "..." string literal
+    depth = 0  # block-comment nesting depth
+    in_line = False  # inside a \* line comment
+    in_str = False  # inside a "..." string literal
     while i < n:
         c = text[i]
-        nxt = text[i + 1] if i + 1 < n else ''
+        nxt = text[i + 1] if i + 1 < n else ""
         if in_line:
-            if c == '\n':
+            if c == "\n":
                 in_line = False
                 out.append(c)
             i += 1
         elif depth > 0:
-            if c == '(' and nxt == '*':
+            if c == "(" and nxt == "*":
                 depth += 1
                 i += 2
-            elif c == '*' and nxt == ')':
+            elif c == "*" and nxt == ")":
                 depth -= 1
                 i += 2
-            elif c == '\n':
+            elif c == "\n":
                 out.append(c)  # keep blank line where the comment sat
                 i += 1
             else:
                 i += 1
         elif in_str:
             out.append(c)
-            if c == '\\' and nxt:
+            if c == "\\" and nxt:
                 out.append(nxt)
                 i += 2
             else:
@@ -323,10 +318,10 @@ def strip_comments(text):
                     in_str = False
                 i += 1
         else:
-            if c == '\\' and nxt == '*':
+            if c == "\\" and nxt == "*":
                 in_line = True
                 i += 2
-            elif c == '(' and nxt == '*':
+            elif c == "(" and nxt == "*":
                 depth = 1
                 i += 2
             elif c == '"':
@@ -336,7 +331,7 @@ def strip_comments(text):
             else:
                 out.append(c)
                 i += 1
-    return ''.join(out)
+    return "".join(out)
 
 
 def apply_edits(lines, edits):
@@ -354,13 +349,13 @@ def apply_edits(lines, edits):
     cursor = 1
     for start, end, repl in edits:
         if start > cursor:
-            out.extend(lines[cursor - 1:start - 1])
+            out.extend(lines[cursor - 1 : start - 1])
         if repl:
             out.append(repl)
         cursor = end + 1
     if cursor <= len(lines):
-        out.extend(lines[cursor - 1:])
-    return ''.join(out)
+        out.extend(lines[cursor - 1 :])
+    return "".join(out)
 
 
 def build_benchmark(source_lines, dump, target_thm, benchmark_module_name, reachable):
@@ -377,34 +372,34 @@ def build_benchmark(source_lines, dump, target_thm, benchmark_module_name, reach
     """
     edits = []
     target_id = id(target_thm)
-    for t in dump['theorems']:
+    for t in dump["theorems"]:
         if id(t) == target_id:
-            ploc = t.get('proof_loc')
+            ploc = t.get("proof_loc")
             # Filter A in process_file guarantees the target has a real proof body.
-            assert ploc and ploc.get('line_start', -1) > 0, (
+            assert ploc and ploc.get("line_start", -1) > 0, (
                 f"build_benchmark invoked on target without proof body at "
                 f"{source_lines[t['loc']['line_start'] - 1].rstrip()!r}; "
                 "should have been filtered upstream."
             )
-            edits.append((ploc['line_start'], ploc['line_end'], 'PROOF OBVIOUS\n'))
+            edits.append((ploc["line_start"], ploc["line_end"], "PROOF OBVIOUS\n"))
         else:
             # Delete other theorems/lemmas entirely.
-            loc = t['loc']
-            edits.append((loc['line_start'], loc['line_end'], ''))
+            loc = t["loc"]
+            edits.append((loc["line_start"], loc["line_end"], ""))
 
     # Delete operator definitions not reachable from the target statement —
     # the inductive invariants and helper operators the AI must rediscover.
-    for o in dump['operators']:
-        if o['name'] not in reachable:
-            loc = o['loc']
-            edits.append((loc['line_start'], loc['line_end'], ''))
+    for o in dump["operators"]:
+        if o["name"] not in reachable:
+            loc = o["loc"]
+            edits.append((loc["line_start"], loc["line_end"], ""))
     # Delete named INSTANCE bindings that aren't needed to state the goal.
     # Unnamed (bare) INSTANCEs import names into scope unqualified and can't be
     # tracked by reachability, so they are always kept.
-    for inst in dump['instances']:
-        if inst.get('name') and inst['name'] not in reachable:
-            loc = inst['loc']
-            edits.append((loc['line_start'], loc['line_end'], ''))
+    for inst in dump["instances"]:
+        if inst.get("name") and inst["name"] not in reachable:
+            loc = inst["loc"]
+            edits.append((loc["line_start"], loc["line_end"], ""))
 
     text = apply_edits(source_lines, edits)
     text = strip_comments(text)
@@ -416,11 +411,11 @@ def build_benchmark(source_lines, dump, target_thm, benchmark_module_name, reach
         if m:
             out_lines[i] = f"{m.group(1)}{benchmark_module_name}{m.group(3)}\n"
             break
-    text = ''.join(out_lines)
+    text = "".join(out_lines)
 
     # Collapse the blank-line runs left behind by deleted defs / stripped
     # comments down to a single blank line.
-    text = re.sub(r'\n[ \t]*\n(?:[ \t]*\n)+', '\n\n', text)
+    text = re.sub(r"\n[ \t]*\n(?:[ \t]*\n)+", "\n\n", text)
     return text
 
 
@@ -442,7 +437,7 @@ def _gather_local_deps(start_mods, src_dir):
             continue
         seen.add(mod)
         out.append((mod, dep_path))
-        with open(dep_path, encoding='utf-8') as f:
+        with open(dep_path, encoding="utf-8") as f:
             dep_content = f.read()
         for ext in parse_extends(dep_content):
             if ext not in STDLIB_MODULES and ext not in seen:
@@ -468,23 +463,23 @@ def copy_deps(dump, source_path, out_dir, reachable):
     """
     src_dir = os.path.dirname(os.path.abspath(source_path))
     direct_deps = []
-    for ext in dump.get('extends', []):
+    for ext in dump.get("extends", []):
         if ext not in STDLIB_MODULES:
             direct_deps.append(ext)
-    for inst in dump.get('instances', []):
-        mod = inst.get('module')
+    for inst in dump.get("instances", []):
+        mod = inst.get("module")
         if not mod:
             continue
-        name = inst.get('name')
+        name = inst.get("name")
         if name and name not in reachable:
             continue  # instance was stripped from the benchmark
         direct_deps.append(mod)
 
     copied = []
     for _mod, dep_path in _gather_local_deps(direct_deps, src_dir):
-        with open(dep_path, encoding='utf-8') as f:
+        with open(dep_path, encoding="utf-8") as f:
             dep_text = f.read()
-        dep_lines = dep_text.split('\n')
+        dep_lines = dep_text.split("\n")
         dep_thms = parse_theorems(dep_lines)
         dest = os.path.join(out_dir, os.path.basename(dep_path))
         if dep_thms:
@@ -493,14 +488,14 @@ def copy_deps(dump, source_path, out_dir, reachable):
         # THEOREM statements stay, only proofs become OMITTED) would otherwise
         # leak strategy prose just like the main file.
         dep_text = strip_comments(dep_text)
-        dep_text = re.sub(r'\n[ \t]*\n(?:[ \t]*\n)+', '\n\n', dep_text)
-        with open(dest, 'w', encoding='utf-8') as f:
-            f.write(dep_text if dep_text.endswith('\n') else dep_text + '\n')
+        dep_text = re.sub(r"\n[ \t]*\n(?:[ \t]*\n)+", "\n\n", dep_text)
+        with open(dest, "w", encoding="utf-8") as f:
+            f.write(dep_text if dep_text.endswith("\n") else dep_text + "\n")
         copied.append(os.path.basename(dep_path))
     return copied
 
 
-def cross_dir_dedup(target_paths, audit_writer, preferred_dir='Data'):
+def cross_dir_dedup(target_paths, audit_writer, preferred_dir="Data"):
     """Filter C — drop target benchmarks that are byte-identical to a target
     in another output directory.
 
@@ -512,9 +507,10 @@ def cross_dir_dedup(target_paths, audit_writer, preferred_dir='Data'):
     Returns the number of files removed.
     """
     import hashlib
+
     by_hash = {}
     for path in target_paths:
-        with open(path, 'rb') as f:
+        with open(path, "rb") as f:
             h = hashlib.sha256(f.read()).hexdigest()
         by_hash.setdefault(h, []).append(path)
 
@@ -546,17 +542,17 @@ def cross_dir_dedup(target_paths, audit_writer, preferred_dir='Data'):
 # grader already copies co-located *.tla, so EXTENDS resolves with no grader
 # change. Certified sound (obligation-set equivalence) — see tmp/split_poc.
 # ---------------------------------------------------------------------------
-_BARE_DECL = re.compile(r'^[ \t]*(CONSTANTS?|VARIABLES?)[ \t]*,?[ \t]*$', re.M)
-_EXTENDS_START = re.compile(r'^EXTENDS\b')
+_BARE_DECL = re.compile(r"^[ \t]*(CONSTANTS?|VARIABLES?)[ \t]*,?[ \t]*$", re.M)
+_EXTENDS_START = re.compile(r"^EXTENDS\b")
 
 
 def _model_closure(dump, seed):
     adj = {}
-    for o in dump['operators']:
-        adj.setdefault(o['name'], set()).update(o.get('references', []))
-    for i in dump['instances']:
-        if i.get('name'):
-            adj.setdefault(i['name'], set()).update(i.get('references', []))
+    for o in dump["operators"]:
+        adj.setdefault(o["name"], set()).update(o.get("references", []))
+    for i in dump["instances"]:
+        if i.get("name"):
+            adj.setdefault(i["name"], set()).update(i.get("references", []))
     out, stack = set(), list(seed)
     while stack:
         n = stack.pop()
@@ -574,18 +570,17 @@ def compute_model_set(dump, targets):
     `ISpec`/`LiveSpec` can't drag `Inv` into the model. The intersection drops
     anything a task is meant to hide; what remains is the common state machine,
     provably free of inductive invariants/proofs."""
-    spec_formulas = dump.get('spec_formulas', [])
-    main_specs = {t['shape'].get('lhs_spec_ref') for t in targets
-                  if t['shape'].get('lhs_spec_ref') in spec_formulas}
+    spec_formulas = dump.get("spec_formulas", [])
+    main_specs = {t["shape"].get("lhs_spec_ref") for t in targets if t["shape"].get("lhs_spec_ref") in spec_formulas}
     if not main_specs:
         return set(), main_specs
     seed = set(main_specs)
-    for a in dump['assumes']:
-        seed.update(a.get('references', []))
+    for a in dump["assumes"]:
+        seed.update(a.get("references", []))
     reachable = {id(t): compute_reachable(dump, t) for t in targets}
     model = _model_closure(dump, seed)
     for t in targets:
-        if t['shape'].get('lhs_spec_ref') in main_specs:
+        if t["shape"].get("lhs_spec_ref") in main_specs:
             model &= reachable[id(t)]
     return model, main_specs
 
@@ -594,41 +589,40 @@ def _decl_edits(dump):
     """Delete CONSTANT/VARIABLE/ASSUME declarations (one per distinct loc) —
     they come via EXTENDS in the task/model-extending file."""
     seen, edits = set(), []
-    for e in (list(dump.get('constants', [])) + list(dump.get('variables', []))
-              + list(dump.get('assumes', []))):
-        loc = e.get('loc')
+    for e in list(dump.get("constants", [])) + list(dump.get("variables", [])) + list(dump.get("assumes", [])):
+        loc = e.get("loc")
         if not loc:
             continue
-        key = (loc['line_start'], loc['line_end'])
+        key = (loc["line_start"], loc["line_end"])
         if key in seen:
             continue
         seen.add(key)
-        edits.append((loc['line_start'], loc['line_end'], ''))
+        edits.append((loc["line_start"], loc["line_end"], ""))
     return edits
 
 
 def _rewrite_extends_line(text, module):
     """Replace the (possibly multi-line) EXTENDS statement with `EXTENDS <module>`."""
-    lines = text.split('\n')
+    lines = text.split("\n")
     out, i, done = [], 0, False
     while i < len(lines):
         if not done and _EXTENDS_START.match(lines[i]):
             j = i
-            while lines[j].rstrip().endswith(','):
+            while lines[j].rstrip().endswith(","):
                 j += 1
-            out.append(f'EXTENDS {module}')
+            out.append(f"EXTENDS {module}")
             i = j + 1
             done = True
             continue
         out.append(lines[i])
         i += 1
-    return '\n'.join(out)
+    return "\n".join(out)
 
 
 def _sm_tidy(text):
     """Drop stranded pure-dash `----` dividers and collapse blank runs."""
-    text = re.sub(r'(?m)^-{4,}[ \t]*$\n?', '', text)
-    return re.sub(r'\n[ \t]*\n(?:[ \t]*\n)+', '\n\n', text)
+    text = re.sub(r"(?m)^-{4,}[ \t]*$\n?", "", text)
+    return re.sub(r"\n[ \t]*\n(?:[ \t]*\n)+", "\n\n", text)
 
 
 def _rename_header(text, new_name):
@@ -645,45 +639,43 @@ def _rename_header(text, new_name):
                 done = True
                 continue
         out.append(line)
-    return ''.join(out)
+    return "".join(out)
 
 
 def build_model(source_lines, dump, model_set):
     """Proof-free shared model (delete-from-source, preserves declaration order
     so an ASSUME/AXIOM that references a later operator still resolves)."""
     edits = []
-    for t in dump['theorems']:
-        edits.append((t['loc']['line_start'], t['loc']['line_end'], ''))
-    for o in dump['operators']:
-        if o['name'] not in model_set:
-            edits.append((o['loc']['line_start'], o['loc']['line_end'], ''))
-    for inst in dump['instances']:
-        if inst.get('name') and inst['name'] not in model_set:
-            edits.append((inst['loc']['line_start'], inst['loc']['line_end'], ''))
+    for t in dump["theorems"]:
+        edits.append((t["loc"]["line_start"], t["loc"]["line_end"], ""))
+    for o in dump["operators"]:
+        if o["name"] not in model_set:
+            edits.append((o["loc"]["line_start"], o["loc"]["line_end"], ""))
+    for inst in dump["instances"]:
+        if inst.get("name") and inst["name"] not in model_set:
+            edits.append((inst["loc"]["line_start"], inst["loc"]["line_end"], ""))
     return _sm_tidy(strip_comments(apply_edits(source_lines, edits)))
 
 
-def build_benchmark_extends(source_lines, dump, target_thm, bench_module_name,
-                            reachable, model_set, module):
+def build_benchmark_extends(source_lines, dump, target_thm, bench_module_name, reachable, model_set, module):
     """Like build_benchmark, but the spec lives in the EXTENDS'd model: also
     delete model operators + the CONSTANT/VARIABLE/ASSUME decls, and rewrite the
     EXTENDS line to `EXTENDS <module>`."""
     edits = list(_decl_edits(dump))
     tid = id(target_thm)
-    for t in dump['theorems']:
+    for t in dump["theorems"]:
         if id(t) == tid:
-            ploc = t['proof_loc']
-            edits.append((ploc['line_start'], ploc['line_end'], 'PROOF OBVIOUS\n'))
+            ploc = t["proof_loc"]
+            edits.append((ploc["line_start"], ploc["line_end"], "PROOF OBVIOUS\n"))
         else:
-            loc = t['loc']
-            edits.append((loc['line_start'], loc['line_end'], ''))
-    for o in dump['operators']:
-        if o['name'] in model_set or o['name'] not in reachable:
-            edits.append((o['loc']['line_start'], o['loc']['line_end'], ''))
-    for inst in dump['instances']:
-        if inst.get('name') and (inst['name'] in model_set
-                                 or inst['name'] not in reachable):
-            edits.append((inst['loc']['line_start'], inst['loc']['line_end'], ''))
+            loc = t["loc"]
+            edits.append((loc["line_start"], loc["line_end"], ""))
+    for o in dump["operators"]:
+        if o["name"] in model_set or o["name"] not in reachable:
+            edits.append((o["loc"]["line_start"], o["loc"]["line_end"], ""))
+    for inst in dump["instances"]:
+        if inst.get("name") and (inst["name"] in model_set or inst["name"] not in reachable):
+            edits.append((inst["loc"]["line_start"], inst["loc"]["line_end"], ""))
     text = apply_edits(source_lines, edits)
     text = strip_comments(text)
     text = _strip_bare_decls(text)
@@ -693,7 +685,7 @@ def build_benchmark_extends(source_lines, dump, target_thm, bench_module_name,
 
 
 def _strip_bare_decls(text):
-    return _BARE_DECL.sub('', text)
+    return _BARE_DECL.sub("", text)
 
 
 def compute_sibling_deps(targets):
@@ -726,15 +718,22 @@ def compute_sibling_deps(targets):
     return result
 
 
-def process_file(source_path, audit_writer, output_root, module_subdir=None,
-                 generated_paths=None, shared_model=False, skip_model_modules=(),
-                 allow_no_proof=False):
+def process_file(
+    source_path,
+    audit_writer,
+    output_root,
+    module_subdir=None,
+    generated_paths=None,
+    shared_model=False,
+    skip_model_modules=(),
+    allow_no_proof=False,
+):
     """Generate L2 benchmarks for one source .tla file. Returns count emitted.
 
     If `generated_paths` is a list, each generated target benchmark path is
     appended to it (for downstream cross-directory dedup).
     """
-    with open(source_path, encoding='utf-8') as f:
+    with open(source_path, encoding="utf-8") as f:
         text = f.read()
     source_lines = text.splitlines(keepends=True)
 
@@ -744,27 +743,21 @@ def process_file(source_path, audit_writer, output_root, module_subdir=None,
         audit_writer.write(f"[level2-audit] {source_path}: SANY parse failed — {e}\n")
         return 0
 
-    module = dump['module']
-    spec_formulas = set(dump['spec_formulas'])
+    module = dump["module"]
+    spec_formulas = set(dump["spec_formulas"])
 
     if not spec_formulas:
-        audit_writer.write(
-            f"[level2-audit] {source_path}: no spec formula identified — shape rule will not match\n"
-        )
+        audit_writer.write(f"[level2-audit] {source_path}: no spec formula identified — shape rule will not match\n")
     elif len(spec_formulas) > 1:
-        audit_writer.write(
-            f"[level2-audit] {source_path}: multiple spec formulas: {sorted(spec_formulas)}\n"
-        )
-    elif 'Spec' not in spec_formulas:
+        audit_writer.write(f"[level2-audit] {source_path}: multiple spec formulas: {sorted(spec_formulas)}\n")
+    elif "Spec" not in spec_formulas:
         only = next(iter(spec_formulas))
-        audit_writer.write(
-            f"[level2-audit] {source_path}: identified spec formula `{only}` — name != `Spec`\n"
-        )
+        audit_writer.write(f"[level2-audit] {source_path}: identified spec formula `{only}` — name != `Spec`\n")
 
-    for t in dump['theorems']:
-        t['_keyword'] = determine_keyword(source_lines, t['loc']['line_start'])
+    for t in dump["theorems"]:
+        t["_keyword"] = determine_keyword(source_lines, t["loc"]["line_start"])
 
-    theorem_candidates = [t for t in dump['theorems'] if t['_keyword'] == 'THEOREM']
+    theorem_candidates = [t for t in dump["theorems"] if t["_keyword"] == "THEOREM"]
     top_level = find_top_level(theorem_candidates, spec_formulas)
 
     # Filter A — require a manual TLAPS proof in the source.
@@ -776,23 +769,25 @@ def process_file(source_path, audit_writer, output_root, module_subdir=None,
     survivors = []
     for entry in top_level:
         target_thm = entry[0]
-        line = target_thm['loc']['line_start']
-        name = target_thm['name'] or f"<unnamed L{line}>"
+        line = target_thm["loc"]["line_start"]
+        name = target_thm["name"] or f"<unnamed L{line}>"
         has_proof = _has_manual_proof(target_thm, source_lines)
         if not has_proof and not allow_no_proof:
             audit_writer.write(
                 f"[level2-audit] {source_path}: top-level THEOREM {name} at line "
                 f"{line} has no manual TLAPS proof body — skipped (filter A)\n"
             )
-        elif (os.path.splitext(os.path.basename(source_path))[0],
-              target_theorem_name(target_thm)[0]) in KNOWN_FALSE_TARGETS:
+        elif (
+            os.path.splitext(os.path.basename(source_path))[0],
+            target_theorem_name(target_thm)[0],
+        ) in KNOWN_FALSE_TARGETS:
             # Filter A' — drop ONLY a goal TLC has shown to be false. An OMITTED
             # sub-step that papers over a *false* claim (e.g. PaxosProof
             # StructOK3) admits no honest proof, so it must not become a
             # benchmark. See KNOWN_FALSE_TARGETS for the per-target evidence.
-            reason = KNOWN_FALSE_TARGETS[(
-                os.path.splitext(os.path.basename(source_path))[0],
-                target_theorem_name(target_thm)[0])]
+            reason = KNOWN_FALSE_TARGETS[
+                (os.path.splitext(os.path.basename(source_path))[0], target_theorem_name(target_thm)[0])
+            ]
             audit_writer.write(
                 f"[level2-audit] {source_path}: top-level THEOREM {name} at line "
                 f"{line} asserts a FALSE goal — skipped (filter A', known-false): "
@@ -833,33 +828,29 @@ def process_file(source_path, audit_writer, output_root, module_subdir=None,
         target_thm = entry[0]
         stmt = _statement_text(target_thm, source_lines)
         if stmt in seen_stmts:
-            line = target_thm['loc']['line_start']
+            line = target_thm["loc"]["line_start"]
             kept_line = seen_stmts[stmt]
-            name = target_thm['name'] or f"<unnamed L{line}>"
+            name = target_thm["name"] or f"<unnamed L{line}>"
             audit_writer.write(
                 f"[level2-audit] {source_path}: top-level THEOREM {name} at line "
                 f"{line} has identical statement text to candidate kept at line "
                 f"{kept_line} — skipped (filter B)\n"
             )
         else:
-            seen_stmts[stmt] = target_thm['loc']['line_start']
+            seen_stmts[stmt] = target_thm["loc"]["line_start"]
             deduped.append(entry)
     top_level = deduped
 
     if not top_level:
-        audit_writer.write(
-            f"[level2-audit] {source_path}: no top-level THEOREM identified — no benchmarks generated\n"
-        )
+        audit_writer.write(f"[level2-audit] {source_path}: no top-level THEOREM identified — no benchmarks generated\n")
         return 0
     if len(top_level) > 1:
         names = []
         for t, unnamed, shp, grph in top_level:
-            label = t['name'] or f"<unnamed L{t['loc']['line_start']}>"
+            label = t["name"] or f"<unnamed L{t['loc']['line_start']}>"
             tag = "[unnamed]" if unnamed else f"[shape={'Y' if shp else 'N'}/graph={'Y' if grph else 'N'}]"
             names.append(label + tag)
-        audit_writer.write(
-            f"[level2-audit] {source_path}: multiple top-level THEOREMs: {names}\n"
-        )
+        audit_writer.write(f"[level2-audit] {source_path}: multiple top-level THEOREMs: {names}\n")
 
     out_dir = os.path.join(output_root, module_subdir or module)
     os.makedirs(out_dir, exist_ok=True)
@@ -872,14 +863,15 @@ def process_file(source_path, audit_writer, output_root, module_subdir=None,
     if shared_model and module in skip_model_modules:
         audit_writer.write(
             f"[level2-audit] {source_path}: module {module} is a local dependency "
-            f"of a sibling — kept full (no shared model)\n")
+            f"of a sibling — kept full (no shared model)\n"
+        )
     if shared_model and module not in skip_model_modules:
         targets = [entry[0] for entry in top_level]
         model_set, main_specs = compute_model_set(dump, targets)
         if model_set:
             model_text = build_model(source_lines, dump, model_set)
             model_path = os.path.join(out_dir, f"{module}.tla")
-            with open(model_path, 'w', encoding='utf-8') as f:
+            with open(model_path, "w", encoding="utf-8") as f:
                 f.write(model_text)
             print(f"  generated model: {os.path.relpath(model_path, PROJECT_ROOT)}")
 
@@ -887,11 +879,11 @@ def process_file(source_path, audit_writer, output_root, module_subdir=None,
     used_names = set()
     count = 0
     for target_thm, _, _, _ in top_level:
-        if not target_thm['name']:
+        if not target_thm["name"]:
             # Not a warning: unnamed THEOREMs are top-level by construction.
             # This entry just records how the filename was derived.
-            line = target_thm['loc']['line_start']
-            rhs = target_thm['shape'].get('rhs_primary_name')
+            line = target_thm["loc"]["line_start"]
+            rhs = target_thm["shape"].get("rhs_primary_name")
             if rhs:
                 audit_writer.write(
                     f"[level2-audit] {source_path}: unnamed top-level THEOREM at line "
@@ -925,15 +917,14 @@ def process_file(source_path, audit_writer, output_root, module_subdir=None,
         reachable = compute_reachable(dump, target_thm)
         # Spec-based targets EXTEND the shared model; non-spec lemmas stay
         # self-contained (the model would over-expose context they hide).
-        is_spec = target_thm['shape'].get('lhs_spec_ref') in main_specs
+        is_spec = target_thm["shape"].get("lhs_spec_ref") in main_specs
         if shared_model and model_set and is_spec:
             bench_text = build_benchmark_extends(
-                source_lines, dump, target_thm, bench_module_name,
-                reachable, model_set, module)
+                source_lines, dump, target_thm, bench_module_name, reachable, model_set, module
+            )
         else:
-            bench_text = build_benchmark(source_lines, dump, target_thm,
-                                         bench_module_name, reachable)
-        with open(bench_file, 'w', encoding='utf-8') as f:
+            bench_text = build_benchmark(source_lines, dump, target_thm, bench_module_name, reachable)
+        with open(bench_file, "w", encoding="utf-8") as f:
             f.write(bench_text)
         copy_deps(dump, source_path, out_dir, reachable)
         count += 1
@@ -946,29 +937,35 @@ def process_file(source_path, audit_writer, output_root, module_subdir=None,
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--source-dir', default=SOURCE_ROOT,
-                        help='Directory of source .tla files (default: %(default)s)')
-    parser.add_argument('--output-dir', default=BENCHMARK_DIR,
-                        help='Output directory for benchmarks (default: %(default)s)')
-    parser.add_argument('--filter', default=None,
-                        help='Glob-ish substring to limit which source files we process')
-    parser.add_argument('files', nargs='*',
-                        help='Specific .tla files to process (overrides --source-dir scan)')
-    parser.add_argument('--shared-model', action='store_true',
-                        help='Emit one proof-free <Module>.tla model per output dir '
-                             'and have spec-based tasks EXTEND it instead of inlining '
-                             'the spec (de-duplicates the spec; grader resolves the '
-                             'co-located model automatically).')
-    parser.add_argument('--allow-no-proof', action='store_true',
-                        help='Keep top-level theorems whose source has only PROOF '
-                             'OBVIOUS/OMITTED (no reference proof). Use for vetted '
-                             'hard from-scratch benchmarks (e.g. ZooKeeper Zab) that '
-                             'are graded by tlapm, not against a human reference.')
+    parser.add_argument(
+        "--source-dir", default=SOURCE_ROOT, help="Directory of source .tla files (default: %(default)s)"
+    )
+    parser.add_argument(
+        "--output-dir", default=BENCHMARK_DIR, help="Output directory for benchmarks (default: %(default)s)"
+    )
+    parser.add_argument("--filter", default=None, help="Glob-ish substring to limit which source files we process")
+    parser.add_argument("files", nargs="*", help="Specific .tla files to process (overrides --source-dir scan)")
+    parser.add_argument(
+        "--shared-model",
+        action="store_true",
+        help="Emit one proof-free <Module>.tla model per output dir "
+        "and have spec-based tasks EXTEND it instead of inlining "
+        "the spec (de-duplicates the spec; grader resolves the "
+        "co-located model automatically).",
+    )
+    parser.add_argument(
+        "--allow-no-proof",
+        action="store_true",
+        help="Keep top-level theorems whose source has only PROOF "
+        "OBVIOUS/OMITTED (no reference proof). Use for vetted "
+        "hard from-scratch benchmarks (e.g. ZooKeeper Zab) that "
+        "are graded by tlapm, not against a human reference.",
+    )
     args = parser.parse_args()
 
     output_root = os.path.abspath(args.output_dir)
     os.makedirs(output_root, exist_ok=True)
-    audit_path = os.path.join(output_root, 'audit.log')
+    audit_path = os.path.join(output_root, "audit.log")
 
     if args.files:
         targets = [(os.path.abspath(p), None) for p in args.files]
@@ -976,16 +973,16 @@ def main():
         src_root = os.path.abspath(args.source_dir)
         targets = []
         for root, _, files in os.walk(src_root):
-            if '.tlaps' in root:
+            if ".tlaps" in root:
                 continue
             for fname in sorted(files):
-                if not fname.endswith('.tla'):
+                if not fname.endswith(".tla"):
                     continue
                 full = os.path.join(root, fname)
                 if args.filter and args.filter not in full:
                     continue
                 subdir = os.path.relpath(root, src_root).split(os.sep)[0]
-                if subdir == '.':
+                if subdir == ".":
                     subdir = os.path.splitext(fname)[0]
                 targets.append((full, subdir))
 
@@ -993,17 +990,21 @@ def main():
 
     total = 0
     generated_paths = []
-    with open(audit_path, 'w', encoding='utf-8') as audit_writer:
+    with open(audit_path, "w", encoding="utf-8") as audit_writer:
         for path, subdir in targets:
             print(f"\nProcessing {os.path.relpath(path, PROJECT_ROOT)}")
             key = subdir if subdir is not None else os.path.splitext(os.path.basename(path))[0]
             try:
-                total += process_file(path, audit_writer, output_root,
-                                      module_subdir=subdir,
-                                      generated_paths=generated_paths,
-                                      shared_model=args.shared_model,
-                                      skip_model_modules=sibling_deps.get(key, set()),
-                                      allow_no_proof=args.allow_no_proof)
+                total += process_file(
+                    path,
+                    audit_writer,
+                    output_root,
+                    module_subdir=subdir,
+                    generated_paths=generated_paths,
+                    shared_model=args.shared_model,
+                    skip_model_modules=sibling_deps.get(key, set()),
+                    allow_no_proof=args.allow_no_proof,
+                )
             except Exception as e:
                 audit_writer.write(f"[level2-audit] {path}: ERROR {e!r}\n")
                 print(f"  ERROR: {e}", file=sys.stderr)
@@ -1013,5 +1014,5 @@ def main():
     print(f"Audit log: {os.path.relpath(audit_path, PROJECT_ROOT)}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/dataset/level2/generate.py
+++ b/src/dataset/level2/generate.py
@@ -86,7 +86,11 @@ SANY_DUMP = os.path.join(PROJECT_ROOT, 'src', 'dataset', 'sany-dump', 'run.sh')
 # Reuse L1's proof-stripping logic for dependency .tla copies.
 sys.path.insert(0, os.path.join(PROJECT_ROOT, 'src', 'dataset', 'level1'))
 from generate import (  # noqa: E402
-    parse_theorems, strip_all_proofs, parse_extends, parse_instances, STDLIB_MODULES,
+    STDLIB_MODULES,
+    parse_extends,
+    parse_instances,
+    parse_theorems,
+    strip_all_proofs,
 )
 
 KEYWORD_PATTERN = re.compile(r'^\s*(THEOREM|LEMMA|AXIOM|COROLLARY|PROPOSITION)\b')

--- a/src/dataset/level2/generate.py
+++ b/src/dataset/level2/generate.py
@@ -481,7 +481,7 @@ def copy_deps(dump, source_path, out_dir, reachable):
         direct_deps.append(mod)
 
     copied = []
-    for mod, dep_path in _gather_local_deps(direct_deps, src_dir):
+    for _mod, dep_path in _gather_local_deps(direct_deps, src_dir):
         with open(dep_path, encoding='utf-8') as f:
             dep_text = f.read()
         dep_lines = dep_text.split('\n')
@@ -711,7 +711,8 @@ def compute_sibling_deps(targets):
         deps = set()
         for p in paths:
             try:
-                content = open(p, encoding='utf-8').read()
+                with open(p, encoding="utf-8") as _f:
+                    content = _f.read()
             except OSError:
                 continue
             self_stem = os.path.splitext(os.path.basename(p))[0]

--- a/src/dataset/level2/generate.py
+++ b/src/dataset/level2/generate.py
@@ -178,10 +178,7 @@ def _statement_text(target_thm, source_lines):
     """
     loc = target_thm['loc']
     ploc = target_thm.get('proof_loc')
-    if ploc and ploc.get('line_start', -1) > 0:
-        end_line = ploc['line_start'] - 1
-    else:
-        end_line = loc['line_end']
+    end_line = ploc['line_start'] - 1 if ploc and ploc.get('line_start', -1) > 0 else loc['line_end']
     return ''.join(source_lines[loc['line_start'] - 1 : end_line]).strip()
 
 
@@ -857,10 +854,7 @@ def process_file(source_path, audit_writer, output_root, module_subdir=None,
         names = []
         for t, unnamed, shp, grph in top_level:
             label = t['name'] or f"<unnamed L{t['loc']['line_start']}>"
-            if unnamed:
-                tag = "[unnamed]"
-            else:
-                tag = f"[shape={'Y' if shp else 'N'}/graph={'Y' if grph else 'N'}]"
+            tag = "[unnamed]" if unnamed else f"[shape={'Y' if shp else 'N'}/graph={'Y' if grph else 'N'}]"
             names.append(label + tag)
         audit_writer.write(
             f"[level2-audit] {source_path}: multiple top-level THEOREMs: {names}\n"

--- a/src/evaluator/backends/__init__.py
+++ b/src/evaluator/backends/__init__.py
@@ -3,8 +3,8 @@
 from typing import Optional
 
 from .base import AgentBackend
-from .codex import CodexBackend
 from .claude_code import ClaudeCodeBackend
+from .codex import CodexBackend
 from .copilot import CopilotBackend
 
 _REGISTRY = {
@@ -14,7 +14,7 @@ _REGISTRY = {
 }
 
 
-def get_backend(name: str, model: Optional[str] = None) -> AgentBackend:
+def get_backend(name: str, model: str | None = None) -> AgentBackend:
     if name not in _REGISTRY:
         raise ValueError(f"unknown backend {name!r}; available: {sorted(_REGISTRY)}")
     return _REGISTRY[name](model=model)

--- a/src/evaluator/backends/__init__.py
+++ b/src/evaluator/backends/__init__.py
@@ -1,7 +1,5 @@
 """Agent backend registry."""
 
-from typing import Optional
-
 from .base import AgentBackend
 from .claude_code import ClaudeCodeBackend
 from .codex import CodexBackend

--- a/src/evaluator/backends/base.py
+++ b/src/evaluator/backends/base.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional, Tuple
 
 
 class AgentBackend(ABC):
@@ -22,10 +21,10 @@ class AgentBackend(ABC):
         """
 
     @abstractmethod
-    def parse_output(self, jsonl_path: str) -> Tuple[str, int, int]:
+    def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         """Parse the backend's stdout dump into (transcript, input_tokens, output_tokens)."""
 
-    def check_auth(self) -> Optional[str]:
+    def check_auth(self) -> str | None:
         """Verify the agent CLI can authenticate.
 
         Returns None if auth looks OK, or a human-readable error string that

--- a/src/evaluator/backends/claude_code.py
+++ b/src/evaluator/backends/claude_code.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-from typing import Optional, Tuple
 
 from .base import AgentBackend
-
 
 DEFAULT_MODEL = "claude-opus-4-7"
 
@@ -16,7 +14,7 @@ DEFAULT_MODEL = "claude-opus-4-7"
 class ClaudeCodeBackend(AgentBackend):
     name = "claude_code"
 
-    def __init__(self, model: Optional[str] = None):
+    def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL
 
     def build_command(self, workspace: str, result_dir: str) -> list[str]:
@@ -39,7 +37,7 @@ class ClaudeCodeBackend(AgentBackend):
             "--model", self.model,
         ]
 
-    def check_auth(self) -> Optional[str]:
+    def check_auth(self) -> str | None:
         # Fast path: env var present.
         if os.environ.get("ANTHROPIC_API_KEY"):
             return None
@@ -69,7 +67,7 @@ class ClaudeCodeBackend(AgentBackend):
     def firewall_hosts(self) -> list[str]:
         return ["api.anthropic.com"]
 
-    def parse_output(self, jsonl_path: str) -> Tuple[str, int, int]:
+    def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         lines: list[str] = []
         in_tok = 0
         out_tok = 0
@@ -77,7 +75,7 @@ class ClaudeCodeBackend(AgentBackend):
         final_out = None
 
         try:
-            with open(jsonl_path, "r") as f:
+            with open(jsonl_path) as f:
                 for raw in f:
                     raw = raw.strip()
                     if not raw:

--- a/src/evaluator/backends/claude_code.py
+++ b/src/evaluator/backends/claude_code.py
@@ -31,10 +31,13 @@ class ClaudeCodeBackend(AgentBackend):
             "--print",
             "--dangerously-skip-permissions",
             "--no-session-persistence",
-            "--output-format", "stream-json",
+            "--output-format",
+            "stream-json",
             "--verbose",
-            "--effort", "max",
-            "--model", self.model,
+            "--effort",
+            "max",
+            "--model",
+            self.model,
         ]
 
     def check_auth(self) -> str | None:
@@ -47,9 +50,10 @@ class ClaudeCodeBackend(AgentBackend):
         # checks can't see.
         try:
             r = subprocess.run(
-                ["claude", "--print", "--no-session-persistence",
-                 "--output-format", "text", "ok"],
-                capture_output=True, text=True, timeout=30,
+                ["claude", "--print", "--no-session-persistence", "--output-format", "text", "ok"],
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             if r.returncode == 0:
                 return None
@@ -130,15 +134,12 @@ class ClaudeCodeBackend(AgentBackend):
                                     result_content = block.get("content", "")
                                     if isinstance(result_content, list):
                                         result_content = "\n".join(
-                                            c.get("text", "") if isinstance(c, dict) else str(c)
-                                            for c in result_content
+                                            c.get("text", "") if isinstance(c, dict) else str(c) for c in result_content
                                         )
                                     result_content = str(result_content)
                                     if len(result_content) > 3000:
                                         result_content = (
-                                            result_content[:1500]
-                                            + "\n... (truncated) ...\n"
-                                            + result_content[-1500:]
+                                            result_content[:1500] + "\n... (truncated) ...\n" + result_content[-1500:]
                                         )
                                     lines.append(f"[TOOL_RESULT] {result_content.rstrip()}")
                                     lines.append("")

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -20,12 +20,17 @@ class CodexBackend(AgentBackend):
     def build_command(self, workspace: str, result_dir: str) -> list[str]:
         last_msg_path = os.path.join(result_dir, "codex_last_message.txt")
         return [
-            "npx", "codex", "exec",
+            "npx",
+            "codex",
+            "exec",
             "--dangerously-bypass-approvals-and-sandbox",
-            "-C", workspace,
-            "-m", self.model,
+            "-C",
+            workspace,
+            "-m",
+            self.model,
             "--json",
-            "-o", last_msg_path,
+            "-o",
+            last_msg_path,
         ]
 
     def check_auth(self) -> str | None:
@@ -37,7 +42,9 @@ class CodexBackend(AgentBackend):
         try:
             r = subprocess.run(
                 ["codex", "login", "status"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             if r.returncode == 0 and "Logged in" in (r.stdout + r.stderr):
                 return None
@@ -45,8 +52,7 @@ class CodexBackend(AgentBackend):
             return "codex: `codex` CLI not found on PATH"
         except Exception:
             pass
-        return ("codex: no auth detected. Set OPENAI_API_KEY or "
-                "AZURE_OPENAI_API_KEY, or run `codex login`.")
+        return "codex: no auth detected. Set OPENAI_API_KEY or AZURE_OPENAI_API_KEY, or run `codex login`."
 
     def firewall_hosts(self) -> list[str]:
         return ["api.openai.com"]

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-from typing import Optional, Tuple
 
 from .base import AgentBackend
-
 
 DEFAULT_MODEL = "gpt-5.5"
 
@@ -16,7 +14,7 @@ DEFAULT_MODEL = "gpt-5.5"
 class CodexBackend(AgentBackend):
     name = "codex"
 
-    def __init__(self, model: Optional[str] = None):
+    def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL
 
     def build_command(self, workspace: str, result_dir: str) -> list[str]:
@@ -30,7 +28,7 @@ class CodexBackend(AgentBackend):
             "-o", last_msg_path,
         ]
 
-    def check_auth(self) -> Optional[str]:
+    def check_auth(self) -> str | None:
         # Fast paths: an env var is set (direct OpenAI or Azure routing).
         if os.environ.get("OPENAI_API_KEY") or os.environ.get("AZURE_OPENAI_API_KEY"):
             return None
@@ -53,13 +51,13 @@ class CodexBackend(AgentBackend):
     def firewall_hosts(self) -> list[str]:
         return ["api.openai.com"]
 
-    def parse_output(self, jsonl_path: str) -> Tuple[str, int, int]:
+    def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         lines: list[str] = []
         in_tok = 0
         out_tok = 0
 
         try:
-            with open(jsonl_path, "r") as f:
+            with open(jsonl_path) as f:
                 for raw in f:
                     raw = raw.strip()
                     if not raw:

--- a/src/evaluator/backends/copilot.py
+++ b/src/evaluator/backends/copilot.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-from typing import Optional, Tuple
 
 from .base import AgentBackend
-
 
 DEFAULT_MODEL = "claude-opus-4.8"
 
@@ -16,7 +14,7 @@ DEFAULT_MODEL = "claude-opus-4.8"
 class CopilotBackend(AgentBackend):
     name = "copilot"
 
-    def __init__(self, model: Optional[str] = None):
+    def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL
 
     def build_command(self, workspace: str, result_dir: str) -> list[str]:
@@ -49,7 +47,7 @@ class CopilotBackend(AgentBackend):
             "--no-auto-update",
         ]
 
-    def check_auth(self) -> Optional[str]:
+    def check_auth(self) -> str | None:
         # Fast path: a token env var is set (headless auth).
         # Checked by the CLI in this order: COPILOT_GITHUB_TOKEN, GH_TOKEN,
         # GITHUB_TOKEN.
@@ -91,7 +89,7 @@ class CopilotBackend(AgentBackend):
             "api.enterprise.githubcopilot.com",  # enterprise
         ]
 
-    def parse_output(self, jsonl_path: str) -> Tuple[str, int, int]:
+    def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         lines: list[str] = []
         in_tok = 0
         out_tok = 0
@@ -99,7 +97,7 @@ class CopilotBackend(AgentBackend):
         tool_names: dict[str, str] = {}
 
         try:
-            with open(jsonl_path, "r") as f:
+            with open(jsonl_path) as f:
                 for raw in f:
                     raw = raw.strip()
                     if not raw:

--- a/src/evaluator/backends/copilot.py
+++ b/src/evaluator/backends/copilot.py
@@ -36,11 +36,16 @@ class CopilotBackend(AgentBackend):
         return [
             "copilot",
             "--allow-all",
-            "-C", workspace,
-            "--output-format", "json",
-            "--model", self.model,
-            "--effort", "max",
-            "--log-level", "none",
+            "-C",
+            workspace,
+            "--output-format",
+            "json",
+            "--model",
+            self.model,
+            "--effort",
+            "max",
+            "--log-level",
+            "none",
             "--no-color",
             "--disable-builtin-mcps",
             "--no-custom-instructions",
@@ -51,19 +56,27 @@ class CopilotBackend(AgentBackend):
         # Fast path: a token env var is set (headless auth).
         # Checked by the CLI in this order: COPILOT_GITHUB_TOKEN, GH_TOKEN,
         # GITHUB_TOKEN.
-        if (os.environ.get("COPILOT_GITHUB_TOKEN")
-                or os.environ.get("GH_TOKEN")
-                or os.environ.get("GITHUB_TOKEN")):
+        if os.environ.get("COPILOT_GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"):
             return None
         # Slow path: probe the CLI with a trivial prompt. This covers OAuth
         # (`copilot login`) / credential-store auth that env-var checks can't
         # see. --disable-builtin-mcps keeps the probe fast and offline-safe.
         try:
             r = subprocess.run(
-                ["copilot", "--allow-all", "--disable-builtin-mcps",
-                 "--no-color", "--no-auto-update",
-                 "--output-format", "text", "-p", "ok"],
-                capture_output=True, text=True, timeout=60,
+                [
+                    "copilot",
+                    "--allow-all",
+                    "--disable-builtin-mcps",
+                    "--no-color",
+                    "--no-auto-update",
+                    "--output-format",
+                    "text",
+                    "-p",
+                    "ok",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
             )
             if r.returncode == 0:
                 return None
@@ -84,8 +97,8 @@ class CopilotBackend(AgentBackend):
         # host varies by plan, so allow all three; --no-auto-update means the
         # CLI never needs api.github.com for a release check.
         return [
-            "api.githubcopilot.com",            # individual / pro
-            "api.business.githubcopilot.com",   # business
+            "api.githubcopilot.com",  # individual / pro
+            "api.business.githubcopilot.com",  # business
             "api.enterprise.githubcopilot.com",  # enterprise
         ]
 

--- a/src/evaluator/levels/base.py
+++ b/src/evaluator/levels/base.py
@@ -21,8 +21,7 @@ from abc import ABC
 # A top-level proof goal — `THEOREM`/`LEMMA`/`COROLLARY`/`PROPOSITION` at the
 # start of a logical line (optionally named). This is what makes a file a
 # benchmark to be proved, as opposed to a shared model / dependency layer.
-_TOP_LEVEL_GOAL = re.compile(r'^[ \t]*(THEOREM|LEMMA|COROLLARY|PROPOSITION)\b',
-                             re.MULTILINE)
+_TOP_LEVEL_GOAL = re.compile(r"^[ \t]*(THEOREM|LEMMA|COROLLARY|PROPOSITION)\b", re.MULTILINE)
 
 
 class Level(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; subclasses set class attrs
@@ -63,7 +62,7 @@ class Level(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; su
         BOTH so the model file is treated as a dependency, not run as a task.
         """
         name = os.path.splitext(os.path.basename(path))[0]
-        if '_' not in name:
+        if "_" not in name:
             return False
         try:
             with open(path) as f:
@@ -73,19 +72,17 @@ class Level(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; su
         return _TOP_LEVEL_GOAL.search(text) is not None
 
     def get_benchmark_files(self, filter_pattern: str | None = None) -> list[str]:
-        files = sorted(
-            glob.glob(os.path.join(self.benchmark_dir(), '**', '*.tla'), recursive=True)
-        )
+        files = sorted(glob.glob(os.path.join(self.benchmark_dir(), "**", "*.tla"), recursive=True))
         files = [f for f in files if self.is_benchmark_file(f)]
         if filter_pattern:
-            patterns = [p.strip() for p in filter_pattern.split(',')]
+            patterns = [p.strip() for p in filter_pattern.split(",")]
             files = [f for f in files if any(p in f for p in patterns)]
         return files
 
     def get_dependencies(self, benchmark_path: str) -> list[str]:
         bench_dir = os.path.dirname(benchmark_path)
         deps = []
-        for f in glob.glob(os.path.join(bench_dir, '*.tla')):
+        for f in glob.glob(os.path.join(bench_dir, "*.tla")):
             if os.path.abspath(f) == os.path.abspath(benchmark_path):
                 continue
             if not self.is_benchmark_file(f):
@@ -95,9 +92,9 @@ class Level(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; su
     def prompt_template_path(self) -> str:
         prompts_dir = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            'prompts',
+            "prompts",
         )
-        return os.path.join(prompts_dir, f'{self.name}.txt')
+        return os.path.join(prompts_dir, f"{self.name}.txt")
 
     def build_prompt(self, benchmark_basename: str, tlapm_path: str, tlapm_lib: str) -> str:
         with open(self.prompt_template_path()) as f:
@@ -108,19 +105,22 @@ class Level(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; su
             tlapm_lib=tlapm_lib,
         )
 
-    def checker_command(self, workspace: str, benchmark_basename: str,
-                        output_path: str, timeout: int,
-                        benchmark_dir: str | None = None) -> list[str]:
+    def checker_command(
+        self, workspace: str, benchmark_basename: str, output_path: str, timeout: int, benchmark_dir: str | None = None
+    ) -> list[str]:
         cmd = [
             self._checker_binary,
             os.path.join(workspace, benchmark_basename),
-            '--level', str(self.level_number),
-            '--output', output_path,
-            '--timeout', str(timeout),
+            "--level",
+            str(self.level_number),
+            "--output",
+            output_path,
+            "--timeout",
+            str(timeout),
         ]
         # Grading passes the canonical read-only module dir so the semantic
         # engine's provenance is tamper-proof (the agent's own self-check falls
         # back to git-root reconstruction inside its workspace).
         if benchmark_dir:
-            cmd += ['--benchmark-dir', benchmark_dir]
+            cmd += ["--benchmark-dir", benchmark_dir]
         return cmd

--- a/src/evaluator/levels/base.py
+++ b/src/evaluator/levels/base.py
@@ -17,8 +17,6 @@ import glob
 import os
 import re
 from abc import ABC
-from typing import Optional
-
 
 # A top-level proof goal — `THEOREM`/`LEMMA`/`COROLLARY`/`PROPOSITION` at the
 # start of a logical line (optionally named). This is what makes a file a
@@ -68,13 +66,13 @@ class Level(ABC):
         if '_' not in name:
             return False
         try:
-            with open(path, 'r') as f:
+            with open(path) as f:
                 text = f.read()
         except OSError:
             return False
         return _TOP_LEVEL_GOAL.search(text) is not None
 
-    def get_benchmark_files(self, filter_pattern: Optional[str] = None) -> list[str]:
+    def get_benchmark_files(self, filter_pattern: str | None = None) -> list[str]:
         files = sorted(
             glob.glob(os.path.join(self.benchmark_dir(), '**', '*.tla'), recursive=True)
         )
@@ -102,7 +100,7 @@ class Level(ABC):
         return os.path.join(prompts_dir, f'{self.name}.txt')
 
     def build_prompt(self, benchmark_basename: str, tlapm_path: str, tlapm_lib: str) -> str:
-        with open(self.prompt_template_path(), 'r') as f:
+        with open(self.prompt_template_path()) as f:
             template = f.read()
         return template.format(
             benchmark_basename=benchmark_basename,

--- a/src/evaluator/levels/base.py
+++ b/src/evaluator/levels/base.py
@@ -25,7 +25,7 @@ _TOP_LEVEL_GOAL = re.compile(r'^[ \t]*(THEOREM|LEMMA|COROLLARY|PROPOSITION)\b',
                              re.MULTILINE)
 
 
-class Level(ABC):
+class Level(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; subclasses set class attrs
     name: str = ""
     level_number: int = 0
     description: str = ""

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -14,22 +14,21 @@ Usage:
                       [--timeout SECS] [--check-timeout SECS] [--output-dir DIR]
 """
 
-import os
-import sys
-import re
+import argparse
 import glob
 import json
+import os
+import re
 import shlex
 import shutil
 import signal
 import subprocess
-import argparse
+import sys
 import tempfile
-import time
 import threading
+import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Optional
 
 # Allow `python3 src/evaluator/runner.py` as well as module import.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -70,7 +69,7 @@ def ensure_tlapm():
     print("Done.")
 
 
-def find_tlapm_lib(tlapm_path: str) -> Optional[str]:
+def find_tlapm_lib(tlapm_path: str) -> str | None:
     """Derive lib path from tlapm binary path. Supports 1.5 and 1.6 layouts."""
     base = os.path.dirname(os.path.dirname(tlapm_path))
     for sub in ['lib/tlapm/stdlib', 'lib/tlaps', 'lib/tlapm', 'lib']:
@@ -80,7 +79,7 @@ def find_tlapm_lib(tlapm_path: str) -> Optional[str]:
     return None
 
 
-def fetch_usage(usage_script: str) -> Optional[dict]:
+def fetch_usage(usage_script: str) -> dict | None:
     """Return the parsed OAuth usage JSON, or None if unavailable.
 
     Fails open (returns None) on any error — missing script, API-key-only auth
@@ -251,7 +250,7 @@ def kill_agent_tree(proc, workspace: str):
             pass
 
 
-def _mem_available_gb() -> Optional[float]:
+def _mem_available_gb() -> float | None:
     """MemAvailable in GiB from /proc/meminfo, or None if unreadable."""
     try:
         with open('/proc/meminfo') as f:
@@ -303,7 +302,7 @@ class WorkItem:
     tlapm_path: str
     tlapm_lib: str
     # Quota gate (Claude Max subscription). usage_script=None disables it.
-    usage_script: Optional[str] = None
+    usage_script: str | None = None
     quota_5h: float = 0
     quota_7d: float = 0
     quota_max_waits: int = 0
@@ -646,7 +645,7 @@ def main():
     benchmark_root, checker_binary = resolve_paths()
     if not os.path.isfile(checker_binary):
         print(f"ERROR: checker binary not found at {checker_binary}")
-        print(f"       run `make` at the repo root to build it.")
+        print("       run `make` at the repo root to build it.")
         sys.exit(1)
     level = get_level(args.level, benchmark_root, checker_binary)
 
@@ -681,8 +680,8 @@ def main():
                 print(f"Quota:   gate ON — now 5h={u5}% (limit {args.quota_5h}%), "
                       f"7d={u7}% (limit {args.quota_7d}%), max-waits={args.quota_max_waits}")
             else:
-                print(f"Quota:   gate OFF — usage endpoint unavailable "
-                      f"(API-key auth or no OAuth token at ~/.claude/.credentials.json)")
+                print("Quota:   gate OFF — usage endpoint unavailable "
+                      "(API-key auth or no OAuth token at ~/.claude/.credentials.json)")
         elif args.usage_script:
             print(f"Quota:   gate OFF — usage script not found at {candidate}")
 

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -39,7 +39,7 @@ from levels import get_level, list_levels  # noqa: E402
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # File at <repo>/src/evaluator/runner.py — ascend two levels for repo root.
-REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, '..', '..'))
+REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
 
 
 def resolve_paths():
@@ -48,19 +48,19 @@ def resolve_paths():
     Docker: /benchmark + /usr/local/bin/check_proof_bin (set by docker-compose).
     Host:   <repo>/benchmark + <repo>/check_proof_bin.
     """
-    if os.path.isdir('/benchmark'):
-        return '/benchmark', '/usr/local/bin/check_proof_bin'
-    return os.path.join(REPO_ROOT, 'benchmark'), os.path.join(REPO_ROOT, 'check_proof_bin')
+    if os.path.isdir("/benchmark"):
+        return "/benchmark", "/usr/local/bin/check_proof_bin"
+    return os.path.join(REPO_ROOT, "benchmark"), os.path.join(REPO_ROOT, "check_proof_bin")
 
 
 # Persistent tlapm location — /opt/tlapm in docker, ~/.tlapm on host.
-TLAPM_PERSISTENT = '/opt/tlapm' if os.path.isdir('/opt/tlapm') else os.path.expanduser('~/.tlapm')
-TLAPM_SOURCE = '/tmp/tlapm'
+TLAPM_PERSISTENT = "/opt/tlapm" if os.path.isdir("/opt/tlapm") else os.path.expanduser("~/.tlapm")
+TLAPM_SOURCE = "/tmp/tlapm"
 
 
 def ensure_tlapm():
     """Ensure tlapm is available at TLAPM_PERSISTENT (host-only fallback)."""
-    if os.path.isfile(os.path.join(TLAPM_PERSISTENT, 'bin', 'tlapm')):
+    if os.path.isfile(os.path.join(TLAPM_PERSISTENT, "bin", "tlapm")):
         print(f"tlapm at {TLAPM_PERSISTENT}")
         return
     if not os.path.isdir(TLAPM_SOURCE):
@@ -74,7 +74,7 @@ def ensure_tlapm():
 def find_tlapm_lib(tlapm_path: str) -> str | None:
     """Derive lib path from tlapm binary path. Supports 1.5 and 1.6 layouts."""
     base = os.path.dirname(os.path.dirname(tlapm_path))
-    for sub in ['lib/tlapm/stdlib', 'lib/tlaps', 'lib/tlapm', 'lib']:
+    for sub in ["lib/tlapm/stdlib", "lib/tlaps", "lib/tlapm", "lib"]:
         path = os.path.join(base, sub)
         if os.path.isdir(path):
             return path
@@ -92,8 +92,7 @@ def fetch_usage(usage_script: str) -> dict | None:
     if not usage_script or not os.path.isfile(usage_script):
         return None
     try:
-        r = subprocess.run(['bash', usage_script], capture_output=True,
-                            text=True, timeout=30)
+        r = subprocess.run(["bash", usage_script], capture_output=True, text=True, timeout=30)
     except Exception:
         return None
     if r.returncode != 0 or not r.stdout.strip():
@@ -109,14 +108,14 @@ def _usage_over(usage: dict, quota_5h: float, quota_7d: float):
     any window over its limit. A limit <= 0 disables that window's check."""
     over = []
     resets = []
-    for key, limit in (('five_hour', quota_5h), ('seven_day', quota_7d)):
+    for key, limit in (("five_hour", quota_5h), ("seven_day", quota_7d)):
         if limit <= 0:
             continue
         obj = usage.get(key) or {}
-        util = obj.get('utilization') or 0
+        util = obj.get("utilization") or 0
         if util > limit:
             over.append(f"{key}={util}% (limit {limit}%)")
-            ra = obj.get('resets_at')
+            ra = obj.get("resets_at")
             if ra:
                 resets.append(ra)
     earliest = sorted(resets)[0] if resets else None
@@ -133,6 +132,7 @@ def _secs_until(resets_at: str) -> int:
     """
     try:
         from datetime import datetime
+
         dt = datetime.fromisoformat(resets_at)
         secs = int(dt.timestamp() - time.time()) + 120
         return min(max(secs, 60), 3600)
@@ -160,14 +160,19 @@ def wait_for_quota(item: "WorkItem", log_prefix: str = "") -> bool:
             return True
         waits += 1
         if waits > item.quota_max_waits:
-            print(f"{log_prefix}quota over after {item.quota_max_waits} waits "
-                  f"({', '.join(over)}); aborting this benchmark", flush=True)
+            print(
+                f"{log_prefix}quota over after {item.quota_max_waits} waits "
+                f"({', '.join(over)}); aborting this benchmark",
+                flush=True,
+            )
             return False
         sleep_secs = _secs_until(reset_at) if reset_at else 600
         when = reset_at or f"+{sleep_secs}s"
-        print(f"{log_prefix}quota over: {', '.join(over)} — sleeping "
-              f"{sleep_secs}s until {when} (wait {waits}/{item.quota_max_waits})",
-              flush=True)
+        print(
+            f"{log_prefix}quota over: {', '.join(over)} — sleeping "
+            f"{sleep_secs}s until {when} (wait {waits}/{item.quota_max_waits})",
+            flush=True,
+        )
         time.sleep(sleep_secs)
 
 
@@ -175,18 +180,18 @@ def _proc_descendants(root_pid: int) -> list:
     """All live descendant PIDs of root_pid, via a /proc ppid walk."""
     children: dict = {}
     try:
-        entries = os.listdir('/proc')
+        entries = os.listdir("/proc")
     except OSError:
         return []
     for entry in entries:
         if not entry.isdigit():
             continue
         try:
-            with open(f'/proc/{entry}/stat', 'rb') as f:
-                data = f.read().decode('latin1')
+            with open(f"/proc/{entry}/stat", "rb") as f:
+                data = f.read().decode("latin1")
             # comm (field 2) is parenthesised and may contain spaces; ppid is
             # the 2nd field after the closing ')'.
-            ppid = int(data[data.rindex(')') + 2:].split()[1])
+            ppid = int(data[data.rindex(")") + 2 :].split()[1])
         except (OSError, ValueError, IndexError):
             continue
         children.setdefault(ppid, []).append(int(entry))
@@ -204,14 +209,14 @@ def _procs_with_cwd_under(path: str) -> list:
     base = os.path.realpath(path)
     out = []
     try:
-        entries = os.listdir('/proc')
+        entries = os.listdir("/proc")
     except OSError:
         return out
     for entry in entries:
         if not entry.isdigit():
             continue
         try:
-            cwd = os.readlink(f'/proc/{entry}/cwd')
+            cwd = os.readlink(f"/proc/{entry}/cwd")
         except OSError:
             continue
         if cwd == base or cwd.startswith(base + os.sep):
@@ -247,9 +252,9 @@ def kill_agent_tree(proc, workspace: str):
 def _mem_available_gb() -> float | None:
     """MemAvailable in GiB from /proc/meminfo, or None if unreadable."""
     try:
-        with open('/proc/meminfo') as f:
+        with open("/proc/meminfo") as f:
             for line in f:
-                if line.startswith('MemAvailable:'):
+                if line.startswith("MemAvailable:"):
                     return int(line.split()[1]) / 1024 / 1024
     except OSError:
         pass
@@ -273,11 +278,17 @@ def wait_for_memory(min_free_gb: float, max_waits: int, log_prefix: str = "") ->
             return True
         waits += 1
         if waits > max_waits:
-            print(f"{log_prefix}low memory ({avail:.0f}GB < {min_free_gb:.0f}GB) "
-                  f"after {max_waits} waits — launching anyway", flush=True)
+            print(
+                f"{log_prefix}low memory ({avail:.0f}GB < {min_free_gb:.0f}GB) "
+                f"after {max_waits} waits — launching anyway",
+                flush=True,
+            )
             return True
-        print(f"{log_prefix}waiting for memory: {avail:.0f}GB free < "
-              f"{min_free_gb:.0f}GB needed (wait {waits}/{max_waits})", flush=True)
+        print(
+            f"{log_prefix}waiting for memory: {avail:.0f}GB free < "
+            f"{min_free_gb:.0f}GB needed (wait {waits}/{max_waits})",
+            flush=True,
+        )
         time.sleep(60)
 
 
@@ -287,6 +298,7 @@ _summary_lock = threading.Lock()
 @dataclass
 class WorkItem:
     """A single (benchmark, backend, level) task fed to the worker pool."""
+
     benchmark_path: str
     output_dir: str
     timeout: int
@@ -311,11 +323,11 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, level_na
         total = len(results)
         verdicts = {}
         for r in results:
-            v = r['check_verdict']
+            v = r["check_verdict"]
             verdicts[v] = verdicts.get(v, 0) + 1
 
-        total_input = sum(r.get('input_tokens', 0) for r in results)
-        total_output = sum(r.get('output_tokens', 0) for r in results)
+        total_input = sum(r.get("input_tokens", 0) for r in results)
+        total_output = sum(r.get("output_tokens", 0) for r in results)
 
         lines = []
         lines.append(f"# {backend_name} on {level_name}\n")
@@ -326,35 +338,39 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, level_na
         lines.append("## Summary\n")
         lines.append("| Verdict | Count |")
         lines.append("|---------|-------|")
-        for v in ['PASS', 'FAIL', 'CHEATING', 'TIMEOUT', 'ERROR']:
+        for v in ["PASS", "FAIL", "CHEATING", "TIMEOUT", "ERROR"]:
             count = verdicts.get(v, 0)
             if count > 0:
-                icon = {'PASS': '✅', 'FAIL': '❌', 'CHEATING': '⚠️', 'TIMEOUT': '⏱️', 'ERROR': '💥'}[v]
+                icon = {"PASS": "✅", "FAIL": "❌", "CHEATING": "⚠️", "TIMEOUT": "⏱️", "ERROR": "💥"}[v]
                 lines.append(f"| {icon} {v} | {count} |")
         lines.append("")
 
         lines.append("## Details\n")
         lines.append("| Benchmark | Verdict | Time | Obligations | Tokens (in/out) | Notes |")
         lines.append("|-----------|---------|------|-------------|-----------------|-------|")
-        for r in sorted(results, key=lambda x: x['benchmark']):
-            icon = {'PASS': '✅', 'FAIL': '❌', 'CHEATING': '⚠️', 'TIMEOUT': '⏱️', 'ERROR': '💥'}.get(r['check_verdict'], '❓')
-            notes = r.get('error', '')
+        for r in sorted(results, key=lambda x: x["benchmark"]):
+            icon = {"PASS": "✅", "FAIL": "❌", "CHEATING": "⚠️", "TIMEOUT": "⏱️", "ERROR": "💥"}.get(
+                r["check_verdict"], "❓"
+            )
+            notes = r.get("error", "")
             tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
-            if 'obligations' in r:
-                obs = str(r['obligations'])
-            elif 'obligations_failed' in r:
+            if "obligations" in r:
+                obs = str(r["obligations"])
+            elif "obligations_failed" in r:
                 obs = f"{r['obligations_failed']}/{r['obligations_total']} failed"
             else:
-                obs = ''
-            lines.append(f"| `{r['benchmark']}` | {icon} {r['check_verdict']} | {r['time_secs']:.0f}s | {obs} | {tokens} | {notes} |")
+                obs = ""
+            lines.append(
+                f"| `{r['benchmark']}` | {icon} {r['check_verdict']} | {r['time_secs']:.0f}s | {obs} | {tokens} | {notes} |"
+            )
         lines.append("")
 
-        report = '\n'.join(lines)
-        report_path = os.path.join(output_dir, 'summary.md')
-        with open(report_path, 'w') as f:
+        report = "\n".join(lines)
+        report_path = os.path.join(output_dir, "summary.md")
+        with open(report_path, "w") as f:
             f.write(report)
 
-        with open(os.path.join(output_dir, 'results.json'), 'w') as f:
+        with open(os.path.join(output_dir, "results.json"), "w") as f:
             json.dump(results, f, indent=2)
 
 
@@ -372,15 +388,15 @@ def run_single_benchmark(item: WorkItem):
     os.makedirs(result_dir, exist_ok=True)
 
     result = {
-        'benchmark': rel_path,
-        'module': module_dir,
-        'theorem': name_no_ext,
-        'backend': backend.name,
-        'level': level.name,
-        'agent_exit': -1,
-        'check_verdict': 'ERROR',
-        'time_secs': 0,
-        'error': '',
+        "benchmark": rel_path,
+        "module": module_dir,
+        "theorem": name_no_ext,
+        "backend": backend.name,
+        "level": level.name,
+        "agent_exit": -1,
+        "check_verdict": "ERROR",
+        "time_secs": 0,
+        "error": "",
     }
 
     # Quota gate: pause before doing any work if the Claude Max subscription
@@ -389,13 +405,13 @@ def run_single_benchmark(item: WorkItem):
     # No-op when gating is disabled or usage can't be measured (codex / API-key
     # auth / docker), in which case it returns True immediately.
     if not wait_for_quota(item, log_prefix=f"[{name_no_ext}] "):
-        result['agent_exit'] = -3
-        result['error'] = 'quota exceeded (max waits reached); skipped'
-        result['input_tokens'] = 0
-        result['output_tokens'] = 0
+        result["agent_exit"] = -3
+        result["error"] = "quota exceeded (max waits reached); skipped"
+        result["input_tokens"] = 0
+        result["output_tokens"] = 0
         return result
 
-    workspace = tempfile.mkdtemp(prefix=f'{backend.name}_bench_{name_no_ext}_')
+    workspace = tempfile.mkdtemp(prefix=f"{backend.name}_bench_{name_no_ext}_")
     try:
         # Copy benchmark + dependencies into the isolated workspace
         shutil.copy2(item.benchmark_path, os.path.join(workspace, basename))
@@ -404,14 +420,20 @@ def run_single_benchmark(item: WorkItem):
 
         # Init git repo with original files as initial commit (the baseline
         # the cheating check compares against)
-        subprocess.run(['git', 'init'], capture_output=True, cwd=workspace)
-        subprocess.run(['git', 'add', '.'], capture_output=True, cwd=workspace)
-        subprocess.run(['git', 'commit', '-m', 'initial benchmark'],
-                       capture_output=True, cwd=workspace,
-                       env={**os.environ, 'GIT_AUTHOR_NAME': 'bench',
-                            'GIT_AUTHOR_EMAIL': 'bench@bench',
-                            'GIT_COMMITTER_NAME': 'bench',
-                            'GIT_COMMITTER_EMAIL': 'bench@bench'})
+        subprocess.run(["git", "init"], capture_output=True, cwd=workspace)
+        subprocess.run(["git", "add", "."], capture_output=True, cwd=workspace)
+        subprocess.run(
+            ["git", "commit", "-m", "initial benchmark"],
+            capture_output=True,
+            cwd=workspace,
+            env={
+                **os.environ,
+                "GIT_AUTHOR_NAME": "bench",
+                "GIT_AUTHOR_EMAIL": "bench@bench",
+                "GIT_COMMITTER_NAME": "bench",
+                "GIT_COMMITTER_EMAIL": "bench@bench",
+            },
+        )
 
         # The cheat checker is the baked, root-owned, read-only binary on PATH
         # (/usr/local/bin/check_proof_bin in docker). It is NEVER copied into the
@@ -419,20 +441,20 @@ def run_single_benchmark(item: WorkItem):
         checker_bin = level.checker_binary_path()
 
         # Archive the original benchmark
-        shutil.copy2(item.benchmark_path, os.path.join(result_dir, 'benchmark.tla'))
+        shutil.copy2(item.benchmark_path, os.path.join(result_dir, "benchmark.tla"))
 
         # Build prompt
         prompt = level.build_prompt(basename, item.tlapm_path, item.tlapm_lib)
-        prompt_file = os.path.join(result_dir, 'prompt.txt')
-        with open(prompt_file, 'w') as f:
+        prompt_file = os.path.join(result_dir, "prompt.txt")
+        with open(prompt_file, "w") as f:
             f.write(prompt)
 
         # Run the agent
-        agent_jsonl = os.path.join(result_dir, f'{backend.name}_output.jsonl')
+        agent_jsonl = os.path.join(result_dir, f"{backend.name}_output.jsonl")
         cmd = backend.build_command(workspace, result_dir)
 
         # Source shell profile for host env vars (no-op in docker).
-        shell_cmd = 'source ~/.zshrc 2>/dev/null; source ~/.bashrc 2>/dev/null; exec ' + ' '.join(
+        shell_cmd = "source ~/.zshrc 2>/dev/null; source ~/.bashrc 2>/dev/null; exec " + " ".join(
             shlex.quote(c) for c in cmd
         )
 
@@ -443,18 +465,18 @@ def run_single_benchmark(item: WorkItem):
         start_time = time.time()
         # timeout <= 0 means no limit.
         _to = item.timeout if item.timeout and item.timeout > 0 else None
-        timed_out = {'v': False}
+        timed_out = {"v": False}
         proc = None
         # Make `check_proof_bin` resolvable on PATH for the agent's self-check
         # without a writable workspace copy. In docker it already lives in
         # /usr/local/bin; on host we prepend the repo root (where the binary is).
         agent_env = dict(os.environ)
         checker_dir = os.path.dirname(os.path.abspath(checker_bin))
-        agent_env['PATH'] = checker_dir + os.pathsep + agent_env.get('PATH', '')
+        agent_env["PATH"] = checker_dir + os.pathsep + agent_env.get("PATH", "")
         try:
-            with open(agent_jsonl, 'w') as jsonl_f:
+            with open(agent_jsonl, "w") as jsonl_f:
                 proc = subprocess.Popen(
-                    ['bash', '-c', shell_cmd],
+                    ["bash", "-c", shell_cmd],
                     stdin=subprocess.PIPE,
                     stdout=jsonl_f,
                     stderr=subprocess.PIPE,
@@ -470,8 +492,9 @@ def run_single_benchmark(item: WorkItem):
                 # leaked ~150GB). We don't rely on communicate()'s own timeout —
                 # it failed to fire when a hung tlapm child held the pipe open.
                 def _watchdog():
-                    timed_out['v'] = True
+                    timed_out["v"] = True
                     kill_agent_tree(proc, workspace)
+
                 timer = threading.Timer(_to, _watchdog) if _to else None
                 if timer:
                     timer.daemon = True
@@ -482,37 +505,37 @@ def run_single_benchmark(item: WorkItem):
                     _bt = (_to + 600) if _to else None
                     _, stderr = proc.communicate(input=prompt, timeout=_bt)
                 except subprocess.TimeoutExpired:
-                    timed_out['v'] = True
+                    timed_out["v"] = True
                     kill_agent_tree(proc, workspace)
                     with contextlib.suppress(Exception):
                         proc.wait(timeout=30)
-                    stderr = ''
+                    stderr = ""
                 finally:
                     if timer:
                         timer.cancel()
-            result['agent_exit'] = proc.returncode
+            result["agent_exit"] = proc.returncode
             if stderr:
-                with open(os.path.join(result_dir, 'agent_stderr.txt'), 'w') as f:
+                with open(os.path.join(result_dir, "agent_stderr.txt"), "w") as f:
                     f.write(stderr)
-            if timed_out['v']:
-                result['agent_exit'] = -1
-                result['error'] = f'{backend.name} timeout after {item.timeout}s'
+            if timed_out["v"]:
+                result["agent_exit"] = -1
+                result["error"] = f"{backend.name} timeout after {item.timeout}s"
                 kill_agent_tree(proc, workspace)  # final sweep
         except Exception as e:
-            result['agent_exit'] = -2
-            result['error'] = str(e)
+            result["agent_exit"] = -2
+            result["error"] = str(e)
             if proc is not None:
                 kill_agent_tree(proc, workspace)
 
         elapsed = time.time() - start_time
-        result['time_secs'] = elapsed
+        result["time_secs"] = elapsed
 
         transcript, input_tokens, output_tokens = backend.parse_output(agent_jsonl)
-        result['input_tokens'] = input_tokens
-        result['output_tokens'] = output_tokens
+        result["input_tokens"] = input_tokens
+        result["output_tokens"] = output_tokens
 
-        transcript_path = os.path.join(result_dir, 'transcript.txt')
-        with open(transcript_path, 'w') as f:
+        transcript_path = os.path.join(result_dir, "transcript.txt")
+        with open(transcript_path, "w") as f:
             f.write(f"Benchmark: {rel_path}\n")
             f.write(f"Time: {elapsed:.0f}s\n")
             f.write(f"Tokens: {input_tokens:,} input / {output_tokens:,} output\n")
@@ -521,55 +544,61 @@ def run_single_benchmark(item: WorkItem):
 
         # Copy all .tla files from workspace (solution + dependencies)
         solution_path = os.path.join(workspace, basename)
-        for tla_file in glob.glob(os.path.join(workspace, '*.tla')):
+        for tla_file in glob.glob(os.path.join(workspace, "*.tla")):
             shutil.copy2(tla_file, os.path.join(result_dir, os.path.basename(tla_file)))
         if os.path.isfile(solution_path):
-            shutil.copy2(solution_path, os.path.join(result_dir, 'solution.tla'))
+            shutil.copy2(solution_path, os.path.join(result_dir, "solution.tla"))
 
         # Copy .result file if the agent ran the checker itself
-        result_file = os.path.join(workspace, name_no_ext + '.result')
+        result_file = os.path.join(workspace, name_no_ext + ".result")
         if os.path.isfile(result_file):
-            shutil.copy2(result_file, os.path.join(result_dir, 'agent_check.result'))
+            shutil.copy2(result_file, os.path.join(result_dir, "agent_check.result"))
 
         # Run our own checker via the level. The compiled binary now runs the
         # full cheat engine (legacy regex + SANY semantic + incomplete-proof)
         # inline, so a single invocation produces the authoritative verdict.
-        check_result_path = os.path.join(result_dir, 'check.result')
-        cmd = level.checker_command(workspace, basename, check_result_path,
-                                    item.check_timeout,
-                                    benchmark_dir=os.path.dirname(item.benchmark_path))
+        check_result_path = os.path.join(result_dir, "check.result")
+        cmd = level.checker_command(
+            workspace,
+            basename,
+            check_result_path,
+            item.check_timeout,
+            benchmark_dir=os.path.dirname(item.benchmark_path),
+        )
         try:
             check_proc = subprocess.run(
                 cmd,
-                capture_output=True, text=True, timeout=item.check_timeout + 60,
+                capture_output=True,
+                text=True,
+                timeout=item.check_timeout + 60,
                 cwd=workspace,
             )
-            check_log = os.path.join(result_dir, 'check_debug.txt')
-            with open(check_log, 'w') as dbg:
+            check_log = os.path.join(result_dir, "check_debug.txt")
+            with open(check_log, "w") as dbg:
                 dbg.write(f"exit code: {check_proc.returncode}\n")
                 dbg.write(f"stdout:\n{check_proc.stdout}\n")
                 dbg.write(f"stderr:\n{check_proc.stderr}\n")
             if check_proc.returncode == 0:
-                result['check_verdict'] = 'PASS'
+                result["check_verdict"] = "PASS"
             elif check_proc.returncode == 2:
-                result['check_verdict'] = 'CHEATING'
+                result["check_verdict"] = "CHEATING"
             elif check_proc.returncode == 1:
-                result['check_verdict'] = 'FAIL'
+                result["check_verdict"] = "FAIL"
             else:
-                result['check_verdict'] = 'ERROR'
-            ob_matches = re.findall(r'All (\d+) obligation', check_proc.stdout)
+                result["check_verdict"] = "ERROR"
+            ob_matches = re.findall(r"All (\d+) obligation", check_proc.stdout)
             if ob_matches:
-                result['obligations'] = int(ob_matches[-1])
+                result["obligations"] = int(ob_matches[-1])
             else:
-                fail_match = re.search(r'(\d+)/(\d+) obligation', check_proc.stdout)
+                fail_match = re.search(r"(\d+)/(\d+) obligation", check_proc.stdout)
                 if fail_match:
-                    result['obligations_failed'] = int(fail_match.group(1))
-                    result['obligations_total'] = int(fail_match.group(2))
+                    result["obligations_failed"] = int(fail_match.group(1))
+                    result["obligations_total"] = int(fail_match.group(2))
         except subprocess.TimeoutExpired:
-            result['check_verdict'] = 'TIMEOUT'
+            result["check_verdict"] = "TIMEOUT"
         except Exception as e:
-            result['check_verdict'] = 'ERROR'
-            result['error'] = str(e)
+            result["check_verdict"] = "ERROR"
+            result["error"] = str(e)
 
     finally:
         shutil.rmtree(workspace, ignore_errors=True)
@@ -578,36 +607,45 @@ def run_single_benchmark(item: WorkItem):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Run an agent CLI on TLAPS benchmarks')
-    parser.add_argument('--backend', default='codex', choices=list_backends(),
-                        help='Agent backend (default: codex)')
-    parser.add_argument('--level', default='level1', choices=list_levels(),
-                        help='Benchmark level (default: level1)')
-    parser.add_argument('--model', default=None,
-                        help='Override the backend default model')
-    parser.add_argument('--jobs', type=int, default=1, help='Parallel agent runs')
-    parser.add_argument('--filter', default=None, help='Only run benchmarks matching pattern')
-    parser.add_argument('--timeout', type=int, default=7200,
-                        help='Agent timeout per benchmark in seconds (default: 7200; 0 = no limit)')
-    parser.add_argument('--check-timeout', type=int, default=600,
-                        help='Checker timeout per benchmark in seconds (default: 600)')
-    parser.add_argument('--output-dir', default=None, help='Output directory')
+    parser = argparse.ArgumentParser(description="Run an agent CLI on TLAPS benchmarks")
+    parser.add_argument("--backend", default="codex", choices=list_backends(), help="Agent backend (default: codex)")
+    parser.add_argument("--level", default="level1", choices=list_levels(), help="Benchmark level (default: level1)")
+    parser.add_argument("--model", default=None, help="Override the backend default model")
+    parser.add_argument("--jobs", type=int, default=1, help="Parallel agent runs")
+    parser.add_argument("--filter", default=None, help="Only run benchmarks matching pattern")
+    parser.add_argument(
+        "--timeout", type=int, default=7200, help="Agent timeout per benchmark in seconds (default: 7200; 0 = no limit)"
+    )
+    parser.add_argument(
+        "--check-timeout", type=int, default=600, help="Checker timeout per benchmark in seconds (default: 600)"
+    )
+    parser.add_argument("--output-dir", default=None, help="Output directory")
     # Quota gate (claude_code + Claude Max subscription only). Pauses before
     # launching an agent when subscription usage is over threshold, sleeping
     # until the window resets. 0 disables a window's check.
-    parser.add_argument('--quota-5h', type=float, default=80,
-                        help='Pause when 5-hour usage exceeds this %% (default: 80; 0 = off)')
-    parser.add_argument('--quota-7d', type=float, default=95,
-                        help='Pause when 7-day usage exceeds this %% (default: 95; 0 = off)')
-    parser.add_argument('--quota-max-waits', type=int, default=6,
-                        help='Max window resets to sleep through before aborting a benchmark (default: 6)')
-    parser.add_argument('--usage-script', default=None,
-                        help='Path to usage.sh (default: <repo>/scripts/usage.sh)')
-    parser.add_argument('--resume', action='store_true',
-                        help='Reuse --output-dir: skip benchmarks already PASS there, run the rest')
-    parser.add_argument('--min-free-gb', type=float, default=0,
-                        help='Hold off launching an agent until this many GB RAM are free '
-                             '(0 = off). Use on a no-swap host shared with another heavy run.')
+    parser.add_argument(
+        "--quota-5h", type=float, default=80, help="Pause when 5-hour usage exceeds this %% (default: 80; 0 = off)"
+    )
+    parser.add_argument(
+        "--quota-7d", type=float, default=95, help="Pause when 7-day usage exceeds this %% (default: 95; 0 = off)"
+    )
+    parser.add_argument(
+        "--quota-max-waits",
+        type=int,
+        default=6,
+        help="Max window resets to sleep through before aborting a benchmark (default: 6)",
+    )
+    parser.add_argument("--usage-script", default=None, help="Path to usage.sh (default: <repo>/scripts/usage.sh)")
+    parser.add_argument(
+        "--resume", action="store_true", help="Reuse --output-dir: skip benchmarks already PASS there, run the rest"
+    )
+    parser.add_argument(
+        "--min-free-gb",
+        type=float,
+        default=0,
+        help="Hold off launching an agent until this many GB RAM are free "
+        "(0 = off). Use on a no-swap host shared with another heavy run.",
+    )
     args = parser.parse_args()
 
     backend = get_backend(args.backend, model=args.model)
@@ -628,7 +666,7 @@ def main():
     # `<install_root>/bin/tlapm/bin/tlapm`, which the agent then ran and
     # got "Not a directory" on every tlapm invocation.
     tlapm_root = TLAPM_PERSISTENT
-    tlapm_bin = os.path.join(tlapm_root, 'bin', 'tlapm')
+    tlapm_bin = os.path.join(tlapm_root, "bin", "tlapm")
     tlapm_lib = find_tlapm_lib(tlapm_bin)
     if not tlapm_lib:
         print(f"ERROR: tlapm lib not found near {tlapm_bin}")
@@ -645,11 +683,11 @@ def main():
     if args.output_dir:
         output_dir = args.output_dir
     else:
-        timestamp = time.strftime('%Y%m%d_%H%M%S')
-        if os.path.isdir('/result'):
-            output_dir = os.path.join('/result', level.name, backend.name, timestamp)
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        if os.path.isdir("/result"):
+            output_dir = os.path.join("/result", level.name, backend.name, timestamp)
         else:
-            output_dir = os.path.join(REPO_ROOT, 'results', level.name, backend.name, timestamp)
+            output_dir = os.path.join(REPO_ROOT, "results", level.name, backend.name, timestamp)
     output_dir = os.path.abspath(output_dir)
     os.makedirs(output_dir, exist_ok=True)
 
@@ -661,19 +699,23 @@ def main():
     # For other backends, or when usage.sh / OAuth creds are absent, it stays
     # disabled and never blocks a run.
     usage_script = None
-    if backend.name == 'claude_code' and (args.quota_5h > 0 or args.quota_7d > 0):
-        candidate = args.usage_script or os.path.join(REPO_ROOT, 'scripts', 'usage.sh')
+    if backend.name == "claude_code" and (args.quota_5h > 0 or args.quota_7d > 0):
+        candidate = args.usage_script or os.path.join(REPO_ROOT, "scripts", "usage.sh")
         if os.path.isfile(candidate):
             usage = fetch_usage(candidate)
             if usage is not None:
                 usage_script = candidate
-                u5 = (usage.get('five_hour') or {}).get('utilization', 0)
-                u7 = (usage.get('seven_day') or {}).get('utilization', 0)
-                print(f"Quota:   gate ON — now 5h={u5}% (limit {args.quota_5h}%), "
-                      f"7d={u7}% (limit {args.quota_7d}%), max-waits={args.quota_max_waits}")
+                u5 = (usage.get("five_hour") or {}).get("utilization", 0)
+                u7 = (usage.get("seven_day") or {}).get("utilization", 0)
+                print(
+                    f"Quota:   gate ON — now 5h={u5}% (limit {args.quota_5h}%), "
+                    f"7d={u7}% (limit {args.quota_7d}%), max-waits={args.quota_max_waits}"
+                )
             else:
-                print("Quota:   gate OFF — usage endpoint unavailable "
-                      "(API-key auth or no OAuth token at ~/.claude/.credentials.json)")
+                print(
+                    "Quota:   gate OFF — usage endpoint unavailable "
+                    "(API-key auth or no OAuth token at ~/.claude/.credentials.json)"
+                )
         elif args.usage_script:
             print(f"Quota:   gate OFF — usage script not found at {candidate}")
 
@@ -685,19 +727,17 @@ def main():
     results = []
     done_pass = set()
     if args.resume:
-        prev_json = os.path.join(output_dir, 'results.json')
+        prev_json = os.path.join(output_dir, "results.json")
         if os.path.isfile(prev_json):
             with open(prev_json) as f:
                 results = json.load(f)
             # Skip both PASS (already done) and SKIP (operator-marked frontier
             # benchmarks deliberately excluded from retry, e.g. theorems known
             # to time out for reasons outside the agent's control).
-            done_pass = {r['benchmark'] for r in results
-                         if r.get('check_verdict') in ('PASS', 'SKIP')}
-            n_pass = sum(1 for r in results if r.get('check_verdict') == 'PASS')
+            done_pass = {r["benchmark"] for r in results if r.get("check_verdict") in ("PASS", "SKIP")}
+            n_pass = sum(1 for r in results if r.get("check_verdict") == "PASS")
             n_skip = len(done_pass) - n_pass
-            print(f"Resume: loaded {len(results)} prior results, skipping "
-                  f"{n_pass} PASS + {n_skip} SKIP")
+            print(f"Resume: loaded {len(results)} prior results, skipping {n_pass} PASS + {n_skip} SKIP")
         else:
             print(f"Resume: no prior results.json in {output_dir} — running all")
 
@@ -706,24 +746,26 @@ def main():
         rel = os.path.relpath(bf, level.benchmark_dir())
         if rel in done_pass:
             continue
-        work_items.append(WorkItem(
-            benchmark_path=bf,
-            output_dir=output_dir,
-            timeout=args.timeout,
-            check_timeout=args.check_timeout,
-            backend=backend,
-            level=level,
-            tlapm_path=tlapm_root,
-            tlapm_lib=tlapm_lib,
-            usage_script=usage_script,
-            quota_5h=args.quota_5h,
-            quota_7d=args.quota_7d,
-            quota_max_waits=args.quota_max_waits,
-            min_free_gb=args.min_free_gb,
-        ))
+        work_items.append(
+            WorkItem(
+                benchmark_path=bf,
+                output_dir=output_dir,
+                timeout=args.timeout,
+                check_timeout=args.check_timeout,
+                backend=backend,
+                level=level,
+                tlapm_path=tlapm_root,
+                tlapm_lib=tlapm_lib,
+                usage_script=usage_script,
+                quota_5h=args.quota_5h,
+                quota_7d=args.quota_7d,
+                quota_max_waits=args.quota_max_waits,
+                min_free_gb=args.min_free_gb,
+            )
+        )
 
     start_time = time.time()
-    icons = {'PASS': '✅', 'FAIL': '❌', 'CHEATING': '⚠️', 'TIMEOUT': '⏱️', 'ERROR': '💥'}
+    icons = {"PASS": "✅", "FAIL": "❌", "CHEATING": "⚠️", "TIMEOUT": "⏱️", "ERROR": "💥"}
     total_benchmarks = len(benchmark_files)
     prior_done = len(results)
     if args.resume:
@@ -733,9 +775,11 @@ def main():
         for i, item in enumerate(work_items):
             r = run_single_benchmark(item)
             results.append(r)
-            icon = icons.get(r['check_verdict'], '❓')
-            tokens = f"{r.get('input_tokens',0):,}/{r.get('output_tokens',0):,}"
-            print(f"[{prior_done+i+1}/{total_benchmarks}] {icon} {r['benchmark']} ({r['time_secs']:.0f}s, {tokens} tok)")
+            icon = icons.get(r["check_verdict"], "❓")
+            tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
+            print(
+                f"[{prior_done + i + 1}/{total_benchmarks}] {icon} {r['benchmark']} ({r['time_secs']:.0f}s, {tokens} tok)"
+            )
             update_summary(results, output_dir, total_benchmarks, backend.name, level.name)
     else:
         with ProcessPoolExecutor(max_workers=args.jobs) as executor:
@@ -743,31 +787,33 @@ def main():
             for done_count, future in enumerate(as_completed(futures), start=1):
                 r = future.result()
                 results.append(r)
-                icon = icons.get(r['check_verdict'], '❓')
-                tokens = f"{r.get('input_tokens',0):,}/{r.get('output_tokens',0):,}"
-                print(f"[{prior_done+done_count}/{total_benchmarks}] {icon} {r['benchmark']} ({r['time_secs']:.0f}s, {tokens} tok)")
+                icon = icons.get(r["check_verdict"], "❓")
+                tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
+                print(
+                    f"[{prior_done + done_count}/{total_benchmarks}] {icon} {r['benchmark']} ({r['time_secs']:.0f}s, {tokens} tok)"
+                )
                 update_summary(results, output_dir, total_benchmarks, backend.name, level.name)
 
     total_time = time.time() - start_time
 
     update_summary(results, output_dir, total_benchmarks, backend.name, level.name)
-    report_path = os.path.join(output_dir, 'summary.md')
+    report_path = os.path.join(output_dir, "summary.md")
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Completed in {total_time:.0f}s")
     print(f"Report: {report_path}")
 
     verdicts = {}
     for r in results:
-        v = r['check_verdict']
+        v = r["check_verdict"]
         verdicts[v] = verdicts.get(v, 0) + 1
-    for v in ['PASS', 'FAIL', 'CHEATING', 'TIMEOUT', 'ERROR']:
+    for v in ["PASS", "FAIL", "CHEATING", "TIMEOUT", "ERROR"]:
         if v in verdicts:
             print(f"  {icons.get(v, '❓')} {v}: {verdicts[v]}")
-    total_in = sum(r.get('input_tokens', 0) for r in results)
-    total_out = sum(r.get('output_tokens', 0) for r in results)
+    total_in = sum(r.get("input_tokens", 0) for r in results)
+    total_out = sum(r.get("output_tokens", 0) for r in results)
     print(f"  Total tokens: {total_in:,} input / {total_out:,} output")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -32,6 +32,8 @@ from dataclasses import dataclass
 
 # Allow `python3 src/evaluator/runner.py` as well as module import.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import contextlib
+
 from backends import get_backend, list_backends  # noqa: E402
 from levels import get_level, list_levels  # noqa: E402
 
@@ -229,25 +231,17 @@ def kill_agent_tree(proc, workspace: str):
     except Exception:
         return
     targets = set()
-    try:
+    with contextlib.suppress(Exception):
         targets.update(_proc_descendants(pid))
-    except Exception:
-        pass
-    try:
+    with contextlib.suppress(Exception):
         targets.update(_procs_with_cwd_under(workspace))
-    except Exception:
-        pass
     targets.add(pid)
     # Process group first (cheap, scoped to our own session).
-    try:
+    with contextlib.suppress(Exception):
         os.killpg(os.getpgid(pid), signal.SIGKILL)
-    except Exception:
-        pass
     for t in targets:
-        try:
+        with contextlib.suppress(Exception):
             os.kill(t, signal.SIGKILL)
-        except Exception:
-            pass
 
 
 def _mem_available_gb() -> float | None:
@@ -490,10 +484,8 @@ def run_single_benchmark(item: WorkItem):
                 except subprocess.TimeoutExpired:
                     timed_out['v'] = True
                     kill_agent_tree(proc, workspace)
-                    try:
+                    with contextlib.suppress(Exception):
                         proc.wait(timeout=30)
-                    except Exception:
-                        pass
                     stderr = ''
                 finally:
                     if timer:

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -740,9 +740,7 @@ def main():
     else:
         with ProcessPoolExecutor(max_workers=args.jobs) as executor:
             futures = {executor.submit(run_single_benchmark, item): item for item in work_items}
-            done_count = 0
-            for future in as_completed(futures):
-                done_count += 1
+            for done_count, future in enumerate(as_completed(futures), start=1):
                 r = future.result()
                 results.append(r)
                 icon = icons.get(r['check_verdict'], '❓')

--- a/src/tlacheck/cli.py
+++ b/src/tlacheck/cli.py
@@ -24,12 +24,10 @@ from .engine import run_rules
 from .issue import Severity
 
 
-def audit_one(solution_dir: str, target: str, benchmark_dir: str | None,
-              with_summary: bool = False) -> list:
+def audit_one(solution_dir: str, target: str, benchmark_dir: str | None, with_summary: bool = False) -> list:
     # incomplete_proof is wired into the engine rule sets; it only fires when a
     # tlapm --summary is available, so request one when --summary was passed.
-    ctx = build_context(solution_dir, target, benchmark_dir=benchmark_dir,
-                        compute_summary=with_summary)
+    ctx = build_context(solution_dir, target, benchmark_dir=benchmark_dir, compute_summary=with_summary)
     return run_rules(ctx)
 
 
@@ -52,10 +50,10 @@ def main(argv=None):
     ap.add_argument("--target", help="benchmark module name (else inferred)")
     ap.add_argument("--benchmark-dir", help="canonical benchmark/<level>/<module>/ dir")
     ap.add_argument("--scan", help="recursively audit all benchmark dirs under this path")
-    ap.add_argument("--benchmark-root", default="benchmark",
-                    help="root of canonical benchmarks (for --scan provenance)")
-    ap.add_argument("--summary", action="store_true",
-                    help="also run tlapm --summary for incomplete-proof detection")
+    ap.add_argument(
+        "--benchmark-root", default="benchmark", help="root of canonical benchmarks (for --scan provenance)"
+    )
+    ap.add_argument("--summary", action="store_true", help="also run tlapm --summary for incomplete-proof detection")
     args = ap.parse_args(argv)
 
     targets = []

--- a/src/tlacheck/context.py
+++ b/src/tlacheck/context.py
@@ -11,11 +11,10 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Optional
 
 from tlacore.model import Module
 from tlacore.provenance import Provenance, classify
-from tlacore.sany.dump import try_dump, try_dump_normalized
+from tlacore.sany.dump import try_dump_normalized
 from tlacore.source import slice_loc
 from tlacore.tlapm.summary import Summary, run_summary
 
@@ -30,10 +29,10 @@ def _norm(text: str) -> str:
 class CheckContext:
     target_name: str                       # benchmark module name
     solution_dir: str                      # result dir holding the submission
-    solution: Optional[Module]             # parsed solution module (None if SANY failed)
-    baseline: Optional[Module]             # parsed benchmark.tla (given baseline)
+    solution: Module | None             # parsed solution module (None if SANY failed)
+    baseline: Module | None             # parsed benchmark.tla (given baseline)
     provenance: Provenance
-    benchmark_dir: Optional[str] = None    # canonical benchmark/<level>/<module>/
+    benchmark_dir: str | None = None    # canonical benchmark/<level>/<module>/
     solution_source: str = ""              # raw text of the solution file
     baseline_source: str = ""              # raw text of benchmark.tla
     sany_ok: bool = True                   # did Java SANY parse the solution?
@@ -42,7 +41,7 @@ class CheckContext:
     # Java SANY (stricter) refuses. Keyed: "" = solution, mod name = agent module.
     summaries: dict = field(default_factory=dict)
     agent_modules: dict[str, Module] = field(default_factory=dict)  # name -> parsed
-    summary: Optional[Summary] = None
+    summary: Summary | None = None
     tlapm_output: str = ""
     tlapm_passed: bool = False
 
@@ -95,7 +94,7 @@ class CheckContext:
 
 def build_context(solution_dir: str, target_name: str, *,
                   benchmark_dir: str | None = None,
-                  summary: Optional[Summary] = None,
+                  summary: Summary | None = None,
                   tlapm_output: str = "", tlapm_passed: bool = False,
                   solution_file: str | None = None,
                   tlapm_fallback: bool = False,

--- a/src/tlacheck/context.py
+++ b/src/tlacheck/context.py
@@ -27,15 +27,15 @@ def _norm(text: str) -> str:
 
 @dataclass
 class CheckContext:
-    target_name: str                       # benchmark module name
-    solution_dir: str                      # result dir holding the submission
-    solution: Module | None             # parsed solution module (None if SANY failed)
-    baseline: Module | None             # parsed benchmark.tla (given baseline)
+    target_name: str  # benchmark module name
+    solution_dir: str  # result dir holding the submission
+    solution: Module | None  # parsed solution module (None if SANY failed)
+    baseline: Module | None  # parsed benchmark.tla (given baseline)
     provenance: Provenance
-    benchmark_dir: str | None = None    # canonical benchmark/<level>/<module>/
-    solution_source: str = ""              # raw text of the solution file
-    baseline_source: str = ""              # raw text of benchmark.tla
-    sany_ok: bool = True                   # did Java SANY parse the solution?
+    benchmark_dir: str | None = None  # canonical benchmark/<level>/<module>/
+    solution_source: str = ""  # raw text of the solution file
+    baseline_source: str = ""  # raw text of benchmark.tla
+    sany_ok: bool = True  # did Java SANY parse the solution?
     # tlapm authoritative fallback (used when sany_ok is False): tlapm's own
     # parser accepts everything it considers valid, so --summary works where
     # Java SANY (stricter) refuses. Keyed: "" = solution, mod name = agent module.
@@ -92,14 +92,19 @@ class CheckContext:
         return _norm(slice_loc(self.solution_source, assume.loc)) if assume.loc else ""
 
 
-def build_context(solution_dir: str, target_name: str, *,
-                  benchmark_dir: str | None = None,
-                  summary: Summary | None = None,
-                  tlapm_output: str = "", tlapm_passed: bool = False,
-                  solution_file: str | None = None,
-                  tlapm_fallback: bool = False,
-                  compute_summary: bool = False,
-                  fallback_timeout: float = 600) -> CheckContext:
+def build_context(
+    solution_dir: str,
+    target_name: str,
+    *,
+    benchmark_dir: str | None = None,
+    summary: Summary | None = None,
+    tlapm_output: str = "",
+    tlapm_passed: bool = False,
+    solution_file: str | None = None,
+    tlapm_fallback: bool = False,
+    compute_summary: bool = False,
+    fallback_timeout: float = 600,
+) -> CheckContext:
     """Parse the solution + baseline + agent-created modules and assemble a context.
 
     ``benchmark_dir`` is the canonical ``benchmark/<level>/<module>/`` directory
@@ -122,14 +127,14 @@ def build_context(solution_dir: str, target_name: str, *,
     sany_ok = solution is not None
 
     base_path = os.path.join(solution_dir, "benchmark.tla")
-    baseline = (try_dump_normalized(base_path, dep_dirs=dep_dirs)
-                if os.path.exists(base_path) else None)
+    baseline = try_dump_normalized(base_path, dep_dirs=dep_dirs) if os.path.exists(base_path) else None
 
     def _read(p):
         try:
             return open(p, encoding="utf-8", errors="ignore").read()
         except OSError:
             return ""
+
     solution_source = _read(sol_path)
     baseline_source = _read(base_path) if os.path.exists(base_path) else ""
 

--- a/src/tlacheck/engine.py
+++ b/src/tlacheck/engine.py
@@ -21,15 +21,15 @@ SANY_RULES = [
     smuggled_module,
     extra_axiom,
     dependency_modified,
-    incomplete_proof,   # bare-QED / missing step inside a structured proof
+    incomplete_proof,  # bare-QED / missing step inside a structured proof
 ]
 
 # tlapm-authoritative fallback — used when Java SANY refused the solution.
 # Covers the soundness vector (admitted / smuggled) from tlapm's own accounting.
 FALLBACK_RULES = [
     admitted_fallback,
-    dependency_modified,   # pure byte-compare, parser-independent
-    incomplete_proof,      # consumes the fallback tlapm --summary accounting
+    dependency_modified,  # pure byte-compare, parser-independent
+    incomplete_proof,  # consumes the fallback tlapm --summary accounting
 ]
 
 
@@ -45,5 +45,4 @@ def run_rules(ctx: CheckContext) -> list[Issue]:
 def evaluate(ctx: CheckContext, *, incomplete_is_cheating: bool = False) -> Result:
     """Run all rules and fold them into a verdict with the tlapm outcome."""
     issues = run_rules(ctx)
-    return decide(ctx.tlapm_passed, issues,
-                  incomplete_is_cheating=incomplete_is_cheating)
+    return decide(ctx.tlapm_passed, issues, incomplete_is_cheating=incomplete_is_cheating)

--- a/src/tlacheck/engine.py
+++ b/src/tlacheck/engine.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from .context import CheckContext
 from .issue import Issue
-from .verdict import Result, decide
 from .rules import (
-    admitted_statement, smuggled_module, extra_axiom, dependency_modified,
-    admitted_fallback, incomplete_proof,
+    admitted_fallback,
+    admitted_statement,
+    dependency_modified,
+    extra_axiom,
+    incomplete_proof,
+    smuggled_module,
 )
+from .verdict import Result, decide
 
 # SANY-based structural rules — precise, fast, used when Java SANY parsed the
 # solution. Pure functions of the parsed model + provenance.

--- a/src/tlacheck/issue.py
+++ b/src/tlacheck/issue.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
-from typing import Optional
 
 
 class Severity(enum.Enum):
@@ -28,8 +27,8 @@ class Issue:
     vector: str                 # short code, e.g. "ADMITTED_STATEMENT"
     severity: Severity
     message: str                # human-readable explanation
-    location: Optional[str] = None   # "file:line" or module name
-    evidence: Optional[str] = None   # the offending snippet / detail
+    location: str | None = None   # "file:line" or module name
+    evidence: str | None = None   # the offending snippet / detail
 
     def __str__(self) -> str:
         loc = f" [{self.location}]" if self.location else ""

--- a/src/tlacheck/issue.py
+++ b/src/tlacheck/issue.py
@@ -17,6 +17,7 @@ class Severity(enum.Enum):
                  default surfaced separately, not counted as CHEATING.
     WARNING    — informational; never changes the verdict on its own.
     """
+
     CHEATING = "CHEATING"
     INCOMPLETE = "INCOMPLETE"
     WARNING = "WARNING"
@@ -24,11 +25,11 @@ class Severity(enum.Enum):
 
 @dataclass
 class Issue:
-    vector: str                 # short code, e.g. "ADMITTED_STATEMENT"
+    vector: str  # short code, e.g. "ADMITTED_STATEMENT"
     severity: Severity
-    message: str                # human-readable explanation
-    location: str | None = None   # "file:line" or module name
-    evidence: str | None = None   # the offending snippet / detail
+    message: str  # human-readable explanation
+    location: str | None = None  # "file:line" or module name
+    evidence: str | None = None  # the offending snippet / detail
 
     def __str__(self) -> str:
         loc = f" [{self.location}]" if self.location else ""

--- a/src/tlacheck/rules/admitted_fallback.py
+++ b/src/tlacheck/rules/admitted_fallback.py
@@ -38,25 +38,33 @@ def check(ctx: CheckContext) -> list[Issue]:
         for ip in sol.incomplete:
             if ip.theorem_line in given_lines:
                 continue  # given (baseline) admitted lemma — allowed
-            issues.append(Issue(
-                vector=name,
-                severity=Severity.CHEATING,
-                message=(f"[tlapm-fallback] Theorem at line {ip.theorem_line} is "
-                         f"admitted (no real proof / bare QED) — not present in the "
-                         f"baseline; admitted as an axiom."),
-                location=f"{ctx.target_name}:{ip.theorem_line}",
-            ))
+            issues.append(
+                Issue(
+                    vector=name,
+                    severity=Severity.CHEATING,
+                    message=(
+                        f"[tlapm-fallback] Theorem at line {ip.theorem_line} is "
+                        f"admitted (no real proof / bare QED) — not present in the "
+                        f"baseline; admitted as an axiom."
+                    ),
+                    location=f"{ctx.target_name}:{ip.theorem_line}",
+                )
+            )
 
     # Agent-created modules: any admitted theorem is a smuggled axiom.
     for mod, summ in ctx.summaries.items():
         if mod in ("", "__baseline__") or summ is None:
             continue
         for ip in summ.incomplete:
-            issues.append(Issue(
-                vector="SMUGGLED_MODULE",
-                severity=Severity.CHEATING,
-                message=(f"[tlapm-fallback] Agent-created module '{mod}' has an "
-                         f"admitted theorem at line {ip.theorem_line} — smuggled axiom."),
-                location=f"{mod}.tla:{ip.theorem_line}",
-            ))
+            issues.append(
+                Issue(
+                    vector="SMUGGLED_MODULE",
+                    severity=Severity.CHEATING,
+                    message=(
+                        f"[tlapm-fallback] Agent-created module '{mod}' has an "
+                        f"admitted theorem at line {ip.theorem_line} — smuggled axiom."
+                    ),
+                    location=f"{mod}.tla:{ip.theorem_line}",
+                )
+            )
     return issues

--- a/src/tlacheck/rules/admitted_statement.py
+++ b/src/tlacheck/rules/admitted_statement.py
@@ -21,7 +21,7 @@ name = "ADMITTED_STATEMENT"
 
 def check(ctx: CheckContext) -> list[Issue]:
     issues: list[Issue] = []
-    given_admitted = ctx.baseline_admitted_names()       # by name
+    given_admitted = ctx.baseline_admitted_names()  # by name
     given_admitted_texts = ctx.baseline_admitted_stmt_texts()  # by statement text
 
     def is_given(t) -> bool:
@@ -39,14 +39,17 @@ def check(ctx: CheckContext) -> list[Issue]:
     for t in fresh:
         line = t.loc.line_start if t.loc else "?"
         kind = "PROOF OMITTED" if t.proof_is_omitted else "no proof (bare theorem)"
-        issues.append(Issue(
-            vector=name,
-            severity=Severity.CHEATING,
-            message=(f"Agent-introduced theorem '{t.display_name}' has {kind} "
-                     f"— admitted as an axiom (0 obligations)."),
-            location=f"{ctx.solution.filename}:{line}",
-            evidence=t.display_name,
-        ))
+        issues.append(
+            Issue(
+                vector=name,
+                severity=Severity.CHEATING,
+                message=(
+                    f"Agent-introduced theorem '{t.display_name}' has {kind} — admitted as an axiom (0 obligations)."
+                ),
+                location=f"{ctx.solution.filename}:{line}",
+                evidence=t.display_name,
+            )
+        )
 
     # A second, stronger signal: does the target's proof actually LEAN on one of
     # these admitted statements? That turns "introduced an admitted lemma" into
@@ -58,13 +61,17 @@ def check(ctx: CheckContext) -> list[Issue]:
             leaned = [r for r in t.references if r in fresh_named]
             if leaned:
                 line = t.loc.line_start if t.loc else "?"
-                issues.append(Issue(
-                    vector=name,
-                    severity=Severity.CHEATING,
-                    message=(f"Theorem '{t.display_name}' is discharged BY "
-                             f"admitted statement(s) {sorted(leaned)} — circular: "
-                             f"the goal rests on an unproven claim."),
-                    location=f"{ctx.solution.filename}:{line}",
-                    evidence=", ".join(sorted(leaned)),
-                ))
+                issues.append(
+                    Issue(
+                        vector=name,
+                        severity=Severity.CHEATING,
+                        message=(
+                            f"Theorem '{t.display_name}' is discharged BY "
+                            f"admitted statement(s) {sorted(leaned)} — circular: "
+                            f"the goal rests on an unproven claim."
+                        ),
+                        location=f"{ctx.solution.filename}:{line}",
+                        evidence=", ".join(sorted(leaned)),
+                    )
+                )
     return issues

--- a/src/tlacheck/rules/base.py
+++ b/src/tlacheck/rules/base.py
@@ -11,5 +11,4 @@ from ..issue import Issue
 class Rule(Protocol):
     name: str
 
-    def check(self, ctx: CheckContext) -> list[Issue]:
-        ...
+    def check(self, ctx: CheckContext) -> list[Issue]: ...

--- a/src/tlacheck/rules/dependency_modified.py
+++ b/src/tlacheck/rules/dependency_modified.py
@@ -36,10 +36,12 @@ def check(ctx: CheckContext) -> list[Issue]:
         except OSError:
             continue
         if a != b:
-            issues.append(Issue(
-                vector=name,
-                severity=Severity.CHEATING,
-                message=f"Given dependency '{mod}.tla' was modified — not allowed.",
-                location=f"{mod}.tla",
-            ))
+            issues.append(
+                Issue(
+                    vector=name,
+                    severity=Severity.CHEATING,
+                    message=f"Given dependency '{mod}.tla' was modified — not allowed.",
+                    location=f"{mod}.tla",
+                )
+            )
     return issues

--- a/src/tlacheck/rules/dependency_modified.py
+++ b/src/tlacheck/rules/dependency_modified.py
@@ -29,8 +29,10 @@ def check(ctx: CheckContext) -> list[Issue]:
         if not (os.path.exists(sol_f) and os.path.exists(can_f)):
             continue
         try:
-            a = open(sol_f, encoding="utf-8", errors="ignore").read()
-            b = open(can_f, encoding="utf-8", errors="ignore").read()
+            with open(sol_f, encoding="utf-8", errors="ignore") as _sf:
+                a = _sf.read()
+            with open(can_f, encoding="utf-8", errors="ignore") as _cf:
+                b = _cf.read()
         except OSError:
             continue
         if a != b:

--- a/src/tlacheck/rules/extra_axiom.py
+++ b/src/tlacheck/rules/extra_axiom.py
@@ -23,8 +23,7 @@ name = "EXTRA_AXIOM"
 # the agent may legitimately *name* an existing baseline assumption (e.g. turn the
 # given `ASSUME N \in Nat` into `ASSUME NType == N \in Nat`) so it can cite it
 # `BY NType`. Comparing bodies recognises that as given, not a new axiom.
-_BODY = re.compile(
-    r"^(?:ASSUME|ASSUMPTION|AXIOM)\s+(?:[A-Za-z_]\w*\s*==\s*)?(.*)$", re.DOTALL)
+_BODY = re.compile(r"^(?:ASSUME|ASSUMPTION|AXIOM)\s+(?:[A-Za-z_]\w*\s*==\s*)?(.*)$", re.DOTALL)
 
 
 def _body(assume_text: str) -> str:
@@ -35,8 +34,8 @@ def _body(assume_text: str) -> str:
 def check(ctx: CheckContext) -> list[Issue]:
     if ctx.baseline is None:
         return []
-    base_axioms = {a.name for a in ctx.baseline.assumes if a.name}   # by name
-    base_bodies = {_body(t) for t in ctx.baseline_assume_texts()}    # by asserted body
+    base_axioms = {a.name for a in ctx.baseline.assumes if a.name}  # by name
+    base_bodies = {_body(t) for t in ctx.baseline_assume_texts()}  # by asserted body
     issues: list[Issue] = []
     for a in ctx.solution.assumes:
         # Given (allowed) if the baseline has an assume with the same name, OR —
@@ -50,12 +49,13 @@ def check(ctx: CheckContext) -> list[Issue]:
         kind = "AXIOM" if a.is_axiom else "ASSUME"
         line = a.loc.line_start if a.loc else "?"
         label = a.name or f"<unnamed {kind} L{line}>"
-        issues.append(Issue(
-            vector=name,
-            severity=Severity.CHEATING,
-            message=(f"New {kind} '{label}' not in the baseline — assumes away "
-                     f"an obligation."),
-            location=f"{ctx.solution.filename}:{line}",
-            evidence=label,
-        ))
+        issues.append(
+            Issue(
+                vector=name,
+                severity=Severity.CHEATING,
+                message=(f"New {kind} '{label}' not in the baseline — assumes away an obligation."),
+                location=f"{ctx.solution.filename}:{line}",
+                evidence=label,
+            )
+        )
     return issues

--- a/src/tlacheck/rules/incomplete_proof.py
+++ b/src/tlacheck/rules/incomplete_proof.py
@@ -30,21 +30,26 @@ def check(ctx: CheckContext) -> list[Issue]:
     # by admitted_statement as CHEATING; don't also report them as INCOMPLETE.
     # ctx.solution is None on the tlapm fallback path (SANY couldn't parse); the
     # admitted theorems are then surfaced by admitted_fallback instead.
-    admitted_lines = {
-        t.loc.line_start for t in ctx.solution.theorems
-        if t.is_admitted and t.loc
-    } if ctx.solution is not None else set()
+    admitted_lines = (
+        {t.loc.line_start for t in ctx.solution.theorems if t.is_admitted and t.loc}
+        if ctx.solution is not None
+        else set()
+    )
     issues: list[Issue] = []
     sol_name = ctx.solution.filename if ctx.solution is not None else ctx.target_name
     for ip in ctx.summary.incomplete:
         if ip.theorem_line in admitted_lines:
             continue
         locs = ", ".join(str(x) for x in ip.missing_lines) or "?"
-        issues.append(Issue(
-            vector=name,
-            severity=Severity.INCOMPLETE,
-            message=(f"Theorem at line {ip.theorem_line} has {ip.missing_count} "
-                     f"unjustified step(s) (bare QED / missing proof) at line(s) {locs}."),
-            location=f"{sol_name}:{ip.theorem_line}",
-        ))
+        issues.append(
+            Issue(
+                vector=name,
+                severity=Severity.INCOMPLETE,
+                message=(
+                    f"Theorem at line {ip.theorem_line} has {ip.missing_count} "
+                    f"unjustified step(s) (bare QED / missing proof) at line(s) {locs}."
+                ),
+                location=f"{sol_name}:{ip.theorem_line}",
+            )
+        )
     return issues

--- a/src/tlacheck/rules/smuggled_module.py
+++ b/src/tlacheck/rules/smuggled_module.py
@@ -108,12 +108,16 @@ def check(ctx: CheckContext) -> list[Issue]:
                 # modularization (and would carry its own obligations).
                 continue
             line = t.loc.line_start if t.loc else "?"
-            issues.append(Issue(
-                vector=name,
-                severity=Severity.CHEATING,
-                message=(f"Agent-created module '{mod_name}' contains admitted "
-                         f"theorem '{t.display_name}' ({kind}) — smuggled axiom."),
-                location=f"{mod_name}.tla:{line}",
-                evidence=f"{mod_name}!{t.display_name}",
-            ))
+            issues.append(
+                Issue(
+                    vector=name,
+                    severity=Severity.CHEATING,
+                    message=(
+                        f"Agent-created module '{mod_name}' contains admitted "
+                        f"theorem '{t.display_name}' ({kind}) — smuggled axiom."
+                    ),
+                    location=f"{mod_name}.tla:{line}",
+                    evidence=f"{mod_name}!{t.display_name}",
+                )
+            )
     return issues

--- a/src/tlacheck/rules/smuggled_module.py
+++ b/src/tlacheck/rules/smuggled_module.py
@@ -92,7 +92,8 @@ def check(ctx: CheckContext) -> list[Issue]:
         source = ""
         if src_path:
             try:
-                source = open(src_path, encoding="utf-8", errors="ignore").read()
+                with open(src_path, encoding="utf-8", errors="ignore") as _sf:
+                    source = _sf.read()
             except OSError:
                 source = ""
         for t in module.theorems:

--- a/src/tlacheck/rules/statement_modified.py
+++ b/src/tlacheck/rules/statement_modified.py
@@ -17,6 +17,7 @@ import os
 import re
 
 from tlacore.source import slice_loc
+
 from ..context import CheckContext
 from ..issue import Issue, Severity
 

--- a/src/tlacheck/rules/statement_modified.py
+++ b/src/tlacheck/rules/statement_modified.py
@@ -45,8 +45,9 @@ def check(ctx: CheckContext) -> list[Issue]:
     # Read the actual files from the solution dir; module.source_file may point
     # at a now-deleted temp dir (we parse normalized copies there).
     base_src = _read(os.path.join(ctx.solution_dir, "benchmark.tla"))
-    sol_src = (_read(os.path.join(ctx.solution_dir, ctx.target_name + ".tla"))
-               or _read(os.path.join(ctx.solution_dir, "solution.tla")))
+    sol_src = _read(os.path.join(ctx.solution_dir, ctx.target_name + ".tla")) or _read(
+        os.path.join(ctx.solution_dir, "solution.tla")
+    )
     if not base_src or not sol_src:
         return []
 
@@ -56,14 +57,18 @@ def check(ctx: CheckContext) -> list[Issue]:
     issues: list[Issue] = []
     for stmt in base_stmts:
         if stmt and stmt not in sol_stmts:
-            issues.append(Issue(
-                vector=name,
-                severity=Severity.CHEATING,
-                message=("A baseline theorem statement no longer appears verbatim "
-                         "in the solution — target may have been weakened/altered."),
-                location=ctx.solution.filename,
-                evidence=stmt[:120],
-            ))
+            issues.append(
+                Issue(
+                    vector=name,
+                    severity=Severity.CHEATING,
+                    message=(
+                        "A baseline theorem statement no longer appears verbatim "
+                        "in the solution — target may have been weakened/altered."
+                    ),
+                    location=ctx.solution.filename,
+                    evidence=stmt[:120],
+                )
+            )
     return issues
 
 

--- a/src/tlacheck/verdict.py
+++ b/src/tlacheck/verdict.py
@@ -9,11 +9,11 @@ from .issue import Issue, Severity
 
 
 class Verdict(enum.Enum):
-    PASS = "PASS"            # tlapm proved it AND no cheating
-    FAIL = "FAIL"            # tlapm did not prove it
-    CHEATING = "CHEATING"    # tlapm "passed" but a CHEATING issue was found
+    PASS = "PASS"  # tlapm proved it AND no cheating
+    FAIL = "FAIL"  # tlapm did not prove it
+    CHEATING = "CHEATING"  # tlapm "passed" but a CHEATING issue was found
     INCOMPLETE = "INCOMPLETE"  # tlapm "passed" but proof has unjustified steps
-    ERROR = "ERROR"          # could not run the check
+    ERROR = "ERROR"  # could not run the check
 
 
 @dataclass
@@ -31,8 +31,7 @@ class Result:
         return [i for i in self.issues if i.severity is Severity.INCOMPLETE]
 
 
-def decide(tlapm_passed: bool, issues: list[Issue], *,
-           incomplete_is_cheating: bool = False) -> Result:
+def decide(tlapm_passed: bool, issues: list[Issue], *, incomplete_is_cheating: bool = False) -> Result:
     """Combine the tlapm outcome with detected issues into a verdict.
 
     Cheating always wins (even if tlapm "passed" — that is precisely the danger).
@@ -42,14 +41,11 @@ def decide(tlapm_passed: bool, issues: list[Issue], *,
     incomplete = [i for i in issues if i.severity is Severity.INCOMPLETE]
 
     if cheating:
-        return Result(Verdict.CHEATING, issues,
-                      detail=f"{len(cheating)} cheating issue(s)")
+        return Result(Verdict.CHEATING, issues, detail=f"{len(cheating)} cheating issue(s)")
     if incomplete and incomplete_is_cheating:
-        return Result(Verdict.CHEATING, issues,
-                      detail="incomplete proof treated as cheating (policy)")
+        return Result(Verdict.CHEATING, issues, detail="incomplete proof treated as cheating (policy)")
     if not tlapm_passed:
         return Result(Verdict.FAIL, issues, detail="tlapm did not prove the goal")
     if incomplete:
-        return Result(Verdict.INCOMPLETE, issues,
-                      detail=f"{len(incomplete)} unjustified step(s)")
+        return Result(Verdict.INCOMPLETE, issues, detail=f"{len(incomplete)} unjustified step(s)")
     return Result(Verdict.PASS, issues)

--- a/src/tlacore/model.py
+++ b/src/tlacore/model.py
@@ -33,19 +33,21 @@ class Loc:
         if not d:
             return None
         return cls(
-            d.get("line_start", 0), d.get("column_start", 0),
-            d.get("line_end", 0), d.get("column_end", 0),
+            d.get("line_start", 0),
+            d.get("column_start", 0),
+            d.get("line_end", 0),
+            d.get("column_end", 0),
         )
 
 
 @dataclass
 class Theorem:
-    name: str | None            # None for unnamed THEOREM ... (e.g. the target)
+    name: str | None  # None for unnamed THEOREM ... (e.g. the target)
     loc: Loc | None
     statement_loc: Loc | None
-    proof_loc: Loc | None       # None => no proof clause at all (bare theorem)
-    proof_is_omitted: bool         # True => PROOF OMITTED
-    references: list[str]          # theorem/lemma names cited by BY/USE/DEFS
+    proof_loc: Loc | None  # None => no proof clause at all (bare theorem)
+    proof_is_omitted: bool  # True => PROOF OMITTED
+    references: list[str]  # theorem/lemma names cited by BY/USE/DEFS
     statement_references: list[str]
     shape: dict
     raw: dict = field(default_factory=dict, repr=False)
@@ -84,7 +86,7 @@ class Theorem:
 @dataclass
 class Assumption:
     name: str | None
-    is_axiom: bool                 # True => AXIOM, False => ASSUME/ASSUMPTION
+    is_axiom: bool  # True => AXIOM, False => ASSUME/ASSUMPTION
     loc: Loc | None
     references: list[str]
 
@@ -100,8 +102,8 @@ class Assumption:
 
 @dataclass
 class Instance:
-    name: str | None            # e.g. "C" in `C == INSTANCE Consensus`
-    module: str | None          # the instantiated module name
+    name: str | None  # e.g. "C" in `C == INSTANCE Consensus`
+    module: str | None  # the instantiated module name
     loc: Loc | None
     references: list[str]
 
@@ -137,6 +139,7 @@ class Operator:
 @dataclass
 class Symbol:
     """A CONSTANT or VARIABLE declaration."""
+
     name: str
     loc: Loc | None
 

--- a/src/tlacore/model.py
+++ b/src/tlacore/model.py
@@ -19,7 +19,6 @@ Key signals the checker relies on:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -30,7 +29,7 @@ class Loc:
     column_end: int
 
     @classmethod
-    def parse(cls, d: Optional[dict]) -> Optional["Loc"]:
+    def parse(cls, d: dict | None) -> Loc | None:
         if not d:
             return None
         return cls(
@@ -41,10 +40,10 @@ class Loc:
 
 @dataclass
 class Theorem:
-    name: Optional[str]            # None for unnamed THEOREM ... (e.g. the target)
-    loc: Optional[Loc]
-    statement_loc: Optional[Loc]
-    proof_loc: Optional[Loc]       # None => no proof clause at all (bare theorem)
+    name: str | None            # None for unnamed THEOREM ... (e.g. the target)
+    loc: Loc | None
+    statement_loc: Loc | None
+    proof_loc: Loc | None       # None => no proof clause at all (bare theorem)
     proof_is_omitted: bool         # True => PROOF OMITTED
     references: list[str]          # theorem/lemma names cited by BY/USE/DEFS
     statement_references: list[str]
@@ -68,7 +67,7 @@ class Theorem:
         return f"<unnamed L{line}>"
 
     @classmethod
-    def parse(cls, d: dict) -> "Theorem":
+    def parse(cls, d: dict) -> Theorem:
         return cls(
             name=d.get("name"),
             loc=Loc.parse(d.get("loc")),
@@ -84,13 +83,13 @@ class Theorem:
 
 @dataclass
 class Assumption:
-    name: Optional[str]
+    name: str | None
     is_axiom: bool                 # True => AXIOM, False => ASSUME/ASSUMPTION
-    loc: Optional[Loc]
+    loc: Loc | None
     references: list[str]
 
     @classmethod
-    def parse(cls, d: dict) -> "Assumption":
+    def parse(cls, d: dict) -> Assumption:
         return cls(
             name=d.get("name"),
             is_axiom=bool(d.get("is_axiom", False)),
@@ -101,13 +100,13 @@ class Assumption:
 
 @dataclass
 class Instance:
-    name: Optional[str]            # e.g. "C" in `C == INSTANCE Consensus`
-    module: Optional[str]          # the instantiated module name
-    loc: Optional[Loc]
+    name: str | None            # e.g. "C" in `C == INSTANCE Consensus`
+    module: str | None          # the instantiated module name
+    loc: Loc | None
     references: list[str]
 
     @classmethod
-    def parse(cls, d: dict) -> "Instance":
+    def parse(cls, d: dict) -> Instance:
         return cls(
             name=d.get("name"),
             module=d.get("module"),
@@ -119,13 +118,13 @@ class Instance:
 @dataclass
 class Operator:
     name: str
-    loc: Optional[Loc]
+    loc: Loc | None
     is_spec_formula: bool
-    body_kind: Optional[str]
+    body_kind: str | None
     references: list[str]
 
     @classmethod
-    def parse(cls, d: dict) -> "Operator":
+    def parse(cls, d: dict) -> Operator:
         return cls(
             name=d.get("name"),
             loc=Loc.parse(d.get("loc")),
@@ -139,18 +138,18 @@ class Operator:
 class Symbol:
     """A CONSTANT or VARIABLE declaration."""
     name: str
-    loc: Optional[Loc]
+    loc: Loc | None
 
     @classmethod
-    def parse(cls, d: dict) -> "Symbol":
+    def parse(cls, d: dict) -> Symbol:
         return cls(name=d.get("name"), loc=Loc.parse(d.get("loc")))
 
 
 @dataclass
 class Module:
     name: str
-    source_file: Optional[str]
-    filename: Optional[str]
+    source_file: str | None
+    filename: str | None
     line_start: int
     line_end: int
     extends: list[str]
@@ -164,7 +163,7 @@ class Module:
     raw: dict = field(default_factory=dict, repr=False)
 
     @classmethod
-    def parse(cls, d: dict) -> "Module":
+    def parse(cls, d: dict) -> Module:
         return cls(
             name=d.get("module"),
             source_file=d.get("source_file"),

--- a/src/tlacore/provenance.py
+++ b/src/tlacore/provenance.py
@@ -20,32 +20,57 @@ from dataclasses import dataclass, field
 
 # Standard library / prover modules — never agent-created, never scanned.
 STDLIB = {
-    "Integers", "Naturals", "Reals", "Sequences", "FiniteSets", "Bags",
-    "TLC", "TLAPS", "RealTime", "Folds", "Functions", "Json",
-    "FiniteSetTheorems", "FunctionTheorems", "SequenceTheorems",
-    "NaturalsInduction", "WellFoundedInduction", "BagsTheorems",
+    "Integers",
+    "Naturals",
+    "Reals",
+    "Sequences",
+    "FiniteSets",
+    "Bags",
+    "TLC",
+    "TLAPS",
+    "RealTime",
+    "Folds",
+    "Functions",
+    "Json",
+    "FiniteSetTheorems",
+    "FunctionTheorems",
+    "SequenceTheorems",
+    "NaturalsInduction",
+    "WellFoundedInduction",
+    "BagsTheorems",
     "CommunityModules",
     # Vendored CommunityModules (lib/community/) the tlaplus/Examples imports
     # EXTEND by individual module name. Kept in sync with COMMUNITY_MODULES in
     # src/dataset/level1/generate.py.
-    "SequencesExt", "SequencesExtTheorems", "FiniteSetsExt", "FunctionsExt",
-    "BagsExt", "Relation", "Graphs", "GraphsExt", "Combinatorics",
-    "DyadicRationals", "Bitwise", "Statistics", "VectorClocks", "IOUtils",
-    "CSV", "SVG", "TLCExt", "Randomization",
+    "SequencesExt",
+    "SequencesExtTheorems",
+    "FiniteSetsExt",
+    "FunctionsExt",
+    "BagsExt",
+    "Relation",
+    "Graphs",
+    "GraphsExt",
+    "Combinatorics",
+    "DyadicRationals",
+    "Bitwise",
+    "Statistics",
+    "VectorClocks",
+    "IOUtils",
+    "CSV",
+    "SVG",
+    "TLCExt",
+    "Randomization",
 }
 
 
 def _module_names(tla_dir: str) -> set[str]:
-    return {
-        os.path.splitext(os.path.basename(f))[0]
-        for f in glob.glob(os.path.join(tla_dir, "*.tla"))
-    }
+    return {os.path.splitext(os.path.basename(f))[0] for f in glob.glob(os.path.join(tla_dir, "*.tla"))}
 
 
 @dataclass
 class Provenance:
-    target: str                       # the benchmark module name (e.g. "VoteProof_Liveness")
-    given: set[str] = field(default_factory=set)        # module names provided by the benchmark
+    target: str  # the benchmark module name (e.g. "VoteProof_Liveness")
+    given: set[str] = field(default_factory=set)  # module names provided by the benchmark
     agent_created: dict[str, str] = field(default_factory=dict)  # name -> .tla path
 
     def is_given(self, module_name: str) -> bool:
@@ -55,8 +80,7 @@ class Provenance:
         return module_name in self.agent_created
 
 
-def classify(solution_dir: str, target_name: str,
-             benchmark_dir: str | None = None) -> Provenance:
+def classify(solution_dir: str, target_name: str, benchmark_dir: str | None = None) -> Provenance:
     """Classify the .tla files in ``solution_dir`` as given vs agent-created.
 
     Args:

--- a/src/tlacore/sany/dump.py
+++ b/src/tlacore/sany/dump.py
@@ -43,18 +43,17 @@ def dump_raw(tla_path: str, timeout: int = 180) -> dict:
     """Run SANY on ``tla_path`` and return the raw JSON dict."""
     res = subprocess.run(
         [_RUN_SH, tla_path],
-        capture_output=True, text=True, timeout=timeout,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
     )
     out = res.stdout
     idx = out.find(_MARKER)
     if idx < 0:
         err = (res.stderr or "").strip()
-        raise SanyError(
-            f"SANY produced no dump for {tla_path} (exit {res.returncode}). "
-            f"stderr: {err[:400]}"
-        )
+        raise SanyError(f"SANY produced no dump for {tla_path} (exit {res.returncode}). stderr: {err[:400]}")
     try:
-        return json.loads(out[idx + len(_MARKER):])
+        return json.loads(out[idx + len(_MARKER) :])
     except json.JSONDecodeError as e:
         raise SanyError(f"Could not parse SANY dump for {tla_path}: {e}") from e
 
@@ -97,8 +96,9 @@ def _as_dep_dirs(dep_dir, dep_dirs) -> list:
     return []
 
 
-def dump_normalized(tla_path: str, dep_dir: str | None = None,
-                    timeout: int = 180, dep_dirs: list | None = None) -> Module:
+def dump_normalized(
+    tla_path: str, dep_dir: str | None = None, timeout: int = 180, dep_dirs: list | None = None
+) -> Module:
     """Parse ``tla_path`` robustly: correct filename + supply dependency modules.
 
     Two real-world hurdles this clears:
@@ -119,8 +119,12 @@ def dump_normalized(tla_path: str, dep_dir: str | None = None,
     dirs = _as_dep_dirs(dep_dir, dep_dirs) or [os.path.dirname(os.path.abspath(tla_path))]
     base = os.path.basename(tla_path)
     # Fast path: filename matches AND a single dep dir == the file's own dir.
-    if mod and base == f"{mod}.tla" and len(dirs) == 1 and \
-            os.path.abspath(dirs[0]) == os.path.dirname(os.path.abspath(tla_path)):
+    if (
+        mod
+        and base == f"{mod}.tla"
+        and len(dirs) == 1
+        and os.path.abspath(dirs[0]) == os.path.dirname(os.path.abspath(tla_path))
+    ):
         return dump(tla_path, timeout=timeout)
 
     tmp = tempfile.mkdtemp(prefix="tlacore_sany_")
@@ -128,19 +132,17 @@ def dump_normalized(tla_path: str, dep_dir: str | None = None,
         for d in dirs:
             for dep in glob.glob(os.path.join(d, "*.tla")):
                 shutil.copy2(dep, os.path.join(tmp, os.path.basename(dep)))
-        target = os.path.join(tmp, f"{mod}.tla") if mod else \
-            os.path.join(tmp, base)
+        target = os.path.join(tmp, f"{mod}.tla") if mod else os.path.join(tmp, base)
         shutil.copy2(tla_path, target)
         return dump(target, timeout=timeout)
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 
 
-def try_dump_normalized(tla_path: str, dep_dir: str | None = None,
-                        timeout: int = 180,
-                        dep_dirs: list | None = None) -> Module | None:
+def try_dump_normalized(
+    tla_path: str, dep_dir: str | None = None, timeout: int = 180, dep_dirs: list | None = None
+) -> Module | None:
     try:
-        return dump_normalized(tla_path, dep_dir=dep_dir, timeout=timeout,
-                               dep_dirs=dep_dirs)
+        return dump_normalized(tla_path, dep_dir=dep_dir, timeout=timeout, dep_dirs=dep_dirs)
     except (SanyError, subprocess.TimeoutExpired, OSError):
         return None

--- a/src/tlacore/sany/dump.py
+++ b/src/tlacore/sany/dump.py
@@ -18,7 +18,6 @@ import re
 import shutil
 import subprocess
 import tempfile
-from typing import Optional
 
 from ..model import Module
 
@@ -65,7 +64,7 @@ def dump(tla_path: str, timeout: int = 180) -> Module:
     return Module.parse(dump_raw(tla_path, timeout=timeout))
 
 
-def try_dump(tla_path: str, timeout: int = 180) -> Optional[Module]:
+def try_dump(tla_path: str, timeout: int = 180) -> Module | None:
     """Like :func:`dump` but returns ``None`` on any SANY failure.
 
     Useful when scanning a set of files where some may legitimately fail to
@@ -80,7 +79,7 @@ def try_dump(tla_path: str, timeout: int = 180) -> Optional[Module]:
 _MODULE_DECL = re.compile(r"^-+\s*MODULE\s+(\w+)", re.MULTILINE)
 
 
-def module_name_of(tla_path: str) -> Optional[str]:
+def module_name_of(tla_path: str) -> str | None:
     """Read the declared module name from a .tla file's header."""
     try:
         with open(tla_path, encoding="utf-8", errors="ignore") as f:
@@ -98,8 +97,8 @@ def _as_dep_dirs(dep_dir, dep_dirs) -> list:
     return []
 
 
-def dump_normalized(tla_path: str, dep_dir: Optional[str] = None,
-                    timeout: int = 180, dep_dirs: Optional[list] = None) -> Module:
+def dump_normalized(tla_path: str, dep_dir: str | None = None,
+                    timeout: int = 180, dep_dirs: list | None = None) -> Module:
     """Parse ``tla_path`` robustly: correct filename + supply dependency modules.
 
     Two real-world hurdles this clears:
@@ -137,9 +136,9 @@ def dump_normalized(tla_path: str, dep_dir: Optional[str] = None,
         shutil.rmtree(tmp, ignore_errors=True)
 
 
-def try_dump_normalized(tla_path: str, dep_dir: Optional[str] = None,
+def try_dump_normalized(tla_path: str, dep_dir: str | None = None,
                         timeout: int = 180,
-                        dep_dirs: Optional[list] = None) -> Optional[Module]:
+                        dep_dirs: list | None = None) -> Module | None:
     try:
         return dump_normalized(tla_path, dep_dir=dep_dir, timeout=timeout,
                                dep_dirs=dep_dirs)

--- a/src/tlacore/sany/dump.py
+++ b/src/tlacore/sany/dump.py
@@ -56,7 +56,7 @@ def dump_raw(tla_path: str, timeout: int = 180) -> dict:
     try:
         return json.loads(out[idx + len(_MARKER):])
     except json.JSONDecodeError as e:
-        raise SanyError(f"Could not parse SANY dump for {tla_path}: {e}")
+        raise SanyError(f"Could not parse SANY dump for {tla_path}: {e}") from e
 
 
 def dump(tla_path: str, timeout: int = 180) -> Module:

--- a/src/tlacore/source.py
+++ b/src/tlacore/source.py
@@ -29,7 +29,7 @@ def strip_comments(text: str) -> str:
     return text
 
 
-def slice_loc(source: str, loc: "Loc") -> str:
+def slice_loc(source: str, loc: Loc) -> str:
     """Extract the substring of ``source`` covered by a SANY ``Loc`` (1-based)."""
     lines = source.splitlines()
     if not loc or loc.line_start < 1 or loc.line_start > len(lines):

--- a/src/tlacore/source.py
+++ b/src/tlacore/source.py
@@ -35,8 +35,8 @@ def slice_loc(source: str, loc: Loc) -> str:
     if not loc or loc.line_start < 1 or loc.line_start > len(lines):
         return ""
     if loc.line_start == loc.line_end:
-        return lines[loc.line_start - 1][loc.column_start - 1: loc.column_end]
-    out = [lines[loc.line_start - 1][loc.column_start - 1:]]
-    out.extend(lines[loc.line_start: loc.line_end - 1])
+        return lines[loc.line_start - 1][loc.column_start - 1 : loc.column_end]
+    out = [lines[loc.line_start - 1][loc.column_start - 1 :]]
+    out.extend(lines[loc.line_start : loc.line_end - 1])
     out.append(lines[loc.line_end - 1][: loc.column_end])
     return "\n".join(out)

--- a/src/tlacore/tlapm/invoke.py
+++ b/src/tlacore/tlapm/invoke.py
@@ -55,8 +55,12 @@ def run_killgroup(cmd: list[str], timeout: float, cwd: str) -> tuple[str, str, i
     ``subprocess.TimeoutExpired`` after cleanup.
     """
     proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
-        cwd=cwd, start_new_session=True,
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=cwd,
+        start_new_session=True,
     )
     try:
         out, err = proc.communicate(timeout=timeout)

--- a/src/tlacore/tlapm/invoke.py
+++ b/src/tlacore/tlapm/invoke.py
@@ -12,6 +12,7 @@ PPid-chain descendants *before* killing and SIGKILL each one, leaves-first.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import signal
 import subprocess
@@ -62,17 +63,11 @@ def run_killgroup(cmd: list[str], timeout: float, cwd: str) -> tuple[str, str, i
         return out, err, proc.returncode
     except subprocess.TimeoutExpired:
         escapees = _descendant_pids(proc.pid)
-        try:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            pass
         for pid in escapees:
-            try:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.kill(pid, signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
-                pass
-        try:
+        with contextlib.suppress(Exception):
             proc.communicate(timeout=10)
-        except Exception:
-            pass
         raise

--- a/src/tlacore/tlapm/locate.py
+++ b/src/tlacore/tlapm/locate.py
@@ -56,8 +56,7 @@ def find_tlapm_lib(tlapm_path: str) -> str | None:
     return None
 
 
-def resolve(tlapm: str | None = None,
-            tlapm_lib: str | None = None) -> tuple[str, str]:
+def resolve(tlapm: str | None = None, tlapm_lib: str | None = None) -> tuple[str, str]:
     """Resolve (tlapm_binary, tlapm_lib), raising if either cannot be found."""
     tlapm = tlapm or find_tlapm()
     if not tlapm:

--- a/src/tlacore/tlapm/locate.py
+++ b/src/tlacore/tlapm/locate.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import os
 import shutil
-from typing import Optional
 
 _BIN_CANDIDATES = [
     "/opt/tlapm/bin/tlapm",
@@ -22,7 +21,7 @@ _HERE = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", ".."))
 
 
-def find_community_lib() -> Optional[str]:
+def find_community_lib() -> str | None:
     """Return the vendored CommunityModules dir (lib/community/), or None.
 
     Honors the COMMUNITY_LIB env var, else looks under the repo root. Holds
@@ -34,7 +33,7 @@ def find_community_lib() -> Optional[str]:
     return cand if os.path.isdir(cand) else None
 
 
-def find_tlapm() -> Optional[str]:
+def find_tlapm() -> str | None:
     """Return the path to the tlapm binary, or None."""
     for cand in _BIN_CANDIDATES + [shutil.which("tlapm")]:
         if cand and os.path.isfile(cand):
@@ -42,7 +41,7 @@ def find_tlapm() -> Optional[str]:
     return None
 
 
-def find_tlapm_lib(tlapm_path: str) -> Optional[str]:
+def find_tlapm_lib(tlapm_path: str) -> str | None:
     """Derive the stdlib directory from the tlapm binary path.
 
     tlapm 1.6 keeps the stdlib at lib/tlapm/stdlib; 1.5 used lib/tlaps. The
@@ -57,8 +56,8 @@ def find_tlapm_lib(tlapm_path: str) -> Optional[str]:
     return None
 
 
-def resolve(tlapm: Optional[str] = None,
-            tlapm_lib: Optional[str] = None) -> tuple[str, str]:
+def resolve(tlapm: str | None = None,
+            tlapm_lib: str | None = None) -> tuple[str, str]:
     """Resolve (tlapm_binary, tlapm_lib), raising if either cannot be found."""
     tlapm = tlapm or find_tlapm()
     if not tlapm:

--- a/src/tlacore/tlapm/summary.py
+++ b/src/tlacore/tlapm/summary.py
@@ -14,7 +14,7 @@ import re
 from dataclasses import dataclass, field
 
 from .invoke import run_killgroup
-from .locate import resolve, find_community_lib
+from .locate import find_community_lib, resolve
 
 
 @dataclass

--- a/src/tlacore/tlapm/summary.py
+++ b/src/tlacore/tlapm/summary.py
@@ -38,8 +38,7 @@ class Summary:
 
 _OBL = re.compile(r"obligations_count\s*=\s*(\d+)")
 _MISS_TOP = re.compile(r"^\s*missing_proofs_count\s*=\s*(\d+)", re.MULTILINE)
-_SECTION = re.compile(
-    r"----\s+incomplete proof of theorem at line (\d+),\s*character \d+\s*----")
+_SECTION = re.compile(r"----\s+incomplete proof of theorem at line (\d+),\s*character \d+\s*----")
 _MISS_LOC = re.compile(r"missing_proof_\d+\s+at\s+line\s+(\d+)")
 
 
@@ -67,8 +66,9 @@ def parse_summary(output: str) -> Summary:
     return s
 
 
-def run_summary(tla_path: str, cwd: str, *, tlapm: str | None = None,
-                tlapm_lib: str | None = None, timeout: float = 600) -> Summary:
+def run_summary(
+    tla_path: str, cwd: str, *, tlapm: str | None = None, tlapm_lib: str | None = None, timeout: float = 600
+) -> Summary:
     """Run ``tlapm --summary`` on ``tla_path`` and return the parsed summary."""
     tlapm, tlapm_lib = resolve(tlapm, tlapm_lib)
     cmd = [tlapm, "--summary", "-I", tlapm_lib]

--- a/tests/tlacheck/test_rules.py
+++ b/tests/tlacheck/test_rules.py
@@ -25,8 +25,9 @@ FIX = os.path.join(os.path.dirname(__file__), "fixtures")
 
 def _ctx(name, baseline=None):
     m = dump(os.path.join(FIX, name + ".tla"))
-    return CheckContext(target_name=name, solution_dir=FIX, solution=m,
-                        baseline=baseline, provenance=Provenance(target=name))
+    return CheckContext(
+        target_name=name, solution_dir=FIX, solution=m, baseline=baseline, provenance=Provenance(target=name)
+    )
 
 
 def _agent_ctx(agent_name, solution_name=None):
@@ -40,9 +41,14 @@ def _agent_ctx(agent_name, solution_name=None):
     prov = Provenance(target=solution_name or "Target")
     prov.agent_created[agent_name] = path
     solution = dump(os.path.join(FIX, solution_name + ".tla")) if solution_name else None
-    return CheckContext(target_name=solution_name or "Target", solution_dir=FIX,
-                        solution=solution, baseline=None, provenance=prov,
-                        agent_modules={agent_name: dump(path)})
+    return CheckContext(
+        target_name=solution_name or "Target",
+        solution_dir=FIX,
+        solution=solution,
+        baseline=None,
+        provenance=prov,
+        agent_modules={agent_name: dump(path)},
+    )
 
 
 def _axiom_ctx(solution_name, baseline_name):
@@ -50,10 +56,14 @@ def _axiom_ctx(solution_name, baseline_name):
     sol_p = os.path.join(FIX, solution_name + ".tla")
     base_p = os.path.join(FIX, baseline_name + ".tla")
     return CheckContext(
-        target_name=solution_name, solution_dir=FIX,
-        solution=dump(sol_p), baseline=dump(base_p),
+        target_name=solution_name,
+        solution_dir=FIX,
+        solution=dump(sol_p),
+        baseline=dump(base_p),
         provenance=Provenance(target=solution_name),
-        solution_source=_read(sol_p), baseline_source=_read(base_p))
+        solution_source=_read(sol_p),
+        baseline_source=_read(base_p),
+    )
 
 
 def test_clean_proof_not_flagged():
@@ -91,16 +101,14 @@ def test_unreferenced_scratch_module_not_flagged():
     # Regression: agents leave scratch modules (test2.tla) in the workspace that
     # the real solution never EXTENDS. tlapm never loads them, so a smuggled
     # axiom there is inert — must NOT be flagged.
-    issues = smuggled_module.check(
-        _agent_ctx("SmuggledObvious", solution_name="ScratchSolution"))
+    issues = smuggled_module.check(_agent_ctx("SmuggledObvious", solution_name="ScratchSolution"))
     assert issues == [], f"unreferenced scratch module wrongly flagged: {issues}"
 
 
 def test_referenced_smuggled_module_flagged():
     # ...but when the solution DOES EXTEND the smuggled module, it is reachable
     # and the axiom is live — still caught.
-    issues = smuggled_module.check(
-        _agent_ctx("SmuggledObvious", solution_name="ImporterSolution"))
+    issues = smuggled_module.check(_agent_ctx("SmuggledObvious", solution_name="ImporterSolution"))
     assert any(i.vector == "SMUGGLED_MODULE" for i in issues), issues
 
 

--- a/tests/tlacheck/test_rules.py
+++ b/tests/tlacheck/test_rules.py
@@ -9,11 +9,11 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
-from tlacore.sany.dump import dump
-from tlacore.provenance import Provenance
 from tlacheck.context import CheckContext
-from tlacheck.rules import admitted_statement, smuggled_module, extra_axiom
 from tlacheck.issue import Severity
+from tlacheck.rules import admitted_statement, extra_axiom, smuggled_module
+from tlacore.provenance import Provenance
+from tlacore.sany.dump import dump
 
 
 def _read(p):

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,111 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
+name = "pyinstaller"
+version = "6.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/4d/ec706c3fcf39e26888c35b39615ff4d5865d184069666c47492cff1fbe50/pyinstaller-6.21.0.tar.gz", hash = "sha256:bb9fab705983e393a2d1cac77d6972513057ad800215fd861dc15ff5272e98fd", size = 4061519, upload-time = "2026-06-13T14:15:06.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/4a/53cf98bf66daed012dc9cd78c8203f19a675d696f2fc12afcf8c5049a0e0/pyinstaller-6.21.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:327d132389f37912609e01be62810cf96b5aa95b613903e4b8692e0d12fb0eda", size = 1052350, upload-time = "2026-06-13T14:13:55.88Z" },
+    { url = "https://files.pythonhosted.org/packages/30/83/b591295c352ef464c50b4c6ffff1c4f771d875c9e833f578d1b9f564f6b3/pyinstaller-6.21.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7071d4b094d5b40deeef5fa3d3b98a1b846087f7562b49209663d5f9281fe251", size = 748477, upload-time = "2026-06-13T14:14:00.327Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8f/88fff4e403873b1e22286911350e75ff00db014aa08e57045da9d4328993/pyinstaller-6.21.0-py3-none-manylinux2014_i686.whl", hash = "sha256:6b6374d652107dd4a2eeece903ff82bb4045bb5e1006c5a158a6dcdbefe84bf2", size = 760877, upload-time = "2026-06-13T14:14:04.836Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/13/f0e48fbdfd1d05d948157121cea8b1b823dcb89efe6934b71fdd8bdb3f0f/pyinstaller-6.21.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4e3108b3f02384560da70e39b8bf22b0ad597d02bd68a40d76ea91c1cfa00cad", size = 759194, upload-time = "2026-06-13T14:14:10.61Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d5/ea7878cf9924ed30d946d8288777424e6d069d94f5bde56b4d0890069664/pyinstaller-6.21.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:697532279f535ad572bda613db4f821540e235c7854ca6da4d3bf0373f4415ee", size = 754979, upload-time = "2026-06-13T14:14:15.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/09/51b8905714b733bac66dbc041a7821372d70d888d273ae474c4037d4202d/pyinstaller-6.21.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:605169523a6b5ace39f13dfbff21add9f2bc43df99c7daf9394fefb2c45e8b6f", size = 754812, upload-time = "2026-06-13T14:14:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/43/d77779439d8c6c2e27a77bcfbd1d5cc0f568ebb611bb472b11af81b5f177/pyinstaller-6.21.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:5fa56746c1e76f93634d018502301378a2d0c382553d37d8c3c34ff436c12dd1", size = 753887, upload-time = "2026-06-13T14:14:25.268Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/c22df1f6837784ac349057ba693f08e7b1ca7a0e06f9c33c63bc6280007b/pyinstaller-6.21.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:42395ec76df8e8120c36b13339d9db8cab83e316a12839ee303cc00fc941bb74", size = 753779, upload-time = "2026-06-13T14:14:29.445Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/76/1ce8a27ce62ba8cf3a87c9ce6d575610f4e55d7cb0123e7512fc3f4b921a/pyinstaller-6.21.0-py3-none-win32.whl", hash = "sha256:c6b28d30d8fd99ce162ff3aab5013ed44dbfb747566b1f01b9bed7964d7c14e9", size = 1336462, upload-time = "2026-06-13T14:14:35.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/ca1d7e5257dd8566a9dfc0dfb02f8a8075eeb53d4b2d3c579f1276759042/pyinstaller-6.21.0-py3-none-win_amd64.whl", hash = "sha256:7fae06c494ce0ebfe6bd3055c0e409def884f63af2e3705d06bd431ad9237fc7", size = 1397487, upload-time = "2026-06-13T14:14:42.328Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/75/21b51523ce8d96629b71311775a0a65f5f5a872124ab0de33e5c848f8bff/pyinstaller-6.21.0-py3-none-win_arm64.whl", hash = "sha256:f13c95c9c03fb567217135919f93815c305813126780b0ed6e0123cb8acaf025", size = 1346094, upload-time = "2026-06-13T14:14:48.914Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/5b/c9fe0db5e83ee1c39b2258fa21d23b15e1a60786b6c5990ee5074ead8bb6/pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725", size = 173354, upload-time = "2026-06-08T22:37:16.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl", hash = "sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3", size = 457159, upload-time = "2026-06-08T22:37:14.722Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "tlaps-bench"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pyinstaller" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyinstaller", specifier = ">=6.21.0" }]


### PR DESCRIPTION
## Summary
Adds Ruff for linting and formatting. Applies auto-fixes and auto-format across the codebase.

## Changes
- **pyproject.toml**: Added `[tool.ruff]` configuration (lint rules + formatter settings)
- **pyproject.toml**: Moved `pyinstaller` from runtime dependencies to `[project.optional-dependencies] dev`
- Applied ruff auto-fixes and formatting to all Python files

The diff is 37 files / +1550,-1280 lines but almost entirely mechanical formatting and import reordering. Actual logic changes are minimal (file handle fixes, exception chaining).

## Why Ruff?
We had no linting or formatting tooling. Stuff like unused imports, bare `open()` without `with`, deprecated `typing.Optional` patterns, and inconsistent style could go unnoticed.

Ruff is a single tool that handles both linting and formatting. It catches:

- Undefined variables and unused imports (F/pyflakes rules)
- Common bugs and code smells (B/flake8-bugbear rules)
- Outdated Python patterns that can be modernized (UP/pyupgrade rules)
- Unnecessarily complex code that can be simplified (SIM/flake8-simplify rules)
- Unsorted or improperly grouped imports (I/isort rules)
- Style issues like incorrect whitespace and line formatting (E/pycodestyle rules)

More rules [here](https://docs.astral.sh/ruff/rules/) if we want to add anything else.

## What the auto-fixes did
- `Optional[X]` → `X | None` (we require Python ≥ 3.12)
- Bare `open(...).read()` → proper `with open(...) as f:` blocks
- `try/except: pass` → `contextlib.suppress(...)` where appropriate
- Exception chaining (`raise ... from e`)
- Removed unused imports and variables
- Import sorting
- Consistent double-quote style and line-length formatting (120 chars)

Reviewed all the changes (auto safe fix, auto unsafe fix, manual changes). No behavioral differences except the resource-management fixes (file handles, exception chaining) which should be strictly better.

## Setup (recommended for IDE integration)

Install the **Ruff** extension from the [VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff), then add to your `settings.json`:

```json
"[python]": {
    "editor.defaultFormatter": "charliermarsh.ruff",
    "editor.formatOnSave": true
},
"editor.codeActionsOnSave": {
    "source.fixAll": "explicit"
},
"editor.formatOnSaveMode": "modificationsIfAvailable"
```

## Usage

```bash
# Lint check
ruff check .

# Format check (dry-run, no changes)
ruff format --check .

# Auto-fix lint issues (safe fixes)
ruff check --fix .

# Auto-fix lint issues (unsafe fixes — changes should be reviewed)
ruff check --fix --unsafe-fixes .

# Auto-format
ruff format .

# Fix + format in one go
ruff check --fix . && ruff format .
```

## Pre-commit hook?

Did not add a pre-commit hook for now. Ruff is fast enough to run manually. If we want local enforcement we could add a `.pre-commit-config.yaml` or add a CI check instead. Any recommendation?

---

### Note
The setup and rules here are something I used for my work and also personal projects. Thought it might be helpful here too.
