### PR TITLE
Cheat checker: framework

### DIFF
--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -738,7 +738,6 @@ def main():
                 tlapm_obligations_proved=(not obligation_failed and tlapm_exit in (0, 11)),
                 n_missing=n_missing,
                 sany_valid=(sany_status != "invalid"),
-                graded_on_canonical=(args.benchmark_dir is not None),
                 preamble_modified=legacy_preamble_modified,
                 proof_omitted=legacy_proof_omitted,
             )

--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -742,6 +742,28 @@ def main():
     try:
         from tlacheck.gates import from_tlacheck, grade
 
+        # Legacy-only signals (not tlacheck vectors): L1 preamble byte-match and
+        # agent-added PROOF OMITTED. Computed here, with the same detectors the
+        # authoritative check uses, so the gates stay at least as strict as today.
+        shadow_preamble_modified = False
+        shadow_proof_omitted = False
+        try:
+            with open(filepath) as _f:
+                _sol_text = _f.read()
+            if args.level == 1:
+                _main = get_main_version(filepath)
+                if _main:
+                    _main_lines = _main.split("\n")
+                    _po = find_proof_obvious_line(_main_lines)
+                    if _po is not None:
+                        _cur_lines = _sol_text.split("\n")
+                        shadow_preamble_modified = bool(detect_preamble_modification(_main_lines, _cur_lines, _po))
+                        shadow_proof_omitted = bool(detect_proof_omitted("\n".join(_cur_lines[_po:])))
+            else:
+                shadow_proof_omitted = bool(detect_proof_omitted(_sol_text))
+        except Exception:
+            pass
+
         shadow = grade(
             from_tlacheck(
                 engine_result,
@@ -749,6 +771,8 @@ def main():
                 n_missing=n_missing,
                 sany_valid=(sany_status != "invalid"),
                 graded_on_canonical=(args.benchmark_dir is not None),
+                preamble_modified=shadow_preamble_modified,
+                proof_omitted=shadow_proof_omitted,
             )
         )
         emit()

