### PR TITLE
Add macOS arm64 (Apple Silicon) support to native setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,24 @@ lib/                           Vendored: tla2tools.jar (gitignored)
 docker/                        Container build + isolation
 ```
 
-### Setup (Linux x86-64)
+### Setup (Linux x86-64 / macOS arm64)
+
+Native setup runs on Linux x86-64 and macOS arm64 (Apple Silicon). Intel Macs
+are unsupported — upstream tlapm publishes no x86-64 macOS binary.
 
 Native setup requires GNU Make, `curl`, `tar`, [uv](https://docs.astral.sh/uv/),
 and a JDK 21 or newer (`java` and `javac`). The project itself requires Python
 ≥ 3.12; `uv` selects or installs a compatible Python automatically.
+
+On macOS, Homebrew's `openjdk` is keg-only, so `brew install openjdk@21` does not
+by itself put `java`/`javac` on `PATH`. Register it once (no `sudo` needed) so it
+becomes the default JDK:
+
+```bash
+brew install openjdk@21
+ln -sfn "$(brew --prefix)/opt/openjdk@21/libexec/openjdk.jdk" \
+  ~/Library/Java/JavaVirtualMachines/openjdk-21.jdk
+```
 
 From the repository root, run:
 
@@ -156,10 +169,11 @@ make setup
 ```
 
 This one idempotent command syncs the locked Python environment, installs the
-pinned tlapm/Apalache/SANY dependencies, compiles the SANY semantic dumper,
-builds `check_proof_bin`, and runs a fast SANY smoke test. It is safe to rerun.
-Missing system prerequisites and a moved TLAPM rolling-release pin are reported
-as actionable errors. Allow roughly 3 GB of free disk space: the first run
+pinned tlapm/Apalache/SANY dependencies (the platform-matching tlapm binary is
+selected automatically), compiles the SANY semantic dumper, builds
+`check_proof_bin`, and runs a fast SANY smoke test. It is safe to rerun. Missing
+system prerequisites and a moved TLAPM rolling-release pin are reported as
+actionable errors. Allow roughly 3 GB of free disk space: the first run
 downloads an approximately 850 MB TLAPM archive and installs about 1.7 GB of
 external tools.
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -9,14 +9,31 @@
 
 set -euo pipefail
 
+# Detect the host platform. tlapm ships a separate binary per platform; the
+# other deps (Apalache, tla2tools, CommunityModules) are JVM/text artifacts and
+# are platform-agnostic, so only the tlapm asset name is conditional below.
+HOST_OS="$(uname -s)"
+HOST_ARCH="$(uname -m)"
+
 # Pinned versions — bump deliberately, then re-run.
 # 1.6.0-pre is a *rolling* tag (the asset is rebuilt in place), so the tag alone
 # is not reproducible — pin by the expected `tlapm --version` commit and
 # re-download on mismatch. 80172c6 is the first rolling build carrying `--strict`
 # (tlaplus/tlapm#278); bump TLAPM_COMMIT deliberately when upgrading.
+# TLAPM_TAG/TLAPM_COMMIT are shared across platforms (same release); only the
+# downloaded asset differs. The 1.6.0-pre release publishes Linux x86_64 and
+# macOS arm64 binaries — there is no Intel (x86_64) macOS build.
 TLAPM_TAG="1.6.0-pre"
 TLAPM_COMMIT="80172c6"
-TLAPM_ASSET="tlapm-${TLAPM_TAG}-x86_64-linux-gnu.tar.gz"
+case "${HOST_OS} ${HOST_ARCH}" in
+  "Linux x86_64") TLAPM_ASSET="tlapm-${TLAPM_TAG}-x86_64-linux-gnu.tar.gz" ;;
+  "Darwin arm64") TLAPM_ASSET="tlapm-${TLAPM_TAG}-arm64-darwin.tar.gz" ;;
+  *)
+    echo "[install_deps] ERROR: unsupported platform '${HOST_OS} ${HOST_ARCH}'." >&2
+    echo "[install_deps]        tlapm ${TLAPM_TAG} provides binaries for Linux x86_64 and macOS arm64 only." >&2
+    exit 1
+    ;;
+esac
 TLAPM_URL="https://github.com/tlaplus/tlapm/releases/download/${TLAPM_TAG}/${TLAPM_ASSET}"
 
 APALACHE_TAG="v0.57.0"
