### PR TITLE
Add one-command native setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: build clean
+CHECKER_SOURCES := \
+	src/common/__init__.py \
+	src/common/check_proof.py \
+	src/common/cheating_detection.py \
+	$(shell find src/tlacheck src/tlacore -type f -name '*.py')
 
-check_proof_bin: src/common/check_proof.py src/common/cheating_detection.py
-	pyinstaller --onefile --name check_proof_bin \
+.PHONY: setup build clean
+
+check_proof_bin: $(CHECKER_SOURCES)
+	uv run --locked pyinstaller --onefile --name check_proof_bin \
 		--paths src/common --paths src \
 		--collect-submodules tlacheck \
 		--collect-submodules tlacore \
@@ -10,6 +16,9 @@ check_proof_bin: src/common/check_proof.py src/common/cheating_detection.py
 	rm -rf dist/ build/ check_proof_bin.spec
 
 build: check_proof_bin
+
+setup:
+	bash scripts/setup.sh
 
 clean:
 	rm -f check_proof_bin

--- a/README.md
+++ b/README.md
@@ -143,18 +143,29 @@ lib/                           Vendored: tla2tools.jar (gitignored)
 docker/                        Container build + isolation
 ```
 
-### Setup
+### Setup (Linux x86-64)
 
-Requires Python ≥ 3.12, Java 21 (for SANY), and [uv](https://docs.astral.sh/uv/).
+Native setup requires GNU Make, `curl`, `tar`, [uv](https://docs.astral.sh/uv/),
+and a JDK 21 or newer (`java` and `javac`). The project itself requires Python
+≥ 3.12; `uv` selects or installs a compatible Python automatically.
+
+From the repository root, run:
 
 ```bash
-uv sync              # creates .venv, installs deps + the `tlaps-bench` command
-source .venv/bin/activate
+make setup
 ```
 
-This installs a single `tlaps-bench` CLI with subcommands for every operation
-below (`tlaps-bench --help` lists them; `tlaps-bench <command> --help` shows a
-command's full flag set):
+This one idempotent command syncs the locked Python environment, installs the
+pinned tlapm/Apalache/SANY dependencies, compiles the SANY semantic dumper,
+builds `check_proof_bin`, and runs a fast SANY smoke test. It is safe to rerun.
+Missing system prerequisites and a moved TLAPM rolling-release pin are reported
+as actionable errors. Allow roughly 3 GB of free disk space: the first run
+downloads an approximately 850 MB TLAPM archive and installs about 1.7 GB of
+external tools.
+
+`make setup` also installs a single `tlaps-bench` CLI with subcommands for every
+operation below (`tlaps-bench --help` lists them; `tlaps-bench <command> --help`
+shows a command's full flag set):
 
 | Command | Does |
 |---|---|
@@ -164,15 +175,14 @@ command's full flag set):
 | `tlaps-bench generate` | Generate benchmarks (`--level level1`/`level2`) |
 | `tlaps-bench score` | Score / aggregate results (not implemented yet) |
 
+Virtualenv activation is optional: run `source .venv/bin/activate` once so the
+`tlaps-bench` command is on your `PATH`, or leave the venv inactive and prefix
+each command below with `uv run` (e.g. `uv run tlaps-bench run --filter GCD_GCD3`).
+
 ### Run the benchmark
 
-First build the checker binary (one-time, required before any run):
-
-```bash
-make            # produces ./check_proof_bin via PyInstaller
-```
-
-Then drive the runner. It is `--backend` × `--level` parameterised — pick one of each.
+`make setup` builds the checker binary required by the runner. The runner is
+`--backend` × `--level` parameterised — pick one of each.
 
 ```bash
 # Single benchmark, L1, Codex (default backend, default level)
@@ -193,7 +203,11 @@ tlaps-bench run --backend copilot --jobs 40
 tlaps-bench run --backend copilot --model gpt-5.5 --jobs 40
 ```
 
-Requires: tlapm 1.6 pre-release at `~/.tlapm/` (or `/tmp/tlapm/` as a host-only fallback the runner will copy on first use) and the relevant agent CLI on `PATH` — [OpenAI Codex CLI](https://github.com/openai/codex) for `--backend codex`, [Claude Code](https://github.com/anthropics/claude-code) for `--backend claude_code`, [GitHub Copilot CLI](https://github.com/github/copilot-cli) for `--backend copilot`.
+`make setup` installs the pinned tlapm 1.6 pre-release at `~/.tlapm/`. Each run
+also requires the relevant agent CLI on `PATH` — [OpenAI Codex CLI](https://github.com/openai/codex)
+for `--backend codex`, [Claude Code](https://github.com/anthropics/claude-code) for
+`--backend claude_code`, or [GitHub Copilot CLI](https://github.com/github/copilot-cli)
+for `--backend copilot`.
 
 ### Usage monitoring & quota gate (Claude Max)
 
@@ -227,6 +241,7 @@ token are absent — so it never blocks a run it can't measure.
 ### Run with Docker (recommended)
 
 ```bash