--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -373,8 +373,10 @@ def run_tlacheck_engine(filepath, target_name, summary_output, tlapm_passed, ben
     """Run the compiled-in SANY + incomplete-proof cheat engine.
 
     Folds CHEATING and INCOMPLETE findings into one list — any of them must fail
-    the run. On any internal error returns ([], reason) so the engine never
-    spuriously fails an otherwise-valid proof. ``benchmark_dir`` (when the runner
+    the run. Returns ``(issue_strings, reason, result)`` where ``result`` is the
+    tlacheck ``Result`` (or ``None`` on any internal error, so the engine never
+    spuriously fails an otherwise-valid proof — ``result`` also feeds the shadow
+    gate-framework verdict). ``benchmark_dir`` (when the runner
     supplies the canonical read-only module dir) is the tamper-proof provenance
     oracle; otherwise we reconstruct it from the git root commit.
     """
@@ -383,7 +385,7 @@ def run_tlacheck_engine(filepath, target_name, summary_output, tlapm_passed, ben
         from tlacheck.engine import evaluate
         from tlacore.tlapm.summary import parse_summary
     except Exception as e:
-        return [], f"tlacheck import failed: {e}"
+        return [], f"tlacheck import failed: {e}", None
 
     cleanup = []
     try:
@@ -391,7 +393,7 @@ def run_tlacheck_engine(filepath, target_name, summary_output, tlapm_passed, ben
         bench = benchmark_dir or git_bench
         if sol_dir is None:
             if benchmark_dir is None:
-                return [], "no git baseline available"
+                return [], "no git baseline available", None
             sol_dir = os.path.dirname(os.path.abspath(filepath))
         summary = parse_summary(summary_output) if summary_output else None
         ctx = build_context(
@@ -405,12 +407,12 @@ def run_tlacheck_engine(filepath, target_name, summary_output, tlapm_passed, ben
         )
         res = evaluate(ctx)
     except Exception as e:
-        return [], f"tlacheck error: {e}"
+        return [], f"tlacheck error: {e}", None
     finally:
         for d in cleanup:
             shutil.rmtree(d, ignore_errors=True)
 
-    return ([str(i) for i in res.cheating_issues] + [str(i) for i in res.incomplete_issues]), ""
+    return ([str(i) for i in res.cheating_issues] + [str(i) for i in res.incomplete_issues]), "", res
 
 
 # Machine-readable marker the runner greps for to set the structured
@@ -670,7 +672,7 @@ def main():
     # ANY helper lemma (not just the target). Runs on every check so the agent
     # gets the same verdict the grader does. Any finding fails the run.
     target_name = os.path.splitext(os.path.basename(filepath))[0]
-    engine_issues, engine_reason = run_tlacheck_engine(
+    engine_issues, engine_reason, engine_result = run_tlacheck_engine(
         filepath, target_name, summary_output, tlapm_passed, benchmark_dir=args.benchmark_dir
     )
     if engine_reason:
@@ -729,6 +731,35 @@ def main():
             emit(f"  ❌ FAIL — timeout after {args.timeout}s")
         else:
             emit(f"  ❌ FAIL — tlapm exit code {tlapm_exit}")
+
+    # --- Shadow: consolidated gate-framework verdict (W1) --------------------
+    # Run the A/B/C gate grader (src/tlacheck/gates.py) alongside the
+    # authoritative verdict above. INFORMATIONAL ONLY — it never changes
+    # exit_code; it lets us validate the consolidated grader against the live
+    # checker before cutover. Wrapped so it can never break the real check.
+    # Known gap: legacy-only checks (L1 preamble byte-match, PROOF OMITTED regex)
+    # aren't migrated onto the gates yet, so a verdict may differ for those.
+    try:
+        from tlacheck.gates import from_tlacheck, grade
+
+        shadow = grade(
+            from_tlacheck(
+                engine_result,
+                tlapm_obligations_proved=(not obligation_failed and tlapm_exit in (0, 11)),
+                n_missing=n_missing,
+                sany_valid=(sany_status != "invalid"),
+                graded_on_canonical=(args.benchmark_dir is not None),
+            )
+        )
+        emit()
+        emit("  [shadow] gate-framework verdict: " + ("PASS" if shadow.passed else "FAIL"))
+        for reason in shadow.reasons:
+            emit(f"    {reason}")
+        if shadow.passed != (exit_code == 0):
+            emit("  [shadow] NOTE: differs from authoritative verdict "
+                 "(expected where legacy-only checks aren't migrated yet)")
+    except Exception as e:  # shadow must never break the authoritative check
+        emit(f"  [shadow] gate-framework skipped ({e})")
 
     # Write result file
     print(f"\nResult written to: {output_path}")

--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -19,12 +19,12 @@ Levels:
 Output:
     - Raw tlapm output (preserved verbatim)
     - Cheating check (compares against main branch where applicable)
-    - Summary verdict: PASS / FAIL / CHEATING
+    - Binary verdict: PASS / FAIL. A cheat is not a separate verdict — it is just
+      a FAIL; the failing gate is shown in the output and on a GATES-FAILED line.
 
 Exit codes:
     0 = PASS
-    1 = FAIL (proof doesn't verify)
-    2 = CHEATING (tampering detected)
+    1 = FAIL (proof doesn't verify, or a soundness gate failed)
     3 = ERROR (could not run check)
 """
 
@@ -514,12 +514,12 @@ def main():
     if args.sany_only:
         status, detail = check_sany_valid(filepath)
         if status == "valid":
-            print("✅ SANY OK — parses under standalone tla2sany")
+            print("SANY OK — parses under standalone tla2sany")
             sys.exit(0)
         if status == "invalid":
-            print(f"❌ FAIL {SANY_INVALID_MARKER} — {detail[:300]}")
+            print(f"FAIL {SANY_INVALID_MARKER} — {detail[:300]}")
             sys.exit(1)
-        print(f"⚠️  SANY check unavailable ({detail[:200]}) — could not run; not treated as invalid")
+        print(f"WARNING: SANY check unavailable ({detail[:200]}) — could not run; not treated as invalid")
         sys.exit(0)
 
     # Set up output: write to file and stdout
@@ -697,93 +697,79 @@ def main():
     else:
         emit("  No cheating detected.")
 
-    # --- Step 3: Verdict ---
+    # --- Step 3: Verdict — BINARY pass/fail via the A/B/C gate framework ------
     emit()
     emit("=" * 60)
     emit("VERDICT")
     emit("=" * 60)
 
-    if real_issues:
-        exit_code = 2
-        emit(f"  ⚠️  CHEATING — {len(real_issues)} issue(s) found")
-    elif sany_status == "invalid":
-        # SANY-invalid is a FAIL (not a cheat), but a distinct one: the solution
-        # is rejected by the canonical parser even if tlapm's lenient parser
-        # accepted it. The marker lets the runner flag sany_valid=False.
-        exit_code = 1
-        emit(f"  ❌ FAIL {SANY_INVALID_MARKER} — solution does not parse under standalone tla2sany: {sany_detail[:200]}")
-    elif tlapm_passed:
-        exit_code = 0
-        emit("  ✅ PASS — all obligations proved")
-    else:
-        exit_code = 1
-        # Extract obligation summary
-        m = re.search(r"(\d+)/(\d+) obligation", tlapm_output)
-        if obligation_failed and m:
-            emit(f"  ❌ FAIL — {m.group(1)}/{m.group(2)} obligations failed")
-        elif obligation_failed:
-            emit(f"  ❌ FAIL — tlapm reported failed obligations (exit {tlapm_exit})")
-        elif n_missing > 0:
-            emit(f"  ❌ FAIL — proof incomplete: {n_missing} step(s) have no proof (tlapm --strict)")
-        elif tlapm_exit == 12:
-            emit("  ❌ FAIL — no proof obligation for the selected target (tlapm --strict)")
-        elif "TIMEOUT" in tlapm_output:
-            emit(f"  ❌ FAIL — timeout after {args.timeout}s")
+    # Legacy-only signals not yet a tlacheck vector (L1 preamble byte-match,
+    # agent-added PROOF OMITTED), computed with the same detectors the legacy
+    # path uses, so the gates capture everything the old checker did.
+    legacy_preamble_modified = False
+    legacy_proof_omitted = False
+    try:
+        with open(filepath) as _f:
+            _sol_text = _f.read()
+        if args.level == 1:
+            _main = get_main_version(filepath)
+            if _main:
+                _main_lines = _main.split("\n")
+                _po = find_proof_obvious_line(_main_lines)
+                if _po is not None:
+                    _cur = _sol_text.split("\n")
+                    legacy_preamble_modified = bool(detect_preamble_modification(_main_lines, _cur, _po))
+                    legacy_proof_omitted = bool(detect_proof_omitted("\n".join(_cur[_po:])))
         else:
-            emit(f"  ❌ FAIL — tlapm exit code {tlapm_exit}")
+            legacy_proof_omitted = bool(detect_proof_omitted(_sol_text))
+    except Exception:
+        pass
 
-    # --- Shadow: consolidated gate-framework verdict (W1) --------------------
-    # Run the A/B/C gate grader (src/tlacheck/gates.py) alongside the
-    # authoritative verdict above. INFORMATIONAL ONLY — it never changes
-    # exit_code; it lets us validate the consolidated grader against the live
-    # checker before cutover. Wrapped so it can never break the real check.
-    # Known gap: legacy-only checks (L1 preamble byte-match, PROOF OMITTED regex)
-    # aren't migrated onto the gates yet, so a verdict may differ for those.
+    # The gate framework (src/tlacheck/gates.py) is the authoritative grader:
+    # PASS iff identity AND discharge AND trust. "Cheating" is NOT a separate verdict
+    # — it is just a gate failing, so the outcome is binary PASS / FAIL.
+    grade_passed, grade_reasons, grade_gates = True, [], []
     try:
         from tlacheck.gates import from_tlacheck, grade
 
-        # Legacy-only signals (not tlacheck vectors): L1 preamble byte-match and
-        # agent-added PROOF OMITTED. Computed here, with the same detectors the
-        # authoritative check uses, so the gates stay at least as strict as today.
-        shadow_preamble_modified = False
-        shadow_proof_omitted = False
-        try:
-            with open(filepath) as _f:
-                _sol_text = _f.read()
-            if args.level == 1:
-                _main = get_main_version(filepath)
-                if _main:
-                    _main_lines = _main.split("\n")
-                    _po = find_proof_obvious_line(_main_lines)
-                    if _po is not None:
-                        _cur_lines = _sol_text.split("\n")
-                        shadow_preamble_modified = bool(detect_preamble_modification(_main_lines, _cur_lines, _po))
-                        shadow_proof_omitted = bool(detect_proof_omitted("\n".join(_cur_lines[_po:])))
-            else:
-                shadow_proof_omitted = bool(detect_proof_omitted(_sol_text))
-        except Exception:
-            pass
-
-        shadow = grade(
+        _gr = grade(
             from_tlacheck(
                 engine_result,
                 tlapm_obligations_proved=(not obligation_failed and tlapm_exit in (0, 11)),
                 n_missing=n_missing,
                 sany_valid=(sany_status != "invalid"),
                 graded_on_canonical=(args.benchmark_dir is not None),
-                preamble_modified=shadow_preamble_modified,
-                proof_omitted=shadow_proof_omitted,
+                preamble_modified=legacy_preamble_modified,
+                proof_omitted=legacy_proof_omitted,
             )
         )
-        emit()
-        emit("  [shadow] gate-framework verdict: " + ("PASS" if shadow.passed else "FAIL"))
-        for reason in shadow.reasons:
+        grade_passed, grade_reasons = _gr.passed, _gr.reasons
+        grade_gates = [g.value for g in _gr.failed_gates()]
+    except Exception as e:  # never let the grader crash the check
+        grade_reasons = [f"gate framework unavailable ({e}); fell back to legacy verdict"]
+        grade_passed = None  # signal: use legacy verdict alone
+
+    # Safety net during migration: the legacy path must also agree before we
+    # report PASS, so the consolidated grader can never be LESS strict than the
+    # checker it replaces. Validated equal on a real-solution corpus; kept until
+    # the legacy detectors are retired.
+    legacy_pass = (not real_issues) and (sany_status != "invalid") and tlapm_passed
+    passed = legacy_pass if grade_passed is None else (grade_passed and legacy_pass)
+
+    if passed:
+        exit_code = 0
+        emit("  PASS — target goal genuinely proved (identity and discharge and trust)")
+    else:
+        exit_code = 1
+        emit("  FAIL")
+        for reason in grade_reasons:
             emit(f"    {reason}")
-        if shadow.passed != (exit_code == 0):
-            emit("  [shadow] NOTE: differs from authoritative verdict "
-                 "(expected where legacy-only checks aren't migrated yet)")
-    except Exception as e:  # shadow must never break the authoritative check
-        emit(f"  [shadow] gate-framework skipped ({e})")
+        if sany_status == "invalid":
+            emit(f"    {SANY_INVALID_MARKER} {sany_detail[:200]}")
+        if grade_gates:
+            emit(f"  GATES-FAILED: {','.join(grade_gates)}")
+        if grade_passed and not legacy_pass:
+            emit("  FAIL: legacy safety-net flagged a failure the gates missed — investigate divergence")
 
     # Write result file
     print(f"\nResult written to: {output_path}")

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -604,6 +604,11 @@ def run_single_benchmark(item: WorkItem):
             # with [SANY-INVALID]; verdict stays FAIL but this distinguishes
             # "doesn't parse under standalone tla2sany" from "proof didn't verify".
             result["sany_valid"] = "[SANY-INVALID]" not in (check_proc.stdout or "")
+            # Which gate(s) failed (binary verdict keeps the analysis signal):
+            # A:identity / C:trust ~ tamper/cheat-type, B:discharge ~ incomplete.
+            gm = re.search(r"GATES-FAILED:\s*([^\n]+)", check_proc.stdout or "")
+            if gm:
+                result["failed_gates"] = [g.strip() for g in gm.group(1).split(",") if g.strip()]
             ob_matches = re.findall(r"All (\d+) obligation", check_proc.stdout)
             if ob_matches:
                 result["obligations"] = int(ob_matches[-1])

--- a/src/tlacheck/gates.py
+++ b/src/tlacheck/gates.py
@@ -1,39 +1,28 @@
 """Cheat-checker framework — the single sound-reduction predicate, as three gates.
 
-This module IS the framework (W0): a benchmark solution passes iff
+This module IS the framework: a benchmark solution passes iff
 
     PASS  ⟺  A (identity) ∧ B (discharge) ∧ C (trust)
 
   A — IDENTITY:  the thing that got proved IS the canonical target. The target
-                 statement / CONSTANT / VARIABLE / ASSUME and the definitions it
-                 depends on are unchanged; no new AXIOM/ASSUME; no smuggled
-                 module or definition; the file parses under standalone SANY.
+                 statement / CONSTANT / VARIABLE / ASSUME are unchanged (L1
+                 preamble byte-identical); no new AXIOM/ASSUME; no smuggled
+                 module; the file parses under standalone SANY.
   B — DISCHARGE: the target goal is genuinely discharged. tlapm proved every
                  generated obligation, no step is MISSING (bare QED / unproven
-                 helper / unfinished target), and the only admitted steps are
-                 exactly the baseline's GIVEN lemmas (no agent-added admit).
-  C — TRUST:     grading ran on trusted files — canonical read-only deps/model
-                 plus the agent's proof, in a sandbox, with tlapm unmodified.
+                 helper / unfinished target), the goal is not admitted as a
+                 restated lemma, and the agent added no PROOF OMITTED step.
+  C — TRUST:     grading ran on trusted files — a given dependency was not
+                 modified (deps / model are read-only).
 
 "Cheating" is NOT a separate verdict: a cheat is simply some gate failing, so the
-outcome is BINARY PASS/FAIL. The per-check reasons are kept for the agent's
-in-run formative feedback ("gate B: this obligation has no proof") — never as a
-CHEAT accusation. (See the project discussion: a sound reduction lets feedback be
-transparent because there is no exploitable gap left to game.)
+outcome is BINARY PASS / FAIL. The per-check reasons (concrete check name +
+explanation) are the agent's in-run formative feedback — never a CHEAT
+accusation. The A/B/C grouping organizes the checks for humans; the agent sees
+the concrete check, not the abstract gate label.
 
-This layer ORGANIZES existing detection onto the three gates (W1) and collapses
-to a binary verdict (W2). It is the consolidation point for logic currently
-spread across `tlacheck` rules, `tlapm --strict`, and the SANY validity check.
-
-SAFETY INVARIANT (walking-skeleton migration): not-yet-built stronger checks are
-PLACEHOLDERs that FAIL-OPEN. That is sound ONLY because the already-WIRED sibling
-checks still cover every known cheat vector, so this layer is never LESS strict
-than today's checker. Never delete a WIRED check before its stronger replacement
-(the PARTIAL/PLACEHOLDER it would subsume) actually lands.
-
-Roadmap (status per check below): W3 tighten admitted-set to a baseline set-diff;
-W4 semantic statement-match (catch operator redefinition); W5 trusted-file replay
-(discard dependency edits rather than merely detecting them).
+This is the consolidation point for logic spread across `tlacheck` rules,
+`tlapm --strict`, and the SANY validity check.
 """
 
 from __future__ import annotations
@@ -48,17 +37,10 @@ class Gate(str, Enum):
     C_TRUST = "C:trust"  # graded on trusted files
 
 
-class Status(str, Enum):
-    WIRED = "wired"  # real check, migrated from existing detection
-    PARTIAL = "partial"  # works now; to be tightened (see TODO in detail)
-    PLACEHOLDER = "placeholder"  # not implemented; FAIL-OPEN, covered by siblings
-
-
 @dataclass
 class Check:
     name: str
     gate: Gate
-    status: Status
     ok: bool
     detail: str = ""
 
@@ -67,10 +49,9 @@ class Check:
 class GraderInputs:
     """What the existing detectors found, normalized into gate inputs.
 
-    Computed by the caller (check_proof.py / the runner) from a tlacheck
-    ``Result`` + the ``tlapm --strict`` status + SANY validity; see
-    :func:`from_tlacheck`. Defaults are the "clean" values so a partially-filled
-    instance never spuriously fails.
+    Computed by the caller (check_proof.py) from a tlacheck ``Result`` + the
+    ``tlapm --strict`` status + SANY validity; see :func:`from_tlacheck`. Defaults
+    are the "clean" values so a partially-filled instance never spuriously fails.
     """
 
     # Gate A — identity
@@ -84,10 +65,8 @@ class GraderInputs:
     n_missing: int = 0  # `--strict` MISSING steps (agent gaps)
     admitted_goal: bool = False  # a helper restates the target and is admitted
     proof_omitted: bool = False  # agent added a PROOF OMITTED / bare OMITTED step
-    admitted_extra: bool = False  # agent added an admitted lemma beyond baseline (W3)
     # Gate C — trust
     deps_modified: bool = False  # a given dependency file was changed
-    graded_on_canonical: bool = False  # grading used canonical read-only files (W5)
 
 
 @dataclass
@@ -97,8 +76,8 @@ class GradeResult:
 
     @property
     def reasons(self) -> list[str]:
-        """Human/agent-facing reasons for any failing gate (formative feedback)."""
-        return [f"[{c.gate.value}] {c.name}: {c.detail}" for c in self.checks if not c.ok]
+        """Concrete failing-check reasons for agent feedback (no abstract gate prefix)."""
+        return [f"{c.name}: {c.detail}" for c in self.checks if not c.ok]
 
     def failed_gates(self) -> list[Gate]:
         return sorted({c.gate for c in self.checks if not c.ok}, key=lambda g: g.value)
@@ -119,63 +98,46 @@ VECTOR_GATE = {
 def grade(inp: GraderInputs) -> GradeResult:
     """Evaluate the three gates and collapse to a binary verdict."""
     checks = [
-        # ── Gate A: IDENTITY — the proved thing IS the canonical target ──────
-        Check("sany_valid", Gate.A_IDENTITY, Status.WIRED, inp.sany_valid,
+        # Gate A — identity: the proved thing IS the canonical target
+        Check("sany_valid", Gate.A_IDENTITY, inp.sany_valid,
               "solution does not parse under standalone tla2sany"),
-        Check("statement_unchanged", Gate.A_IDENTITY, Status.WIRED, not inp.statement_modified,
+        Check("statement_unchanged", Gate.A_IDENTITY, not inp.statement_modified,
               "target theorem statement was changed or weakened"),
-        Check("no_extra_axiom", Gate.A_IDENTITY, Status.WIRED, not inp.extra_axiom,
+        Check("no_extra_axiom", Gate.A_IDENTITY, not inp.extra_axiom,
               "a new AXIOM/ASSUME was introduced beyond the baseline"),
-        Check("no_smuggled_module", Gate.A_IDENTITY, Status.WIRED, not inp.smuggled_module,
+        Check("no_smuggled_module", Gate.A_IDENTITY, not inp.smuggled_module,
               "an agent-created module smuggles content into the proof"),
-        Check("preamble_unchanged", Gate.A_IDENTITY, Status.WIRED, not inp.preamble_modified,
+        Check("preamble_unchanged", Gate.A_IDENTITY, not inp.preamble_modified,
               "the L1 preamble (definitions / CONSTANT / VARIABLE / ASSUME above PROOF OBVIOUS) was modified"),
-        Check("no_smuggled_definition", Gate.A_IDENTITY, Status.PLACEHOLDER, True,
-              "TODO(W4) semantic statement-match: catch redefining an operator used in the "
-              "statement so the text is identical but the meaning is weaker"),
-        # ── Gate B: DISCHARGE — the target goal is genuinely proved ──────────
-        Check("obligations_proved", Gate.B_DISCHARGE, Status.WIRED, inp.tlapm_obligations_proved,
+        # Gate B — discharge: the target goal is genuinely proved
+        Check("obligations_proved", Gate.B_DISCHARGE, inp.tlapm_obligations_proved,
               "tlapm did not prove all generated obligations"),
-        Check("no_missing_steps", Gate.B_DISCHARGE, Status.WIRED, inp.n_missing == 0,
+        Check("no_missing_steps", Gate.B_DISCHARGE, inp.n_missing == 0,
               f"{inp.n_missing} step(s) have no proof (bare QED / unproven helper / unfinished target)"),
-        Check("no_admitted_goal", Gate.B_DISCHARGE, Status.WIRED, not inp.admitted_goal,
+        Check("no_admitted_goal", Gate.B_DISCHARGE, not inp.admitted_goal,
               "the target goal is restated as an admitted (unproven) helper lemma"),
-        Check("no_added_omitted", Gate.B_DISCHARGE, Status.WIRED, not inp.proof_omitted,
+        Check("no_added_omitted", Gate.B_DISCHARGE, not inp.proof_omitted,
               "the agent added a PROOF OMITTED / bare OMITTED step (an unproven admit)"),
-        Check("admitted_set_eq_baseline", Gate.B_DISCHARGE, Status.PARTIAL, not inp.admitted_extra,
-              "TODO(W3) tighten to admitted-set == baseline; an admitted lemma was added"),
-        # ── Gate C: TRUST — graded on trusted files ──────────────────────────
-        Check("deps_unmodified", Gate.C_TRUST, Status.WIRED, not inp.deps_modified,
+        # Gate C — trust: graded on trusted files
+        Check("deps_unmodified", Gate.C_TRUST, not inp.deps_modified,
               "a given dependency file was modified"),
-        Check("graded_on_canonical", Gate.C_TRUST, Status.PLACEHOLDER, True,
-              "TODO(W5) trusted replay: re-run tlapm on canonical read-only deps + the agent's "
-              "proof so dependency edits are discarded rather than merely detected"),
     ]
     return GradeResult(passed=all(c.ok for c in checks), checks=checks)
 
 
-def from_tlacheck(
-    result,
-    *,
-    tlapm_obligations_proved,
-    n_missing,
-    sany_valid,
-    graded_on_canonical=False,
-    preamble_modified=False,
-    proof_omitted=False,
-):
-    """Migrate existing detection onto the gate inputs (W1).
+def from_tlacheck(result, *, tlapm_obligations_proved, n_missing, sany_valid,
+                  preamble_modified=False, proof_omitted=False):
+    """Migrate existing detection onto the gate inputs.
 
     Buckets a tlacheck ``Result``'s issues (by vector, ignoring WARNINGs) together
     with the ``tlapm --strict`` status and SANY validity into a
     :class:`GraderInputs`. ``result`` is duck-typed: any object exposing
     ``.issues`` where each issue has ``.vector`` and ``.severity`` (with a
-    ``.value``/name distinguishing ``WARNING``).
+    ``.value`` distinguishing ``WARNING``).
 
     ``preamble_modified`` (L1 byte-match) and ``proof_omitted`` (agent-added
     PROOF OMITTED / bare OMITTED) are legacy-only detections that are not tlacheck
-    vectors; the caller computes them so the gates stay at least as strict as the
-    current checker.
+    vectors; the caller computes them.
     """
     vectors = {
         i.vector
@@ -192,9 +154,5 @@ def from_tlacheck(
         n_missing=n_missing,
         admitted_goal=bool(vectors & {"ADMITTED_STATEMENT", "ADMITTED_FALLBACK"}),
         proof_omitted=proof_omitted,
-        # admitted_extra (W3, the true baseline set-diff) is not computed yet; the
-        # WIRED no_admitted_goal check covers the known cases until W3 lands.
-        admitted_extra=False,
         deps_modified="DEPENDENCY_MODIFIED" in vectors,
-        graded_on_canonical=graded_on_canonical,
     )

--- a/src/tlacheck/gates.py
+++ b/src/tlacheck/gates.py
@@ -78,10 +78,12 @@ class GraderInputs:
     statement_modified: bool = False  # target statement changed / weakened
     extra_axiom: bool = False  # new AXIOM/ASSUME beyond baseline
     smuggled_module: bool = False  # agent-created module sneaking content in
+    preamble_modified: bool = False  # L1 preamble (defs/CONSTANT/VARIABLE/ASSUME) changed
     # Gate B — discharge
     tlapm_obligations_proved: bool = False  # every generated obligation PROVED, none failed
     n_missing: int = 0  # `--strict` MISSING steps (agent gaps)
     admitted_goal: bool = False  # a helper restates the target and is admitted
+    proof_omitted: bool = False  # agent added a PROOF OMITTED / bare OMITTED step
     admitted_extra: bool = False  # agent added an admitted lemma beyond baseline (W3)
     # Gate C — trust
     deps_modified: bool = False  # a given dependency file was changed
@@ -126,6 +128,8 @@ def grade(inp: GraderInputs) -> GradeResult:
               "a new AXIOM/ASSUME was introduced beyond the baseline"),
         Check("no_smuggled_module", Gate.A_IDENTITY, Status.WIRED, not inp.smuggled_module,
               "an agent-created module smuggles content into the proof"),
+        Check("preamble_unchanged", Gate.A_IDENTITY, Status.WIRED, not inp.preamble_modified,
+              "the L1 preamble (definitions / CONSTANT / VARIABLE / ASSUME above PROOF OBVIOUS) was modified"),
         Check("no_smuggled_definition", Gate.A_IDENTITY, Status.PLACEHOLDER, True,
               "TODO(W4) semantic statement-match: catch redefining an operator used in the "
               "statement so the text is identical but the meaning is weaker"),
@@ -136,6 +140,8 @@ def grade(inp: GraderInputs) -> GradeResult:
               f"{inp.n_missing} step(s) have no proof (bare QED / unproven helper / unfinished target)"),
         Check("no_admitted_goal", Gate.B_DISCHARGE, Status.WIRED, not inp.admitted_goal,
               "the target goal is restated as an admitted (unproven) helper lemma"),
+        Check("no_added_omitted", Gate.B_DISCHARGE, Status.WIRED, not inp.proof_omitted,
+              "the agent added a PROOF OMITTED / bare OMITTED step (an unproven admit)"),
         Check("admitted_set_eq_baseline", Gate.B_DISCHARGE, Status.PARTIAL, not inp.admitted_extra,
               "TODO(W3) tighten to admitted-set == baseline; an admitted lemma was added"),
         # ── Gate C: TRUST — graded on trusted files ──────────────────────────
@@ -148,7 +154,16 @@ def grade(inp: GraderInputs) -> GradeResult:
     return GradeResult(passed=all(c.ok for c in checks), checks=checks)
 
 
-def from_tlacheck(result, *, tlapm_obligations_proved, n_missing, sany_valid, graded_on_canonical=False):
+def from_tlacheck(
+    result,
+    *,
+    tlapm_obligations_proved,
+    n_missing,
+    sany_valid,
+    graded_on_canonical=False,
+    preamble_modified=False,
+    proof_omitted=False,
+):
     """Migrate existing detection onto the gate inputs (W1).
 
     Buckets a tlacheck ``Result``'s issues (by vector, ignoring WARNINGs) together
@@ -156,6 +171,11 @@ def from_tlacheck(result, *, tlapm_obligations_proved, n_missing, sany_valid, gr
     :class:`GraderInputs`. ``result`` is duck-typed: any object exposing
     ``.issues`` where each issue has ``.vector`` and ``.severity`` (with a
     ``.value``/name distinguishing ``WARNING``).
+
+    ``preamble_modified`` (L1 byte-match) and ``proof_omitted`` (agent-added
+    PROOF OMITTED / bare OMITTED) are legacy-only detections that are not tlacheck
+    vectors; the caller computes them so the gates stay at least as strict as the
+    current checker.
     """
     vectors = {
         i.vector
@@ -167,9 +187,11 @@ def from_tlacheck(result, *, tlapm_obligations_proved, n_missing, sany_valid, gr
         statement_modified="STATEMENT_MODIFIED" in vectors,
         extra_axiom="EXTRA_AXIOM" in vectors,
         smuggled_module="SMUGGLED_MODULE" in vectors,
+        preamble_modified=preamble_modified,
         tlapm_obligations_proved=tlapm_obligations_proved,
         n_missing=n_missing,
         admitted_goal=bool(vectors & {"ADMITTED_STATEMENT", "ADMITTED_FALLBACK"}),
+        proof_omitted=proof_omitted,
         # admitted_extra (W3, the true baseline set-diff) is not computed yet; the
         # WIRED no_admitted_goal check covers the known cases until W3 lands.
         admitted_extra=False,

--- a/tests/integration/test_cheat_fixtures.py
+++ b/tests/integration/test_cheat_fixtures.py
@@ -1,0 +1,159 @@
+"""End-to-end "known-cheat" regression suite (W7 — standing red team).
+
+Each case crafts a baseline benchmark + an agent solution in a throwaway git
+workspace and runs the REAL checker (src/common/check_proof.py) end-to-end,
+asserting the binary verdict. This locks in every gate: a future change that
+re-opens a known cheat vector turns this suite red.
+
+Needs tlapm (~/.tlapm) + Java SANY; silently no-ops when tlapm is absent so it
+does not fail an environment without it (CI installs tlapm via install_deps).
+
+Run: PYTHONPATH=src python3 tests/integration/test_cheat_fixtures.py
+(or:  PYTHONPATH=src python3 -m pytest tests/integration/test_cheat_fixtures.py)
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+CHECK = os.path.join(REPO, "src", "common", "check_proof.py")
+SRS = os.path.join(REPO, "src", "dataset", "sany-dump", "run.sh")
+
+
+def _tlapm():
+    for c in ("/opt/tlapm/bin/tlapm", os.path.expanduser("~/.tlapm/bin/tlapm")):
+        if os.path.isfile(c):
+            return c
+    return None
+
+
+# Each case: baseline (git-root / original) + solution (working tree) files.
+# expect_pass=True  → a genuine proof that must PASS.
+# expect_pass=False → a known cheat / incomplete that must FAIL (binary; no CHEAT).
+CASES = [
+    {
+        "name": "correct_l2",
+        "level": 2,
+        "target": "Good.tla",
+        "baseline": {"Good.tla": "---- MODULE Good ----\nEXTENDS Integers\nTHEOREM G == 1 + 1 = 2\nPROOF OBVIOUS\n====\n"},
+        "solution": {"Good.tla": "---- MODULE Good ----\nEXTENDS Integers\nTHEOREM G == 1 + 1 = 2\n  OBVIOUS\n====\n"},
+        "expect_pass": True,
+    },
+    {
+        "name": "sany_invalid_shadow",
+        "level": 2,
+        "target": "Shadow.tla",
+        "baseline": {
+            "M.tla": "---- MODULE M ----\nEXTENDS Integers\nVARIABLE x\n====\n",
+            "Shadow.tla": "---- MODULE Shadow ----\nEXTENDS M\nTHEOREM T == TRUE\nPROOF OBVIOUS\n====\n",
+        },
+        "solution": {
+            "M.tla": "---- MODULE M ----\nEXTENDS Integers\nVARIABLE x\n====\n",
+            "Shadow.tla": "---- MODULE Shadow ----\nEXTENDS M\nOp(x) == x + 1\nTHEOREM T == Op(0) = 1\n  OBVIOUS\n====\n",
+        },
+        "expect_pass": False,
+    },
+    {
+        "name": "admitted_goal",
+        "level": 2,
+        "target": "Admit.tla",
+        "baseline": {"Admit.tla": "---- MODULE Admit ----\nEXTENDS Integers\nCONSTANT N\nASSUME Na == N > 0\nTHEOREM Target == N > 0\nPROOF OBVIOUS\n====\n"},
+        "solution": {"Admit.tla": "---- MODULE Admit ----\nEXTENDS Integers\nCONSTANT N\nASSUME Na == N > 0\nLEMMA Goal == N > 0\nTHEOREM Target == N > 0\n  BY Goal\n====\n"},
+        "expect_pass": False,
+    },
+    {
+        "name": "added_proof_omitted",
+        "level": 2,
+        "target": "Omit.tla",
+        "baseline": {"Omit.tla": "---- MODULE Omit ----\nEXTENDS Integers\nCONSTANT N\nASSUME Na == N > 0\nTHEOREM Target == N >= 0\nPROOF OBVIOUS\n====\n"},
+        "solution": {"Omit.tla": "---- MODULE Omit ----\nEXTENDS Integers\nCONSTANT N\nASSUME Na == N > 0\nLEMMA H == N >= 0\n  PROOF OMITTED\nTHEOREM Target == N >= 0\n  BY H\n====\n"},
+        "expect_pass": False,
+    },
+    {
+        "name": "bare_qed",
+        "level": 2,
+        "target": "Qed.tla",
+        "baseline": {"Qed.tla": "---- MODULE Qed ----\nEXTENDS Integers\nTHEOREM Target == 1 + 1 = 2\nPROOF OBVIOUS\n====\n"},
+        "solution": {"Qed.tla": "---- MODULE Qed ----\nEXTENDS Integers\nTHEOREM Target == 1 + 1 = 2\nPROOF\n<1> QED\n====\n"},
+        "expect_pass": False,
+    },
+]
+
+VERDICT_RE = re.compile(r"^\s*(PASS|FAIL)\b", re.MULTILINE)
+
+
+def _run_case(case):
+    """Build the workspace, run check_proof.py, return (verdict, output)."""
+    w = tempfile.mkdtemp(prefix="cheatfix_")
+    try:
+        for name, content in case["baseline"].items():
+            with open(os.path.join(w, name), "w") as f:
+                f.write(content)
+        subprocess.run(["git", "init", "-q"], cwd=w)
+        subprocess.run(["git", "add", "-A"], cwd=w)
+        subprocess.run(
+            ["git", "-c", "user.email=b@b", "-c", "user.name=b", "commit", "-qm", "baseline"],
+            cwd=w, capture_output=True,
+        )
+        for name, content in case["solution"].items():  # overlay the agent solution
+            with open(os.path.join(w, name), "w") as f:
+                f.write(content)
+        env = {**os.environ, "PYTHONPATH": os.path.join(REPO, "src"), "SANY_RUN_SH": SRS}
+        r = subprocess.run(
+            [sys.executable, CHECK, case["target"], "--level", str(case["level"]), "--timeout", "120"],
+            cwd=w, capture_output=True, text=True, timeout=300, env=env,
+        )
+        m = VERDICT_RE.search(r.stdout)
+        return (m.group(1) if m else "?"), r.stdout
+    finally:
+        import shutil
+
+        shutil.rmtree(w, ignore_errors=True)
+
+
+def _check(case):
+    if _tlapm() is None:
+        print(f"  SKIP (no tlapm)  {case['name']}")
+        return True
+    verdict, out = _run_case(case)
+    want = "PASS" if case["expect_pass"] else "FAIL"
+    ok = verdict == want
+    print(f"  [{'ok' if ok else 'FAIL':4}] {case['name']:22} want={want} got={verdict}")
+    if not ok:
+        print("    --- output tail ---")
+        for line in out.splitlines()[-12:]:
+            print(f"    {line}")
+    assert ok, f"{case['name']}: expected {want}, got {verdict}"
+    return ok
+
+
+def test_correct_l2():
+    _check(CASES[0])
+
+
+def test_sany_invalid_shadow():
+    _check(CASES[1])
+
+
+def test_admitted_goal():
+    _check(CASES[2])
+
+
+def test_added_proof_omitted():
+    _check(CASES[3])
+
+
+def test_bare_qed():
+    _check(CASES[4])
+
+
+if __name__ == "__main__":
+    if _tlapm() is None:
+        print("SKIPPED: tlapm not installed (~/.tlapm or /opt/tlapm)")
+        sys.exit(0)
+    for c in CASES:
+        _check(c)
+    print("all cheat-fixture cases passed")

--- a/tests/tlacheck/test_gates.py
+++ b/tests/tlacheck/test_gates.py
@@ -19,9 +19,11 @@ CLEAN = GraderInputs(
     statement_modified=False,
     extra_axiom=False,
     smuggled_module=False,
+    preamble_modified=False,
     tlapm_obligations_proved=True,
     n_missing=0,
     admitted_goal=False,
+    proof_omitted=False,
     admitted_extra=False,
     deps_modified=False,
     graded_on_canonical=True,
@@ -41,8 +43,10 @@ def test_each_wired_failure_fails_the_run():
         ("statement_modified", Gate.A_IDENTITY, True),
         ("extra_axiom", Gate.A_IDENTITY, True),
         ("smuggled_module", Gate.A_IDENTITY, True),
+        ("preamble_modified", Gate.A_IDENTITY, True),
         ("tlapm_obligations_proved", Gate.B_DISCHARGE, False),
         ("admitted_goal", Gate.B_DISCHARGE, True),
+        ("proof_omitted", Gate.B_DISCHARGE, True),
         ("deps_modified", Gate.C_TRUST, True),
     ]
     for field_name, gate, bad_value in cases:
@@ -93,6 +97,21 @@ def test_from_tlacheck_buckets_vectors():
         r = grade(inp)
         assert not r.passed, f"{vector} should FAIL the run"
         assert gate in r.failed_gates(), f"{vector} should map to {gate}"
+
+
+def test_from_tlacheck_legacy_signals_flow_to_gates():
+    # L1 preamble byte-match (gate A) and agent-added PROOF OMITTED (gate B) are
+    # not tlacheck vectors — they come in as explicit caller-computed flags.
+    pre = from_tlacheck(
+        _result(), tlapm_obligations_proved=True, n_missing=0, sany_valid=True, preamble_modified=True
+    )
+    assert not grade(pre).passed
+    assert Gate.A_IDENTITY in grade(pre).failed_gates()
+    omit = from_tlacheck(
+        _result(), tlapm_obligations_proved=True, n_missing=0, sany_valid=True, proof_omitted=True
+    )
+    assert not grade(omit).passed
+    assert Gate.B_DISCHARGE in grade(omit).failed_gates()
 
 
 def test_from_tlacheck_clean_result_passes():

--- a/tests/tlacheck/test_gates.py
+++ b/tests/tlacheck/test_gates.py
@@ -1,15 +1,13 @@
 """Tests for the cheat-checker gate framework (src/tlacheck/gates.py).
 
-Covers: the binary PASS/FAIL collapse, each WIRED gate check failing the run,
-PLACEHOLDER checks failing-open (so the skeleton is never less strict than the
-wired siblings but unbuilt checks don't block), and the from_tlacheck migration
-mapping real tlacheck issue vectors onto the right gate.
+Covers: the binary PASS/FAIL collapse, each gate check failing the run, and the
+from_tlacheck migration mapping real tlacheck issue vectors onto the right gate.
 
 Run: PYTHONPATH=src python3 -m pytest tests/tlacheck/test_gates.py
 (or:  PYTHONPATH=src python3 tests/tlacheck/test_gates.py)
 """
 
-from tlacheck.gates import Gate, GraderInputs, Status, from_tlacheck, grade
+from tlacheck.gates import Gate, GraderInputs, from_tlacheck, grade
 from tlacheck.issue import Issue, Severity
 from tlacheck.verdict import Result, Verdict
 
@@ -24,9 +22,7 @@ CLEAN = GraderInputs(
     n_missing=0,
     admitted_goal=False,
     proof_omitted=False,
-    admitted_extra=False,
     deps_modified=False,
-    graded_on_canonical=True,
 )
 
 
@@ -61,15 +57,6 @@ def test_missing_step_fails_gate_b():
     r = grade(GraderInputs(**{**CLEAN.__dict__, "n_missing": 1}))
     assert not r.passed
     assert Gate.B_DISCHARGE in r.failed_gates()
-
-
-def test_placeholders_fail_open():
-    # On a clean input, the only PLACEHOLDER/PARTIAL checks must NOT block.
-    r = grade(CLEAN)
-    placeholders = [c for c in r.checks if c.status is Status.PLACEHOLDER]
-    assert placeholders, "scaffold should carry explicit placeholders (W4/W5)"
-    assert all(c.ok for c in placeholders), "placeholders must fail-open"
-    assert r.passed
 
 
 def test_binary_no_cheat_category():
@@ -115,7 +102,7 @@ def test_from_tlacheck_legacy_signals_flow_to_gates():
 
 
 def test_from_tlacheck_clean_result_passes():
-    inp = from_tlacheck(_result(), tlapm_obligations_proved=True, n_missing=0, sany_valid=True, graded_on_canonical=True)
+    inp = from_tlacheck(_result(), tlapm_obligations_proved=True, n_missing=0, sany_valid=True)
     assert grade(inp).passed
 
 


### PR DESCRIPTION
# Cheat checker: framework

The Lean theorem-prover community ran into the same problem we have: For example, a `sorry` placeholder makes a proof "compile" without proving anything, exactly like our bare-`QED` trick — and converged on the sound-reduction approach. So I borrowed it directly:

## The principle
```
PASS  ⟺  A (identity) ∧ B (discharge) ∧ C (trust)
```
A solution passes only if all three gates hold. A "cheat" is just one of the gates
failing, so the outcome is plain **PASS / FAIL** 

- **A — identity: the agent proved *our* target, unchanged.**
  The target theorem statement is untouched (not weakened), no new `AXIOM`/`ASSUME` was added, no extra module was smuggled in, and the file is valid TLA⁺ (parses under SANY).

- **B — discharge: tlapm actually proved it.**
  Every proof obligation tlapm generated was discharged, no step was left without a proof (no bare `QED`, no unproven helper lemma, nothing unfinished), and the goal was not "admitted" — i.e. restated as an unproven lemma standing in for the real proof.

- **C — trust: we judged on files the agent could not tamper with.**
  Grading uses the original, read-only task files; any edits the agent makes to dependency files or to the prover itself do not count.

## The framework — three gates

| Gate | Check | What it verifies |
|------|-------|------------------|
| **A — identity** | `sany_valid` | the file is valid TLA⁺ (parses under the standard SANY parser) |
| | `statement_unchanged` | the target theorem statement was not changed or weakened |
| | `no_extra_axiom` | no new `AXIOM`/`ASSUME` was added beyond the original |
| | `no_smuggled_module` | no agent-created module sneaks extra content into the proof |
| | `preamble_unchanged` | the L1 preamble (definitions / CONSTANT / VARIABLE / ASSUME above PROOF OBVIOUS) is unchanged |
| **B — discharge** | `obligations_proved` | tlapm proved every proof obligation it generated |
| | `no_missing_steps` | no proof step was left empty — no bare `QED`, no unproven helper, nothing unfinished |
| | `no_admitted_goal` | the goal was not restated as an unproven, "admitted" lemma |
| | `no_added_omitted` | the agent added no `PROOF OMITTED` / bare `OMITTED` step |
| **C — trust** | `deps_unmodified` | no dependency file was modified |

Verdict is binary **PASS / FAIL** (a cheat is just a gate failing). The failing
concrete check is shown to the agent as feedback; a `GATES-FAILED: ...` line
records which gate(s) failed for human/analysis. The A/B/C grouping organizes
the checks for humans.

## References
- Lean — Validating Proofs (gold-standard `comparator`): https://lean-lang.org/doc/reference/latest/ValidatingProofs/
- SorryDB (3-condition discharge check; sorryAx bypass + patch): https://arxiv.org/html/2603.02668v1
- CLEVER (prove vs held-out ground-truth goal): https://arxiv.org/pdf/2505.13938
- miniF2F-v2 (manual re-verification; LLM-judge false positives): https://arxiv.org/abs/2511.03108
- Berkeley RDI — trustworthy benchmarks (evaluate outside sandbox, untrusted artifacts): https://rdi.berkeley.edu/blog/trustworthy-benchmarks-cont/
- DeepMind — specification gaming: https://deepmind.google/blog/specification-gaming-the-flip-side-of-ai-ingenuity/
