### PR TITLE
Minor fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 hengxin(Hengfeng Wei)
+Copyright (c) 2026 The tlaps-bench Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/evaluator/backends/claude_code.py
+++ b/src/evaluator/backends/claude_code.py
@@ -16,7 +16,7 @@ from .base import (
     needs_aws_shared_credentials,
 )
 
-DEFAULT_MODEL = "claude-opus-4-7"
+DEFAULT_MODEL = "claude-opus-4-8"
 
 
 class ClaudeCodeBackend(AgentBackend):

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -40,8 +40,10 @@ class CodexBackend(AgentBackend):
 
     def build_command(self, workspace: str, result_dir: str) -> list[str]:
         last_msg_path = os.path.join(result_dir, "codex_last_message.txt")
+        # Invoke the `codex` binary directly (it must be on PATH). Going through
+        # `npx codex` is wrong: npm has no top-level `codex` package (OpenAI's is
+        # `@openai/codex`), so `npx codex` resolves to an unrelated bogus package.
         cmd = [
-            "npx",
             "codex",
             "exec",
             "--dangerously-bypass-approvals-and-sandbox",


### PR DESCRIPTION
Three small fixes found while testing the benchmark end-to-end:

- Default the `claude_code` backend to `claude-opus-4-8` (was `claude-opus-4-7`).
- Invoke `codex` directly instead of `npx codex` — npm has no top-level `codex` package (OpenAI's is `@openai/codex`), so `npx codex` resolves to an unrelated bogus package.
- Update the LICENSE copyright line to `2026 The tlaps-bench Authors`.