+make setup
 cd docker && bash build.sh
 # Set the API key(s) your chosen backend needs:
 #   OPENAI_API_KEY (or AZURE_OPENAI_API_KEY + AZURE_OPENAI_HOST) for codex
@@ -236,7 +251,9 @@ docker-compose run bench python3 /scripts/runner.py --jobs 40                   
 docker-compose run bench python3 /scripts/runner.py --backend claude_code --level level2 --jobs 40
 ```
 
-The container mounts the whole `benchmark/` tree and the prebuilt `check_proof_bin`, so make sure you've run `make` on the host first. Docker blocks access to GitHub/TLA+ sites to prevent data leakage.
+The container mounts the whole `benchmark/` tree. `make setup` prepares the
+prebuilt checker and SANY assets consumed by `docker/build.sh`. Docker blocks
+access to GitHub/TLA+ sites to prevent data leakage.
 
 ### Validate benchmarks
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -33,6 +33,56 @@ COMMUNITY_URL="https://github.com/tlaplus/CommunityModules/archive/refs/tags/${C
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LIB_DIR="${REPO_ROOT}/lib"
 
+TMP_DIRS=()
+cleanup() {
+  local path
+  for path in "${TMP_DIRS[@]}"; do
+    rm -rf "${path}"
+  done
+}
+trap cleanup EXIT
+
+die() {
+  echo "[install_deps] ERROR: $*" >&2
+  exit 1
+}
+
+download() {
+  local url="$1"
+  local destination="$2"
+  local description="$3"
+  local progress=(--silent)
+  if [[ -t 2 ]]; then
+    progress=(--progress-bar)
+  fi
+  echo "[install_deps] downloading ${description}..."
+  if ! curl --fail --location --show-error "${progress[@]}" \
+    --output "${destination}" "${url}"; then
+    die "failed to download ${description} from ${url}"
+  fi
+}
+
+apalache_version() {
+  "$1" version 2>/dev/null | sed -n '1p'
+}
+
+valid_tla2tools() {
+  local output
+  output="$(java -cp "$1" tla2sany.SANY -help 2>&1 || true)"
+  [[ "${output}" == *"SANY - provides parsing"* ]]
+}
+
+require_disk_space() {
+  local path="$1"
+  local required_kb="$2"
+  local description="$3"
+  local available_kb
+  available_kb="$(df -Pk "${path}" | awk 'NR == 2 { print $4 }')"
+  if [[ "${available_kb}" =~ ^[0-9]+$ ]] && (( available_kb < required_kb )); then
+    die "${description} requires at least $((required_kb / 1024 / 1024)) GB free at ${path}; only $((available_kb / 1024 / 1024)) GB is available"
+  fi
+}
+
 # --- tlapm ---
 # Pin by commit, not mere presence: the rolling tag means an existing ~/.tlapm
 # may be an older build (e.g. one without --strict), so re-install on mismatch.
@@ -40,57 +90,108 @@ if [[ -x "${HOME}/.tlapm/bin/tlapm" ]] \
    && "${HOME}/.tlapm/bin/tlapm" --version 2>/dev/null | grep -q "${TLAPM_COMMIT}"; then
   echo "[install_deps] tlapm ${TLAPM_COMMIT} already at ~/.tlapm — skipping"
 else
-  echo "[install_deps] installing tlapm ${TLAPM_TAG} (${TLAPM_COMMIT})..."
-  curl -fsSL -o "/tmp/${TLAPM_ASSET}" "${TLAPM_URL}"
-  rm -rf "${HOME}/.tlapm" "${HOME}/tlapm"
-  tar -xzf "/tmp/${TLAPM_ASSET}" -C "${HOME}/" # extracts to ~/tlapm/
-  mv "${HOME}/tlapm" "${HOME}/.tlapm"
-  rm -f "/tmp/${TLAPM_ASSET}"
-  rm -f "${HOME}/.tlapm/bin/tlapm_lsp" 2>/dev/null || true
-  installed="$("${HOME}/.tlapm/bin/tlapm" --version 2>/dev/null | head -1 || true)"
-  if ! echo "${installed}" | grep -q "${TLAPM_COMMIT}"; then
-    echo "[install_deps] WARNING: tlapm version '${installed}' != expected ${TLAPM_COMMIT};" >&2
-    echo "[install_deps]          the rolling 1.6.0-pre asset has moved — bump TLAPM_COMMIT." >&2
+  echo "[install_deps] installing tlapm ${TLAPM_TAG} (${TLAPM_COMMIT});"
+  echo "[install_deps] the download is about 850 MB and may take several minutes."
+  require_disk_space "${HOME}" $((2 * 1024 * 1024)) "The tlapm installation"
+  require_disk_space "${TMPDIR:-/tmp}" $((3 * 1024 * 1024)) "Downloading and extracting tlapm"
+  TLAPM_TMP="$(mktemp -d)"
+  TMP_DIRS+=("${TLAPM_TMP}")
+  download "${TLAPM_URL}" "${TLAPM_TMP}/${TLAPM_ASSET}" "tlapm ${TLAPM_TAG}"
+  tar -xzf "${TLAPM_TMP}/${TLAPM_ASSET}" -C "${TLAPM_TMP}/"
+
+  STAGED_TLAPM="${TLAPM_TMP}/tlapm"
+  if [[ ! -x "${STAGED_TLAPM}/bin/tlapm" ]]; then
+    echo "[install_deps] ERROR: downloaded archive does not contain an executable bin/tlapm." >&2
+    exit 1
   fi
+  installed="$("${STAGED_TLAPM}/bin/tlapm" --version 2>/dev/null | sed -n '1p' || true)"
+  if [[ "${installed}" != *"${TLAPM_COMMIT}"* ]]; then
+    echo "[install_deps] ERROR: downloaded tlapm version '${installed:-unknown}'" >&2
+    echo "[install_deps]        does not contain expected commit ${TLAPM_COMMIT}." >&2
+    echo "[install_deps]        The rolling ${TLAPM_TAG} asset has moved. Run 'git pull'" >&2
+    echo "[install_deps]        and retry; if this persists, TLAPM_COMMIT and the" >&2
+    echo "[install_deps]        Dockerfile pin must be updated together." >&2
+    echo "[install_deps]        Any existing ~/.tlapm installation was left unchanged." >&2
+    exit 1
+  fi
+
+  rm -f "${STAGED_TLAPM}/bin/tlapm_lsp" 2>/dev/null || true
+  rm -rf "${HOME}/.tlapm"
+  mv "${STAGED_TLAPM}" "${HOME}/.tlapm"
 fi
 
 # --- Apalache ---
+APALACHE_MARKER="${HOME}/.apalache/.tlaps-bench-version"
+existing_apalache=""
 if [[ -x "${HOME}/.apalache/bin/apalache-mc" ]]; then
-  echo "[install_deps] Apalache already at ~/.apalache — skipping"
+  if [[ -f "${APALACHE_MARKER}" ]]; then
+    existing_apalache="$(<"${APALACHE_MARKER}")"
+  else
+    existing_apalache="$(apalache_version "${HOME}/.apalache/bin/apalache-mc" || true)"
+  fi
+fi
+if [[ "${existing_apalache}" == "${APALACHE_VERSION}" ]]; then
+  printf '%s\n' "${APALACHE_VERSION}" > "${APALACHE_MARKER}"
+  echo "[install_deps] Apalache ${APALACHE_VERSION} already at ~/.apalache — skipping"
 else
-  echo "[install_deps] downloading Apalache ${APALACHE_TAG}..."
-  curl -fsSL -o "/tmp/${APALACHE_ASSET}" "${APALACHE_URL}"
-  rm -rf "${HOME}/.apalache" "${HOME}/apalache-${APALACHE_VERSION}"
-  tar -xzf "/tmp/${APALACHE_ASSET}" -C "${HOME}/"  # extracts to ~/apalache-<version>/
-  mv "${HOME}/apalache-${APALACHE_VERSION}" "${HOME}/.apalache"
-  rm -f "/tmp/${APALACHE_ASSET}"
+  APALACHE_TMP="$(mktemp -d)"
+  TMP_DIRS+=("${APALACHE_TMP}")
+  download "${APALACHE_URL}" "${APALACHE_TMP}/${APALACHE_ASSET}" "Apalache ${APALACHE_TAG}"
+  tar -xzf "${APALACHE_TMP}/${APALACHE_ASSET}" -C "${APALACHE_TMP}/"
+  STAGED_APALACHE="${APALACHE_TMP}/apalache-${APALACHE_VERSION}"
+  [[ -x "${STAGED_APALACHE}/bin/apalache-mc" ]] \
+    || die "downloaded Apalache archive does not contain bin/apalache-mc"
+  installed_apalache="$(apalache_version "${STAGED_APALACHE}/bin/apalache-mc" || true)"
+  [[ "${installed_apalache}" == "${APALACHE_VERSION}" ]] \
+    || die "downloaded Apalache version '${installed_apalache:-unknown}' != expected ${APALACHE_VERSION}; existing installation was left unchanged"
+  printf '%s\n' "${APALACHE_VERSION}" > "${STAGED_APALACHE}/.tlaps-bench-version"
+  rm -rf "${HOME}/.apalache"
+  mv "${STAGED_APALACHE}" "${HOME}/.apalache"
 fi
 
 # --- tla2tools.jar (SANY) ---
 mkdir -p "${LIB_DIR}"
-if [[ -f "${LIB_DIR}/tla2tools.jar" ]]; then
-  echo "[install_deps] tla2tools.jar already at lib/ — skipping"
+TLATOOLS_MARKER="${LIB_DIR}/.tla2tools-version"
+if [[ -f "${LIB_DIR}/tla2tools.jar" \
+      && -f "${TLATOOLS_MARKER}" \
+      && "$(<"${TLATOOLS_MARKER}")" == "${TLATOOLS_TAG}" ]] \
+      && valid_tla2tools "${LIB_DIR}/tla2tools.jar"; then
+  echo "[install_deps] tla2tools.jar ${TLATOOLS_TAG} already at lib/ — skipping"
 else
-  echo "[install_deps] downloading tla2tools.jar ${TLATOOLS_TAG}..."
-  curl -fsSL -o "${LIB_DIR}/tla2tools.jar" "${TLATOOLS_URL}"
+  TLATOOLS_TMP="$(mktemp -d)"
+  TMP_DIRS+=("${TLATOOLS_TMP}")
+  download "${TLATOOLS_URL}" "${TLATOOLS_TMP}/tla2tools.jar" "tla2tools.jar ${TLATOOLS_TAG}"
+  valid_tla2tools "${TLATOOLS_TMP}/tla2tools.jar" \
+    || die "downloaded tla2tools.jar failed the SANY validation check; existing file was left unchanged"
+  mv -f "${TLATOOLS_TMP}/tla2tools.jar" "${LIB_DIR}/tla2tools.jar"
+  printf '%s\n' "${TLATOOLS_TAG}" > "${TLATOOLS_MARKER}"
 fi
 
 # --- CommunityModules (.tla) ---
-if [[ -f "${LIB_DIR}/community/SequencesExt.tla" ]]; then
-  echo "[install_deps] CommunityModules already at lib/community/ — skipping"
+COMMUNITY_MARKER="${LIB_DIR}/community/.tlaps-bench-version"
+if [[ -f "${LIB_DIR}/community/SequencesExt.tla" \
+      && -f "${COMMUNITY_MARKER}" \
+      && "$(<"${COMMUNITY_MARKER}")" == "${COMMUNITY_TAG}" ]]; then
+  echo "[install_deps] CommunityModules ${COMMUNITY_TAG} already at lib/community/ — skipping"
 else
-  echo "[install_deps] downloading CommunityModules ${COMMUNITY_TAG}..."
   CM_TMP="$(mktemp -d)"
-  curl -fsSL -o "${CM_TMP}/community.tar.gz" "${COMMUNITY_URL}"
+  TMP_DIRS+=("${CM_TMP}")
+  download "${COMMUNITY_URL}" "${CM_TMP}/community.tar.gz" "CommunityModules ${COMMUNITY_TAG}"
   tar -xzf "${CM_TMP}/community.tar.gz" -C "${CM_TMP}/"
-  mkdir -p "${LIB_DIR}/community"
-  cp "${CM_TMP}/CommunityModules-${COMMUNITY_TAG}/modules/"*.tla "${LIB_DIR}/community/"
-  rm -rf "${CM_TMP}"
+  STAGED_COMMUNITY="${CM_TMP}/community"
+  mkdir -p "${STAGED_COMMUNITY}"
+  cp "${CM_TMP}/CommunityModules-${COMMUNITY_TAG}/modules/"*.tla "${STAGED_COMMUNITY}/"
+  [[ -f "${STAGED_COMMUNITY}/SequencesExt.tla" ]] \
+    || die "downloaded CommunityModules archive is missing SequencesExt.tla"
+  printf '%s\n' "${COMMUNITY_TAG}" > "${STAGED_COMMUNITY}/.tlaps-bench-version"
+  rm -rf "${LIB_DIR}/community"
+  mv "${STAGED_COMMUNITY}" "${LIB_DIR}/community"
 fi
 
 echo "[install_deps] done."
 echo
 echo "Versions:"
-"${HOME}/.tlapm/bin/tlapm" --version | sed 's/^/  tlapm:    /'
-"${HOME}/.apalache/bin/apalache-mc" 2>&1 | grep -i version | head -1 | sed 's/^/  apalache: /' || true
-java -cp "${LIB_DIR}/tla2tools.jar" tla2sany.SANY 2>&1 | head -1 | sed 's/^/  sany:     /' || true
+echo "  tlapm:           ${TLAPM_TAG} (${TLAPM_COMMIT})"
+echo "  Apalache:        ${APALACHE_VERSION}"
+echo "  tla2tools/SANY:  ${TLATOOLS_TAG}"
+echo "  CommunityModules: ${COMMUNITY_TAG}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Prepare a native Linux x86-64 checkout for benchmark development and runs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+log() {
+  echo "[setup] $*"
+}
+
+die() {
+  echo "[setup] ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  local command_name="$1"
+  local install_hint="$2"
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    die "${command_name} is required. ${install_hint} Then rerun: make setup"
+  fi
+}
+
+version_major() {
+  local version="$1"
+  version="${version%%[-+]*}"
+  if [[ "${version}" == 1.* ]]; then
+    version="${version#1.}"
+  fi
+  echo "${version%%.*}"
+}
+
+check_java() {
+  local java_line java_version java_major
+  java_line="$(java -version 2>&1 | sed -n '1p')"
+  java_version="$(sed -nE 's/.*version "([^"]+)".*/\1/p' <<<"${java_line}")"
+  [[ -n "${java_version}" ]] || die "could not determine the Java version from: ${java_line}"
+  java_major="$(version_major "${java_version}")"
+  [[ "${java_major}" =~ ^[0-9]+$ ]] || die "could not parse the Java version from: ${java_line}"
+  (( java_major >= 21 )) || die "Java 21 or newer is required; found ${java_version}. Install a JDK 21+ package, then rerun: make setup"
+
+  local javac_line javac_version javac_major
+  javac_line="$(javac -version 2>&1 | sed -n '1p')"
+  javac_version="${javac_line#javac }"
+  javac_major="$(version_major "${javac_version}")"
+  [[ "${javac_major}" =~ ^[0-9]+$ ]] || die "could not parse the javac version from: ${javac_line}"
+  (( javac_major >= 21 )) || die "javac 21 or newer is required; found ${javac_version}. Install a JDK 21+ package, then rerun: make setup"
+
+  log "Java ${java_version} and javac ${javac_version}"
+}
+
+main() {
+  cd "${REPO_ROOT}"
+
+  local host_os host_arch
+  host_os="$(uname -s)"
+  host_arch="$(uname -m)"
+  if [[ "${host_os}" != "Linux" || "${host_arch}" != "x86_64" ]]; then
+    die "native setup currently supports Linux x86-64 only; detected ${host_os} ${host_arch}."
+  fi
+
+  require_command make "Install GNU Make (Ubuntu/Debian: sudo apt-get install make)."
+  require_command curl "Install curl (Ubuntu/Debian: sudo apt-get install curl)."
+  require_command tar "Install tar (Ubuntu/Debian: sudo apt-get install tar)."
+  require_command uv "Install uv with: curl -LsSf https://astral.sh/uv/install.sh | sh."
+  require_command java "Install a JDK 21+ package (Ubuntu/Debian: sudo apt-get install openjdk-21-jdk)."
+  require_command javac "A JRE is not sufficient; install a JDK 21+ package (Ubuntu/Debian: sudo apt-get install openjdk-21-jdk)."
+  check_java
+
+  log "syncing the locked Python environment..."
+  uv sync --locked
+
+  log "installing pinned TLAPS dependencies..."
+  bash "${REPO_ROOT}/scripts/install_deps.sh"
+
+  local sany_source sany_class tla2tools
+  sany_source="${REPO_ROOT}/src/dataset/sany-dump/DumpSemantics.java"
+  sany_class="${REPO_ROOT}/src/dataset/sany-dump/build/DumpSemantics.class"
+  tla2tools="${REPO_ROOT}/lib/tla2tools.jar"
+  if [[ ! -f "${sany_class}" || "${sany_source}" -nt "${sany_class}" || "${tla2tools}" -nt "${sany_class}" ]]; then
+    log "compiling the SANY semantic dumper..."
+    bash "${REPO_ROOT}/src/dataset/sany-dump/build.sh"
+  else
+    log "SANY semantic dumper is up to date — skipping compilation"
+  fi
+
+  if env -u MAKEFLAGS make --no-print-directory --question build; then
+    log "check_proof_bin is up to date — skipping build"
+  else
+    log "building check_proof_bin (the first build can take about a minute)..."
+    env -u MAKEFLAGS make --no-print-directory build
+  fi
+
+  log "running the SANY smoke test..."
+  local smoke_output
+  if ! smoke_output="$(
+    SANY_RUN_SH="${REPO_ROOT}/src/dataset/sany-dump/run.sh" \
+      TLAPS_LIB="${HOME}/.tlapm/lib/tlapm/stdlib" \
+      COMMUNITY_LIB="${REPO_ROOT}/lib/community" \
+      "${REPO_ROOT}/check_proof_bin" \
+      "${REPO_ROOT}/benchmark/level1/Euclid/GCD_GCD3.tla" --sany-only 2>&1
+  )"; then
+    echo "${smoke_output}" >&2
+    die "the SANY smoke test failed."
+  fi
+  if [[ "${smoke_output}" != *"SANY OK"* ]]; then
+    echo "${smoke_output}" >&2
+    die "the SANY smoke test could not run successfully."
+  fi
+
+  log "setup complete. Run a benchmark with:"
+  echo "  uv run tlaps-bench run --filter GCD_GCD3"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/src/dataset/sany-dump/build.sh
+++ b/src/dataset/sany-dump/build.sh
@@ -15,5 +15,8 @@ mkdir -p "$BUILD"
 # Target Java 21 bytecode: the docker image ships a Java 21 JRE, so compiling
 # with a newer JDK (e.g. 25) would emit class files the container can't load
 # (UnsupportedClassVersionError). --release 21 pins the bytecode version.
-javac --release 21 -cp "$TLA2TOOLS" -d "$BUILD" "$SCRIPT_DIR/DumpSemantics.java"
+if ! compiler_output="$(javac --release 21 -cp "$TLA2TOOLS" -d "$BUILD" "$SCRIPT_DIR/DumpSemantics.java" 2>&1)"; then
+  echo "$compiler_output" >&2
+  exit 1
+fi
 echo "built: $BUILD/DumpSemantics.class"

--- a/src/dataset/sany-dump/run.sh
+++ b/src/dataset/sany-dump/run.sh
@@ -6,7 +6,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 TLA2TOOLS="$REPO_ROOT/lib/tla2tools.jar"
 BUILD="$SCRIPT_DIR/build"
 if [[ ! -f "$BUILD/DumpSemantics.class" \
-      || "$SCRIPT_DIR/DumpSemantics.java" -nt "$BUILD/DumpSemantics.class" ]]; then
+      || "$SCRIPT_DIR/DumpSemantics.java" -nt "$BUILD/DumpSemantics.class" \
+      || "$TLA2TOOLS" -nt "$BUILD/DumpSemantics.class" ]]; then
   bash "$SCRIPT_DIR/build.sh" >&2
 fi
 # TLAPS stdlib must be on the SANY search path so EXTENDS TLAPS resolves.


### PR DESCRIPTION
## Summary

- Add `make setup` as the recommended one-command native setup path, backed by `scripts/setup.sh`.
- Have setup run the full required local preparation flow: `uv sync --locked`, pinned TLAPS dependency install, SANY dumper compilation, `check_proof_bin` build, and a fast SANY smoke test.
- Make setup safe to rerun by skipping already-current tlapm, Apalache, tla2tools, CommunityModules, SANY, and checker artifacts.
- Harden first-run dependency handling with Java 21+ checks, disk-space checks, staged installs, tlapm commit verification, version markers, and clearer actionable errors.
- Rebuild `check_proof_bin` when checker-related `common`, `tlacheck`, or `tlacore` sources change.
- Ensure the SANY semantic dumper is rebuilt when its Java dependency changes.
- Update README setup/run/Docker instructions so a new user starts with `make setup` and then uses the `tlaps-bench` CLI.

This also aligns the setup docs with the CLI entry point added in #10.