@@ -36,7 +53,10 @@ LIB_DIR="${REPO_ROOT}/lib"
 TMP_DIRS=()
 cleanup() {
   local path
-  for path in "${TMP_DIRS[@]}"; do
+  # macOS ships bash 3.2, where "${arr[@]}" on an empty array trips `set -u`
+  # ("unbound variable"). On a rerun where every download is skipped TMP_DIRS
+  # stays empty, so guard the expansion to keep the EXIT trap from failing.
+  for path in ${TMP_DIRS[@]+"${TMP_DIRS[@]}"}; do
     rm -rf "${path}"
   done
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Prepare a native Linux x86-64 checkout for benchmark development and runs.
+# Prepare a native checkout (Linux x86-64 or macOS arm64) for benchmark
+# development and runs.
 
 set -euo pipefail
 
@@ -54,19 +55,40 @@ check_java() {
 main() {
   cd "${REPO_ROOT}"
 
-  local host_os host_arch
+  local host_os host_arch is_macos=0
   host_os="$(uname -s)"
   host_arch="$(uname -m)"
-  if [[ "${host_os}" != "Linux" || "${host_arch}" != "x86_64" ]]; then
-    die "native setup currently supports Linux x86-64 only; detected ${host_os} ${host_arch}."
+  if [[ "${host_os}" == "Linux" && "${host_arch}" == "x86_64" ]]; then
+    : # Linux x86-64: the original, unchanged path.
+  elif [[ "${host_os}" == "Darwin" && "${host_arch}" == "arm64" ]]; then
+    is_macos=1
+  elif [[ "${host_os}" == "Darwin" ]]; then
+    die "native setup supports macOS on Apple Silicon (arm64) only; detected ${host_os} ${host_arch}. Upstream tlapm publishes no Intel (x86_64) macOS binary, so Intel Macs are unsupported."
+  else
+    die "native setup supports Linux x86-64 and macOS arm64 only; detected ${host_os} ${host_arch}."
   fi
 
-  require_command make "Install GNU Make (Ubuntu/Debian: sudo apt-get install make)."
-  require_command curl "Install curl (Ubuntu/Debian: sudo apt-get install curl)."
-  require_command tar "Install tar (Ubuntu/Debian: sudo apt-get install tar)."
-  require_command uv "Install uv with: curl -LsSf https://astral.sh/uv/install.sh | sh."
-  require_command java "Install a JDK 21+ package (Ubuntu/Debian: sudo apt-get install openjdk-21-jdk)."
-  require_command javac "A JRE is not sufficient; install a JDK 21+ package (Ubuntu/Debian: sudo apt-get install openjdk-21-jdk)."
+  local make_hint curl_hint tar_hint uv_hint jdk_hint
+  if (( is_macos )); then
+    make_hint="Install Xcode Command Line Tools: xcode-select --install."
+    curl_hint="curl ships with macOS; reinstall the Command Line Tools (xcode-select --install) if missing."
+    tar_hint="tar ships with macOS; reinstall the Command Line Tools (xcode-select --install) if missing."
+    uv_hint="Install uv with: brew install uv (or: curl -LsSf https://astral.sh/uv/install.sh | sh)."
+    jdk_hint="Install a JDK 21+ on PATH (java and javac). Homebrew's openjdk is keg-only, so register it after installing, e.g.: brew install openjdk@21 && ln -sfn \$(brew --prefix)/opt/openjdk@21/libexec/openjdk.jdk ~/Library/Java/JavaVirtualMachines/openjdk-21.jdk."
+  else
+    make_hint="Install GNU Make (Ubuntu/Debian: sudo apt-get install make)."
+    curl_hint="Install curl (Ubuntu/Debian: sudo apt-get install curl)."
+    tar_hint="Install tar (Ubuntu/Debian: sudo apt-get install tar)."
+    uv_hint="Install uv with: curl -LsSf https://astral.sh/uv/install.sh | sh."
+    jdk_hint="Install a JDK 21+ package (Ubuntu/Debian: sudo apt-get install openjdk-21-jdk)."
+  fi
+
+  require_command make "${make_hint}"
+  require_command curl "${curl_hint}"
+  require_command tar "${tar_hint}"
+  require_command uv "${uv_hint}"
+  require_command java "${jdk_hint}"
+  require_command javac "A JRE is not sufficient; ${jdk_hint}"
   check_java
 
   log "syncing the locked Python environment..."


### PR DESCRIPTION
Changes made :
- install_deps.sh: download the platform-matching tlapm binary (\`arm64-darwin\` on Mac, \`x86_64-linux-gnu\` on Linux); shared tag/commit pin.
- setup.sh: OS/arch guard branches for Darwin arm64; Intel Macs get a clear \"unsupported\" error (no tlapm Intel build upstream). OS-aware install hints.
- install_deps.sh: fix a bash 3.2 (macOS default shell) bug where the cleanup trap crashed on a rerun.
- README: document macOS arm64 support and the keg-only JDK-on-PATH step.


Testing done :
- Clean \`make setup\` end-to-end: darwin tlapm downloaded + verified, SANY compiled, \`check_proof_bin\` built, smoke test passed
- Rerun is idempotent (all artifacts skipped)
- \`pytest\` green: 27/27, including the real tlapm + SANY end-to-end suite