### PR TITLE
CI: manual Docker image build + push to GHCR

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,72 @@
+name: Docker image
+
+# Manually triggered (a "Run workflow" button under the Actions tab): rebuild the
+# benchmark image from the current main and push it to GHCR. NOT run on every
+# merge — the image is heavy (bundles tlapm + the agent CLIs). Rebuild on demand,
+# e.g. before an eval campaign, so Docker runs use the current checker.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write  # push to ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      # Same cache key as the native CI job, so the toolchain restores quickly.
+      - name: Cache TLAPS toolchain
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.tlapm
+            ~/.apalache
+            lib/tla2tools.jar
+            lib/community
+          key: tlaps-deps-${{ runner.os }}-${{ hashFiles('scripts/install_deps.sh') }}
+
+      # Produce the artifacts the Dockerfile COPYs in: lib/ (toolchain),
+      # ./check_proof_bin (PyInstaller), and the precompiled DumpSemantics class.
+      - name: Prepare build artifacts
+        run: |
+          make setup
+          make build
+          bash src/dataset/sany-dump/build.sh
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -59,6 +59,11 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
+      # GHCR requires a lowercase image path; github.repository keeps the owner's
+      # original case, so this breaks on forks like Qian-Cheng-nju/... without it.
+      - name: Compute lowercase image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
@@ -66,7 +71,7 @@ jobs:
           file: docker/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds `.github/workflows/docker-image.yml`: a **manually-triggered** (`workflow_dispatch`) job that rebuilds the benchmark image from the current `main` and pushes it to GHCR.

**Why manual, not per-merge:** the image is heavy (bundles tlapm + the agent CLIs). Rebuild on demand (e.g. before an eval) so Docker runs pick up the updates, without a slow multi-GB build on every merge.

**What it does:** prepares the artifacts the Dockerfile COPYs (`make setup` for lib/ toolchain, `make build` for check_proof_bin, `sany-dump/build.sh` for the DumpSemantics class), logs in to GHCR with the built-in `GITHUB_TOKEN` (no secrets to manage), and builds + pushes `ghcr.io/<owner>/tlaps-bench` tagged `latest` + the commit SHA, with GitHub Actions layer caching.
