### PR TITLE
Replace sys.path workaround with proper package imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ lib/                           Vendored: tla2tools.jar (gitignored)
 docker/                        Container build + isolation
 ```
 
+### Setup
+
+Requires Python ≥ 3.12, Java 21 (for SANY), and [uv](https://docs.astral.sh/uv/).
+
+```bash
+uv sync              # creates .venv and installs dependencies
+source .venv/bin/activate
+```
+
 ### Run the benchmark
 
 First build the checker binary (one-time, required before any run):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "tlaps-bench"
 version = "0.1.0"
@@ -6,7 +10,12 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pyinstaller>=6.21.0",
+    "pytest",
+    "ruff",
 ]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/tlacheck", "src/tlacore", "src/common", "src/evaluator", "src/dataset"]
 
 [tool.black]
 line-length = 120
@@ -52,3 +61,6 @@ known-first-party = ["common", "tlacheck", "tlacore", "evaluator", "dataset"]
 [tool.ruff.format]
 quote-style = "double"
 docstring-code-format = true
+
+[tool.ty.environment]
+python = ".venv"

--- a/scripts/import_tlaps_example.py
+++ b/scripts/import_tlaps_example.py
@@ -34,12 +34,7 @@ import shutil
 import sys
 from pathlib import Path
 
-# Single source of truth for module classification lives in the L1 generator.
-sys.path.insert(
-    0,
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src", "dataset", "level1"),
-)
-from generate import RESOLVABLE_MODULES  # noqa: E402
+from dataset.level1.generate import RESOLVABLE_MODULES
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SOURCE_ROOT = REPO_ROOT / "source"

--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -29,6 +29,7 @@ Exit codes:
 """
 
 import argparse
+import contextlib
 import glob
 import os
 import re
@@ -38,13 +39,7 @@ import subprocess
 import sys
 import tempfile
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-# Also expose the repo `src/` so the SANY gate can `import tlacheck`/`tlacore`
-# when running from source (frozen builds bundle them directly).
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-import contextlib
-
-from cheating_detection import (
+from common.cheating_detection import (
     detect_dependency_modification,
     detect_empty_proof,
     detect_extra_axioms,
@@ -452,20 +447,21 @@ def main():
         output_lines.append(line)
         print(line)
 
+    def write_result_and_exit(code):
+        with open(output_path, "w") as f:
+            f.write("\n".join(output_lines) + "\n")
+        sys.exit(code)
+
     # Find tlapm
     tlapm_path = args.tlapm or find_tlapm()
     if not tlapm_path:
         emit("ERROR: tlapm not found. Use --tlapm to specify path.")
-        with open(output_path, "w") as f:
-            f.write("\n".join(output_lines) + "\n")
-        sys.exit(3)
+        write_result_and_exit(3)
 
     tlapm_lib = args.tlapm_lib or find_tlapm_lib(tlapm_path)
     if not tlapm_lib:
         emit("ERROR: tlapm lib not found. Use --tlapm-lib to specify path.")
-        with open(output_path, "w") as f:
-            f.write("\n".join(output_lines) + "\n")
-        sys.exit(3)
+        write_result_and_exit(3)
 
     emit(f"Checking: {os.path.relpath(filepath)}")
     emit(f"tlapm: {tlapm_path}")
@@ -621,11 +617,8 @@ def main():
             emit(f"  ❌ FAIL — tlapm exit code {tlapm_exit}")
 
     # Write result file
-    with open(output_path, "w") as f:
-        f.write("\n".join(output_lines) + "\n")
-    emit(f"\nResult written to: {output_path}")
-
-    sys.exit(exit_code)
+    print(f"\nResult written to: {output_path}")
+    write_result_and_exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/src/common/validate.py
+++ b/src/common/validate.py
@@ -25,12 +25,9 @@ import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 
-# Internal imports — generate.py is in ../dataset/level1, cheating_detection here.
-_HERE = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, _HERE)
-sys.path.insert(0, os.path.join(_HERE, "..", "dataset", "level1"))
-from cheating_detection import CheatingIssue  # noqa: E402
-from generate import (  # noqa: E402
+# Internal imports
+from common.cheating_detection import CheatingIssue
+from dataset.level1.generate import (
     BENCHMARK_DIR,
     PROJECT_ROOT,
     SOURCE_ROOT,
@@ -498,7 +495,7 @@ def main():
     counts = {"PASS": 0, "FAIL": 0, "OMITTED": 0, "ERROR": 0, "NO_PROOF": 0}
 
     def on_result(r, idx, total):
-        counts[r.status] = counts.get(r.status, 0) + 1
+        counts[r.status] += 1
         status_icon = {"PASS": "✅", "FAIL": "❌", "OMITTED": "⏭️", "ERROR": "💥", "NO_PROOF": "🔍"}.get(r.status, "❓")
         summary = f"[✅{counts['PASS']} ❌{counts['FAIL']} ⏭️{counts['OMITTED']} 💥{counts['ERROR']}]"
         print(f"  [{idx}/{total}] {status_icon} {r.benchmark_file} ({r.tlapm_time_secs:.1f}s)  {summary}", flush=True)

--- a/src/common/validate.py
+++ b/src/common/validate.py
@@ -26,7 +26,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 
 # Internal imports
-from common.cheating_detection import CheatingIssue
+from common.cheating_detection import CheatingIssue, detect_proof_omitted
 from dataset.level1.generate import (
     BENCHMARK_DIR,
     PROJECT_ROOT,
@@ -314,8 +314,6 @@ def validate_single_benchmark(args_tuple):
         result.tlapm_passed = exit_code == 0
 
         # Only check if source proof uses PROOF OMITTED (placeholder, not a real proof)
-        from cheating_detection import detect_proof_omitted
-
         result.cheating_issues = detect_proof_omitted(proof_text)
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/src/dataset/level2/generate.py
+++ b/src/dataset/level2/generate.py
@@ -84,8 +84,7 @@ BENCHMARK_DIR = os.path.join(PROJECT_ROOT, "benchmark", "level2")
 SANY_DUMP = os.path.join(PROJECT_ROOT, "src", "dataset", "sany-dump", "run.sh")
 
 # Reuse L1's proof-stripping logic for dependency .tla copies.
-sys.path.insert(0, os.path.join(PROJECT_ROOT, "src", "dataset", "level1"))
-from generate import (  # noqa: E402
+from dataset.level1.generate import (  # noqa: E402
     STDLIB_MODULES,
     parse_extends,
     parse_instances,
@@ -736,6 +735,7 @@ def process_file(
     with open(source_path, encoding="utf-8") as f:
         text = f.read()
     source_lines = text.splitlines(keepends=True)
+    base_module = os.path.splitext(os.path.basename(source_path))[0]
 
     try:
         dump = dump_sany(source_path)
@@ -778,16 +778,14 @@ def process_file(
                 f"{line} has no manual TLAPS proof body — skipped (filter A)\n"
             )
         elif (
-            os.path.splitext(os.path.basename(source_path))[0],
+            base_module,
             target_theorem_name(target_thm)[0],
         ) in KNOWN_FALSE_TARGETS:
             # Filter A' — drop ONLY a goal TLC has shown to be false. An OMITTED
             # sub-step that papers over a *false* claim (e.g. PaxosProof
             # StructOK3) admits no honest proof, so it must not become a
             # benchmark. See KNOWN_FALSE_TARGETS for the per-target evidence.
-            reason = KNOWN_FALSE_TARGETS[
-                (os.path.splitext(os.path.basename(source_path))[0], target_theorem_name(target_thm)[0])
-            ]
+            reason = KNOWN_FALSE_TARGETS[(base_module, target_theorem_name(target_thm)[0])]
             audit_writer.write(
                 f"[level2-audit] {source_path}: top-level THEOREM {name} at line "
                 f"{line} asserts a FALSE goal — skipped (filter A', known-false): "
@@ -875,7 +873,6 @@ def process_file(
                 f.write(model_text)
             print(f"  generated model: {os.path.relpath(model_path, PROJECT_ROOT)}")
 
-    base_module = os.path.splitext(os.path.basename(source_path))[0]
     used_names = set()
     count = 0
     for target_thm, _, _, _ in top_level:

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -15,6 +15,7 @@ Usage:
 """
 
 import argparse
+import contextlib
 import glob
 import json
 import os
@@ -30,16 +31,14 @@ import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 
-# Allow `python3 src/evaluator/runner.py` as well as module import.
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import contextlib
-
-from backends import get_backend, list_backends  # noqa: E402
-from levels import get_level, list_levels  # noqa: E402
+from evaluator.backends import get_backend, list_backends
+from evaluator.levels import get_level, list_levels
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # File at <repo>/src/evaluator/runner.py — ascend two levels for repo root.
 REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
+
+VERDICT_ICONS = {"PASS": "✅", "FAIL": "❌", "CHEATING": "⚠️", "TIMEOUT": "⏱️", "ERROR": "💥"}
 
 
 def resolve_paths():
@@ -341,7 +340,7 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, level_na
         for v in ["PASS", "FAIL", "CHEATING", "TIMEOUT", "ERROR"]:
             count = verdicts.get(v, 0)
             if count > 0:
-                icon = {"PASS": "✅", "FAIL": "❌", "CHEATING": "⚠️", "TIMEOUT": "⏱️", "ERROR": "💥"}[v]
+                icon = VERDICT_ICONS[v]
                 lines.append(f"| {icon} {v} | {count} |")
         lines.append("")
 
@@ -349,9 +348,7 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, level_na
         lines.append("| Benchmark | Verdict | Time | Obligations | Tokens (in/out) | Notes |")
         lines.append("|-----------|---------|------|-------------|-----------------|-------|")
         for r in sorted(results, key=lambda x: x["benchmark"]):
-            icon = {"PASS": "✅", "FAIL": "❌", "CHEATING": "⚠️", "TIMEOUT": "⏱️", "ERROR": "💥"}.get(
-                r["check_verdict"], "❓"
-            )
+            icon = VERDICT_ICONS.get(r["check_verdict"], "❓")
             notes = r.get("error", "")
             tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
             if "obligations" in r:
@@ -765,7 +762,6 @@ def main():
         )
 
     start_time = time.time()
-    icons = {"PASS": "✅", "FAIL": "❌", "CHEATING": "⚠️", "TIMEOUT": "⏱️", "ERROR": "💥"}
     total_benchmarks = len(benchmark_files)
     prior_done = len(results)
     if args.resume:
@@ -775,7 +771,7 @@ def main():
         for i, item in enumerate(work_items):
             r = run_single_benchmark(item)
             results.append(r)
-            icon = icons.get(r["check_verdict"], "❓")
+            icon = VERDICT_ICONS.get(r["check_verdict"], "❓")
             tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
             print(
                 f"[{prior_done + i + 1}/{total_benchmarks}] {icon} {r['benchmark']} ({r['time_secs']:.0f}s, {tokens} tok)"
@@ -787,7 +783,7 @@ def main():
             for done_count, future in enumerate(as_completed(futures), start=1):
                 r = future.result()
                 results.append(r)
-                icon = icons.get(r["check_verdict"], "❓")
+                icon = VERDICT_ICONS.get(r["check_verdict"], "❓")
                 tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
                 print(
                     f"[{prior_done + done_count}/{total_benchmarks}] {icon} {r['benchmark']} ({r['time_secs']:.0f}s, {tokens} tok)"
@@ -809,7 +805,7 @@ def main():
         verdicts[v] = verdicts.get(v, 0) + 1
     for v in ["PASS", "FAIL", "CHEATING", "TIMEOUT", "ERROR"]:
         if v in verdicts:
-            print(f"  {icons.get(v, '❓')} {v}: {verdicts[v]}")
+            print(f"  {VERDICT_ICONS.get(v, '❓')} {v}: {verdicts[v]}")
     total_in = sum(r.get("input_tokens", 0) for r in results)
     total_out = sum(r.get("output_tokens", 0) for r in results)
     print(f"  Total tokens: {total_in:,} input / {total_out:,} output")

--- a/tests/tlacheck/test_rules.py
+++ b/tests/tlacheck/test_rules.py
@@ -4,10 +4,7 @@ Run: PYTHONPATH=src python3 -m pytest tests/tlacheck/test_rules.py
 (or just: PYTHONPATH=src python3 tests/tlacheck/test_rules.py)
 """
 
-import os
-import sys
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+from pathlib import Path
 
 from tlacheck.context import CheckContext
 from tlacheck.issue import Severity
@@ -15,16 +12,15 @@ from tlacheck.rules import admitted_statement, extra_axiom, smuggled_module
 from tlacore.provenance import Provenance
 from tlacore.sany.dump import dump
 
-
-def _read(p):
-    return open(p, encoding="utf-8", errors="ignore").read()
+FIX = str(Path(__file__).parent / "fixtures")
 
 
-FIX = os.path.join(os.path.dirname(__file__), "fixtures")
+def _fixture_path(name):
+    return str(Path(FIX) / (name + ".tla"))
 
 
 def _ctx(name, baseline=None):
-    m = dump(os.path.join(FIX, name + ".tla"))
+    m = dump(_fixture_path(name))
     return CheckContext(
         target_name=name, solution_dir=FIX, solution=m, baseline=baseline, provenance=Provenance(target=name)
     )
@@ -37,10 +33,10 @@ def _agent_ctx(agent_name, solution_name=None):
     reachability filter can see whether the solution actually imports the agent
     module); otherwise solution is None.
     """
-    path = os.path.join(FIX, agent_name + ".tla")
+    path = _fixture_path(agent_name)
     prov = Provenance(target=solution_name or "Target")
     prov.agent_created[agent_name] = path
-    solution = dump(os.path.join(FIX, solution_name + ".tla")) if solution_name else None
+    solution = dump(_fixture_path(solution_name)) if solution_name else None
     return CheckContext(
         target_name=solution_name or "Target",
         solution_dir=FIX,
@@ -53,16 +49,16 @@ def _agent_ctx(agent_name, solution_name=None):
 
 def _axiom_ctx(solution_name, baseline_name):
     """Context with a parsed solution + baseline and their sources (for extra_axiom)."""
-    sol_p = os.path.join(FIX, solution_name + ".tla")
-    base_p = os.path.join(FIX, baseline_name + ".tla")
+    sol_p = _fixture_path(solution_name)
+    base_p = _fixture_path(baseline_name)
     return CheckContext(
         target_name=solution_name,
         solution_dir=FIX,
         solution=dump(sol_p),
         baseline=dump(base_p),
         provenance=Provenance(target=solution_name),
-        solution_source=_read(sol_p),
-        baseline_source=_read(base_p),
+        solution_source=Path(sol_p).read_text(encoding="utf-8", errors="ignore"),
+        baseline_source=Path(base_p).read_text(encoding="utf-8", errors="ignore"),
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,24 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
@@ -39,6 +57,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -82,12 +118,53 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+]
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
+    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
 ]
 
 [[package]]
@@ -102,10 +179,16 @@ wheels = [
 [[package]]
 name = "tlaps-bench"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "pyinstaller" },
+    { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pyinstaller", specifier = ">=6.21.0" }]
+requires-dist = [
+    { name = "pyinstaller", specifier = ">=6.21.0" },
+    { name = "pytest" },
+    { name = "ruff" },
+]


### PR DESCRIPTION
Replace sys.path.insert() workarounds with standard package imports now that the project has a proper build system (pyproject.toml + uv).

Scripts and modules now **require `uv sync` + venv activation**. Bare `python3 scripts/foo.py` no longer works without the package installed.

- Remove sys.path manipulation from scripts and src modules
- Add pytest/ruff to dependencies
- Document setup in README (Python ≥ 3.12, Java 21, uv sync)
- Minor code deduplication