### PR TITLE
Add native-path CI workflow (closes #12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native:
+    
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+    
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Run make setup
+        run: make setup
+
+
+      - name: Verify lib/tla2tools.jar is present
+        run: test -f lib/tla2tools.jar
+
+      - name: Lint with ruff
+        run: uv run ruff check
+
+      - name: Run pytest
+        env:
+          PYTHONPATH: src
+        run: uv run pytest tests
+
+    
+      - name: Check tlaps-bench CLI help
+        run: |
+          set -euo pipefail
+          uv run tlaps-bench --help
+          for sub in run check validate generate score; do
+            echo "--- tlaps-bench $sub --help ---"
+            uv run tlaps-bench "$sub" --help
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,29 @@
 name: CI
 
-
 on:
   push:
     branches: [main]
   pull_request:
 
-
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on a PR, but never cancel a push-to-main build so
+  # every main commit keeps a completed CI status.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   native:
-    
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-    
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -30,9 +31,21 @@ jobs:
           distribution: temurin
           java-version: "21"
 
+      # Versions are pinned in install_deps.sh, so key the cache on its contents:
+      # bump a version there and the cache invalidates. install_deps.sh is also
+      # idempotent and self-validates, so a stale entry re-downloads on mismatch.
+      - name: Cache TLAPS toolchain
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.tlapm
+            ~/.apalache
+            lib/tla2tools.jar
+            lib/community
+          key: tlaps-deps-${{ runner.os }}-${{ hashFiles('scripts/install_deps.sh') }}
+
       - name: Run make setup
         run: make setup
-
 
       - name: Verify lib/tla2tools.jar is present
         run: test -f lib/tla2tools.jar
@@ -45,7 +58,6 @@ jobs:
           PYTHONPATH: src
         run: uv run pytest tests
 
-    
       - name: Check tlaps-bench CLI help
         run: |
           set -euo pipefail

--- a/src/dataset/level2/generate.py
+++ b/src/dataset/level2/generate.py
@@ -91,7 +91,6 @@ from dataset.level1.generate import (  # noqa: E402
     parse_theorems,
     strip_all_proofs,
 )
-
 from dataset.sany_audit import gate as sany_gate  # noqa: E402
 
 KEYWORD_PATTERN = re.compile(r"^\s*(THEOREM|LEMMA|AXIOM|COROLLARY|PROPOSITION)\b")

--- a/src/tlacheck/gates.py
+++ b/src/tlacheck/gates.py
@@ -39,16 +39,16 @@ W4 semantic statement-match (catch operator redefinition); W5 trusted-file repla
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 
 
-class Gate(str, Enum):
+class Gate(StrEnum):
     A_IDENTITY = "A:identity"  # proved thing IS the canonical target
     B_DISCHARGE = "B:discharge"  # target goal genuinely discharged
     C_TRUST = "C:trust"  # graded on trusted files
 
 
-class Status(str, Enum):
+class Status(StrEnum):
     WIRED = "wired"  # real check, migrated from existing detection
     PARTIAL = "partial"  # works now; to be tightened (see TODO in detail)
     PLACEHOLDER = "placeholder"  # not implemented; FAIL-OPEN, covered by siblings

--- a/src/tlaps_bench/cli.py
+++ b/src/tlaps_bench/cli.py
@@ -103,6 +103,17 @@ def main(argv: list[str] | None = None) -> int:
         module = "dataset.level1.generate" if level == "level1" else "dataset.level2.generate"
         return _dispatch(f"{PROG} generate --level {level}", module, "main", gen_args)
     if sub == "score":
+        # Give `score` a real argparse parser so `--help` behaves like every
+        # other subcommand (prints usage, exits 0). Invoking it for real still
+        # prints "not implemented" and exits non-zero, so the stub is never
+        # mistaken for a working command.
+        import argparse
+
+        parser = argparse.ArgumentParser(
+            prog=f"{PROG} score",
+            description="Score / aggregate results (not implemented yet).",
+        )
+        parser.parse_args(rest)
         sys.stderr.write("tlaps-bench score: not implemented yet (tracked as a separate task)\n")
         return 1
 


### PR DESCRIPTION
Adds `.github/workflows/ci.yml`, runs on push to `main` and on PRs. 

Steps: provision `uv` + JDK 21, then `make setup` (#9) → `ruff check` →
`pytest` → `tlaps-bench --help` and every subcommand `--help` exit 0 (#10).
Runs on `ubuntu-latest`.

Also changed, to make CI pass:
- `tlaps_bench/cli.py`: `score --help` now exits 0 (argparse); bare `score`
  still exits non-zero.
- `tlacheck/gates.py`: `Gate`/`Status` use `enum.StrEnum` (ruff UP042); no
  behavior change.