### PR TITLE
Add score command

### DIFF
--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -339,7 +339,10 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, level_na
         lines = []
         lines.append(f"# {backend_name} on {level_name}\n")
         lines.append(f"**Date**: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+        n_pass = verdicts.get("PASS", 0)
+        pass_pct = (100.0 * n_pass / total) if total else 0.0
         lines.append(f"**Progress**: {total}/{total_benchmarks}")
+        lines.append(f"**Pass rate**: {n_pass}/{total} ({pass_pct:.1f}%)")
         lines.append(f"**Total tokens**: {total_input:,} input / {total_output:,} output\n")
 
         lines.append("## Summary\n")

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -339,10 +339,17 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, level_na
         lines = []
         lines.append(f"# {backend_name} on {level_name}\n")
         lines.append(f"**Date**: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+        # SKIP = operator-excluded from scoring; drop it from the pass rate
+        # entirely (neither numerator nor denominator) rather than count it FAIL.
         n_pass = verdicts.get("PASS", 0)
-        pass_pct = (100.0 * n_pass / total) if total else 0.0
+        n_skip = verdicts.get("SKIP", 0)
+        scored = total - n_skip
+        pass_pct = (100.0 * n_pass / scored) if scored else 0.0
+        pass_line = f"**Pass rate**: {n_pass}/{scored} ({pass_pct:.1f}%)"
+        if n_skip:
+            pass_line += f" · {n_skip} skipped"
         lines.append(f"**Progress**: {total}/{total_benchmarks}")
-        lines.append(f"**Pass rate**: {n_pass}/{total} ({pass_pct:.1f}%)")
+        lines.append(pass_line)
         lines.append(f"**Total tokens**: {total_input:,} input / {total_output:,} output\n")
 
         lines.append("## Summary\n")

--- a/src/evaluator/score.py
+++ b/src/evaluator/score.py
@@ -1,0 +1,171 @@
+"""Score benchmark results from one or more results.json files.
+
+``tlaps-bench run`` writes a machine-readable ``results.json`` per run. This
+reads one or more of them and prints a Markdown scorecard. It is pure and
+offline — no network, no API keys — so metrics can be (re)computed cheaply
+without re-running the (expensive) agents.
+
+PASS/FAIL: a task counts as passed iff its ``check_verdict`` is exactly
+``"PASS"``. Every other verdict — FAIL, CHEATING, TIMEOUT, ERROR — counts as
+not passed. CHEATING is not a separate category here: a cheat is just a failure.
+
+Pluggable scoring: a scorer assigns a non-negative weight to each task; the
+score of a group of tasks is
+
+    100 * (sum of weights of passed tasks) / (sum of all weights)
+
+The default ``equal`` scorer gives every task weight 1, so the score is simply
+the percentage of tasks passed. To add a scheme (e.g. weight by proof
+obligations), register another weight function in ``SCORERS`` and select it with
+``--scoring``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from collections.abc import Callable
+
+PASS_VERDICT = "PASS"
+
+
+def is_pass(result: dict) -> bool:
+    """A task passed iff its verdict is exactly PASS (CHEATING/FAIL/... do not)."""
+    return result.get("check_verdict") == PASS_VERDICT
+
+
+# A scorer maps one task result to a non-negative weight; the group score is the
+# weighted pass fraction. Add an entry here to define a new scheme, then select
+# it with --scoring.
+SCORERS: dict[str, Callable[[dict], float]] = {
+    "equal": lambda r: 1.0,  # every task counts the same; score = % passed
+}
+
+
+def weighted_score(results: list[dict], weight: Callable[[dict], float]) -> tuple[float, int, int]:
+    """Return (score_percent, n_passed, n_total) for a list of task results."""
+    n_total = len(results)
+    n_pass = sum(1 for r in results if is_pass(r))
+    total_w = sum(max(weight(r), 0.0) for r in results)
+    pass_w = sum(max(weight(r), 0.0) for r in results if is_pass(r))
+    pct = (100.0 * pass_w / total_w) if total_w > 0 else 0.0
+    return pct, n_pass, n_total
+
+
+def load_run(path: str) -> dict:
+    """Load a results.json (``path`` may be the file itself or its run dir).
+
+    Returns {"path", "id", "backend", "level", "results"}.
+    """
+    json_path = os.path.join(path, "results.json") if os.path.isdir(path) else path
+    if not os.path.isfile(json_path):
+        raise FileNotFoundError(f"no results.json at {path}")
+    with open(json_path) as f:
+        results = json.load(f)
+    backends = sorted({r.get("backend") for r in results if r.get("backend")})
+    levels = sorted({r.get("level") for r in results if r.get("level")})
+    run_dir = os.path.dirname(os.path.abspath(json_path))
+    return {
+        "path": json_path,
+        "id": os.path.basename(run_dir) or run_dir,
+        "backend": "+".join(backends) or "?",
+        "level": "+".join(levels) or "?",
+        "results": results,
+    }
+
+
+def _cost(results: list[dict]) -> tuple[int, int, float]:
+    in_tok = sum(r.get("input_tokens", 0) for r in results)
+    out_tok = sum(r.get("output_tokens", 0) for r in results)
+    secs = sum(r.get("time_secs", 0) for r in results)
+    return in_tok, out_tok, secs
+
+
+def scorecard_md(run: dict, weight: Callable[[dict], float], scoring_name: str) -> str:
+    """Markdown scorecard for a single run: overall pass rate + per-module table."""
+    results = run["results"]
+    pct, n_pass, n_total = weighted_score(results, weight)
+    in_tok, out_tok, secs = _cost(results)
+
+    lines = [
+        f"# Scorecard — {run['backend']} / {run['level']}",
+        "",
+        f"**Source**: {run['path']}",
+        f"**Pass rate**: {n_pass}/{n_total} ({pct:.1f}%)",
+        f"**Cost**: {in_tok:,} in / {out_tok:,} out tokens · {secs:,.0f}s total",
+    ]
+    if scoring_name != "equal":
+        lines.append(f"**Scoring**: {scoring_name} (weighted)")
+    lines += [
+        "",
+        "## By module",
+        "",
+        "| Module | Passed | Total | Pass % |",
+        "|--------|-------:|------:|-------:|",
+    ]
+    by_module: dict[str, list[dict]] = defaultdict(list)
+    for r in results:
+        by_module[r.get("module") or "?"].append(r)
+    for module in sorted(by_module):
+        mpct, mp, mt = weighted_score(by_module[module], weight)
+        lines.append(f"| {module} | {mp} | {mt} | {mpct:.1f}% |")
+    lines.append(f"| **Total** | **{n_pass}** | **{n_total}** | **{pct:.1f}%** |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def comparison_md(runs: list[dict], weight: Callable[[dict], float], scoring_name: str) -> str:
+    """Markdown comparison table across several runs (one row per run)."""
+    lines = [f"# Comparison — {len(runs)} runs", ""]
+    if scoring_name != "equal":
+        lines += [f"**Scoring**: {scoring_name} (weighted)", ""]
+    lines += [
+        "| Run | Backend | Level | Pass % | Passed/Total | Tokens (in/out) | Time |",
+        "|-----|---------|-------|-------:|-------------:|-----------------|-----:|",
+    ]
+    for run in runs:
+        pct, n_pass, n_total = weighted_score(run["results"], weight)
+        in_tok, out_tok, secs = _cost(run["results"])
+        lines.append(
+            f"| {run['id']} | {run['backend']} | {run['level']} | {pct:.1f}% | "
+            f"{n_pass}/{n_total} | {in_tok:,}/{out_tok:,} | {secs:,.0f}s |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="tlaps-bench score",
+        description="Score benchmark results (pass rate, per-module breakdown) from results.json.",
+    )
+    parser.add_argument("paths", nargs="+", help="One or more results.json files or run directories")
+    parser.add_argument(
+        "--scoring",
+        default="equal",
+        choices=sorted(SCORERS),
+        help="Scoring scheme (default: equal — every task weight 1, score = %% passed)",
+    )
+    args = parser.parse_args()
+
+    weight = SCORERS[args.scoring]
+    runs = []
+    for p in args.paths:
+        try:
+            runs.append(load_run(p))
+        except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
+            sys.stderr.write(f"tlaps-bench score: {e}\n")
+            return 1
+
+    if len(runs) == 1:
+        print(scorecard_md(runs[0], weight, args.scoring))
+    else:
+        print(comparison_md(runs, weight, args.scoring))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/evaluator/score.py
+++ b/src/evaluator/score.py
@@ -9,6 +9,12 @@ PASS/FAIL: a task counts as passed iff its ``check_verdict`` is exactly
 ``"PASS"``. Every other verdict — FAIL, CHEATING, TIMEOUT, ERROR — counts as
 not passed. CHEATING is not a separate category here: a cheat is just a failure.
 
+SKIP is the one exception: an operator marks a benchmark ``SKIP`` to exclude it
+from scoring (e.g. a theorem known to time out for reasons outside the agent's
+control). A skipped task is in neither the numerator nor the denominator — it is
+dropped from the pass rate entirely, not counted as a failure — and the count of
+skipped tasks is reported separately so nothing is hidden.
+
 Pluggable scoring: a scorer assigns a non-negative weight to each task; the
 score of a group of tasks is
 
@@ -30,11 +36,22 @@ from collections import defaultdict
 from collections.abc import Callable
 
 PASS_VERDICT = "PASS"
+SKIP_VERDICT = "SKIP"
 
 
 def is_pass(result: dict) -> bool:
     """A task passed iff its verdict is exactly PASS (CHEATING/FAIL/... do not)."""
     return result.get("check_verdict") == PASS_VERDICT
+
+
+def is_skipped(result: dict) -> bool:
+    """A task is SKIP iff an operator excluded it from scoring (see module doc)."""
+    return result.get("check_verdict") == SKIP_VERDICT
+
+
+def n_skipped(results: list[dict]) -> int:
+    """How many tasks were operator-excluded from scoring."""
+    return sum(1 for r in results if is_skipped(r))
 
 
 # A scorer maps one task result to a non-negative weight; the group score is the
@@ -46,11 +63,16 @@ SCORERS: dict[str, Callable[[dict], float]] = {
 
 
 def weighted_score(results: list[dict], weight: Callable[[dict], float]) -> tuple[float, int, int]:
-    """Return (score_percent, n_passed, n_total) for a list of task results."""
-    n_total = len(results)
-    n_pass = sum(1 for r in results if is_pass(r))
-    total_w = sum(max(weight(r), 0.0) for r in results)
-    pass_w = sum(max(weight(r), 0.0) for r in results if is_pass(r))
+    """Return (score_percent, n_passed, n_total) over the scored tasks.
+
+    SKIP tasks are dropped first, so ``n_total`` is the number of *scored* tasks
+    (skipped ones count toward neither the pass count nor the denominator).
+    """
+    scored = [r for r in results if not is_skipped(r)]
+    n_total = len(scored)
+    n_pass = sum(1 for r in scored if is_pass(r))
+    total_w = sum(max(weight(r), 0.0) for r in scored)
+    pass_w = sum(max(weight(r), 0.0) for r in scored if is_pass(r))
     pct = (100.0 * pass_w / total_w) if total_w > 0 else 0.0
     return pct, n_pass, n_total
 
@@ -88,13 +110,17 @@ def scorecard_md(run: dict, weight: Callable[[dict], float], scoring_name: str) 
     """Markdown scorecard for a single run: overall pass rate + per-module table."""
     results = run["results"]
     pct, n_pass, n_total = weighted_score(results, weight)
+    skipped = n_skipped(results)
     in_tok, out_tok, secs = _cost(results)
 
+    pass_line = f"**Pass rate**: {n_pass}/{n_total} ({pct:.1f}%)"
+    if skipped:
+        pass_line += f" · {skipped} skipped"
     lines = [
         f"# Scorecard — {run['backend']} / {run['level']}",
         "",
         f"**Source**: {run['path']}",
-        f"**Pass rate**: {n_pass}/{n_total} ({pct:.1f}%)",
+        pass_line,
         f"**Cost**: {in_tok:,} in / {out_tok:,} out tokens · {secs:,.0f}s total",
     ]
     if scoring_name != "equal":
@@ -108,6 +134,8 @@ def scorecard_md(run: dict, weight: Callable[[dict], float], scoring_name: str) 
     ]
     by_module: dict[str, list[dict]] = defaultdict(list)
     for r in results:
+        if is_skipped(r):
+            continue  # fully-skipped modules drop out of the table entirely
         by_module[r.get("module") or "?"].append(r)
     for module in sorted(by_module):
         mpct, mp, mt = weighted_score(by_module[module], weight)
@@ -129,9 +157,13 @@ def comparison_md(runs: list[dict], weight: Callable[[dict], float], scoring_nam
     for run in runs:
         pct, n_pass, n_total = weighted_score(run["results"], weight)
         in_tok, out_tok, secs = _cost(run["results"])
+        passed_total = f"{n_pass}/{n_total}"
+        skipped = n_skipped(run["results"])
+        if skipped:
+            passed_total += f" (+{skipped} skipped)"
         lines.append(
             f"| {run['id']} | {run['backend']} | {run['level']} | {pct:.1f}% | "
-            f"{n_pass}/{n_total} | {in_tok:,}/{out_tok:,} | {secs:,.0f}s |"
+            f"{passed_total} | {in_tok:,}/{out_tok:,} | {secs:,.0f}s |"
         )
     lines.append("")
     return "\n".join(lines)

--- a/src/tlaps_bench/cli.py
+++ b/src/tlaps_bench/cli.py
@@ -6,7 +6,7 @@ SUBCOMMANDS = [
     ("check", "Check a single benchmark proof for correctness and cheating"),
     ("validate", "Batch-validate source proofs with tlapm"),
     ("generate", "Generate benchmarks (--level level1|level2; default level1)"),
-    ("score", "Score / aggregate results (not implemented yet)"),
+    ("score", "Score results (pass rate, per-module breakdown) from results.json"),
 ]
 
 PROG = "tlaps-bench"
@@ -100,19 +100,7 @@ def main(argv: list[str] | None = None) -> int:
         module = "dataset.level1.generate" if level == "level1" else "dataset.level2.generate"
         return _dispatch(f"{PROG} generate --level {level}", module, "main", gen_args)
     if sub == "score":
-        # Give `score` a real argparse parser so `--help` behaves like every
-        # other subcommand (prints usage, exits 0). Invoking it for real still
-        # prints "not implemented" and exits non-zero, so the stub is never
-        # mistaken for a working command.
-        import argparse
-
-        parser = argparse.ArgumentParser(
-            prog=f"{PROG} score",
-            description="Score / aggregate results (not implemented yet).",
-        )
-        parser.parse_args(rest)
-        sys.stderr.write("tlaps-bench score: not implemented yet (tracked as a separate task)\n")
-        return 1
+        return _dispatch(f"{PROG} score", "evaluator.score", "main", rest)
 
     return 2  # unreachable
 

--- a/tests/evaluator/test_score.py
+++ b/tests/evaluator/test_score.py
@@ -2,14 +2,27 @@
 
 A task passes iff check_verdict == "PASS"; CHEATING/FAIL/TIMEOUT/ERROR all count
 as not passed, and CHEATING is never shown as its own category. The default
-"equal" scorer makes the score the plain percentage of tasks passed.
+"equal" scorer makes the score the plain percentage of tasks passed. SKIP is the
+one exception: it is dropped from scoring entirely (neither passed nor failed)
+and only reported as a side count.
 
 Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_score.py
 """
 
 import json
+import sys
 
-from evaluator.score import SCORERS, comparison_md, is_pass, load_run, scorecard_md, weighted_score
+from evaluator.score import (
+    SCORERS,
+    comparison_md,
+    is_pass,
+    is_skipped,
+    load_run,
+    main,
+    n_skipped,
+    scorecard_md,
+    weighted_score,
+)
 
 EQUAL = SCORERS["equal"]
 
@@ -73,3 +86,97 @@ def test_load_run_from_dir(tmp_path):
     assert run["backend"] == "codex"
     assert run["level"] == "level1"
     assert len(run["results"]) == 1
+
+
+# --- SKIP is excluded from scoring, not counted as a failure --------------
+
+
+def test_is_skipped_only_for_SKIP():
+    assert is_skipped(_r("SKIP"))
+    for v in ["PASS", "FAIL", "CHEATING", "TIMEOUT", "ERROR"]:
+        assert not is_skipped(_r(v))
+
+
+def test_skip_drops_out_of_denominator():
+    # 1 PASS + 1 FAIL + 1 SKIP -> 1/2 (50%), NOT 1/3: the skip is excluded.
+    results = [_r("PASS"), _r("FAIL"), _r("SKIP")]
+    pct, n_pass, n_total = weighted_score(results, EQUAL)
+    assert (n_pass, n_total, pct) == (1, 2, 50.0)
+    assert n_skipped(results) == 1
+
+
+def test_all_skip_is_zero_not_crash():
+    results = [_r("SKIP"), _r("SKIP")]
+    assert weighted_score(results, EQUAL) == (0.0, 0, 0)
+    assert n_skipped(results) == 2
+
+
+def test_scorecard_excludes_skip_and_reports_it():
+    # Module A: PASS + SKIP -> 1/1 (skip gone). Module B: all SKIP -> absent.
+    results = [_r("PASS", module="A"), _r("SKIP", module="A"), _r("SKIP", module="B")]
+    run = {"path": "x/results.json", "id": "x", "backend": "codex", "level": "level1", "results": results}
+    md = scorecard_md(run, EQUAL, "equal")
+    assert "**Pass rate**: 1/1 (100.0%) · 2 skipped" in md
+    assert "| A | 1 | 1 | 100.0% |" in md  # skip not counted against module A
+    assert "| B |" not in md  # a fully-skipped module drops out of the table
+    assert "| **Total** | **1** | **1** | **100.0%** |" in md
+
+
+def test_scorecard_no_skip_has_no_skipped_note():
+    results = [_r("PASS"), _r("FAIL")]
+    run = {"path": "x/results.json", "id": "x", "backend": "codex", "level": "level1", "results": results}
+    md = scorecard_md(run, EQUAL, "equal")
+    assert "**Pass rate**: 1/2 (50.0%)" in md
+    assert "skipped" not in md
+
+
+def test_comparison_discloses_skip_inline():
+    runs = [
+        {"id": "r1", "backend": "codex", "level": "level1", "results": [_r("PASS"), _r("FAIL"), _r("SKIP")]},
+        {"id": "r2", "backend": "claude_code", "level": "level1", "results": [_r("PASS"), _r("PASS")]},
+    ]
+    md = comparison_md(runs, EQUAL, "equal")
+    assert "| r1 | codex | level1 | 50.0% | 1/2 (+1 skipped) |" in md
+    assert "| r2 | claude_code | level1 | 100.0% | 2/2 |" in md  # no note when nothing skipped
+
+
+# --- load_run / main entry point ------------------------------------------
+
+
+def test_load_run_from_file_path(tmp_path):
+    f = tmp_path / "results.json"
+    f.write_text(json.dumps([_r("PASS", backend="codex", level="level1")]))
+    run = load_run(str(f))
+    assert run["path"] == str(f)
+    assert run["backend"] == "codex"
+    assert run["id"] == tmp_path.name  # id falls back to the containing dir
+
+
+def _write_run(tmp_path, name, results):
+    d = tmp_path / name
+    d.mkdir()
+    (d / "results.json").write_text(json.dumps(results))
+    return str(d)
+
+
+def test_main_single_prints_scorecard(tmp_path, monkeypatch, capsys):
+    d = _write_run(tmp_path, "run1", [_r("PASS", backend="codex", level="level1"), _r("FAIL")])
+    monkeypatch.setattr(sys, "argv", ["tlaps-bench score", d])
+    assert main() == 0
+    out = capsys.readouterr().out
+    assert "# Scorecard" in out
+    assert "**Pass rate**: 1/2 (50.0%)" in out
+
+
+def test_main_multiple_prints_comparison(tmp_path, monkeypatch, capsys):
+    d1 = _write_run(tmp_path, "run1", [_r("PASS", backend="codex", level="level1")])
+    d2 = _write_run(tmp_path, "run2", [_r("FAIL", backend="codex", level="level1")])
+    monkeypatch.setattr(sys, "argv", ["tlaps-bench score", d1, d2])
+    assert main() == 0
+    assert "# Comparison — 2 runs" in capsys.readouterr().out
+
+
+def test_main_missing_path_exits_1(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["tlaps-bench score", str(tmp_path / "nope")])
+    assert main() == 1
+    assert "no results.json" in capsys.readouterr().err

--- a/tests/evaluator/test_score.py
+++ b/tests/evaluator/test_score.py
@@ -1,0 +1,75 @@
+"""Scoring from results.json.
+
+A task passes iff check_verdict == "PASS"; CHEATING/FAIL/TIMEOUT/ERROR all count
+as not passed, and CHEATING is never shown as its own category. The default
+"equal" scorer makes the score the plain percentage of tasks passed.
+
+Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_score.py
+"""
+
+import json
+
+from evaluator.score import SCORERS, comparison_md, is_pass, load_run, scorecard_md, weighted_score
+
+EQUAL = SCORERS["equal"]
+
+
+def _r(verdict, module="M", **kw):
+    d = {"check_verdict": verdict, "module": module, "input_tokens": 0, "output_tokens": 0, "time_secs": 0}
+    d.update(kw)
+    return d
+
+
+def test_is_pass_only_for_PASS():
+    assert is_pass(_r("PASS"))
+    for v in ["FAIL", "CHEATING", "TIMEOUT", "ERROR"]:
+        assert not is_pass(_r(v))
+
+
+def test_cheating_counts_as_fail():
+    results = [_r("PASS"), _r("PASS"), _r("CHEATING"), _r("FAIL")]
+    pct, n_pass, n_total = weighted_score(results, EQUAL)
+    assert (n_pass, n_total) == (2, 4)
+    assert pct == 50.0
+
+
+def test_equal_weight_is_percent_passed():
+    results = [_r("PASS")] * 3 + [_r("FAIL")]
+    pct, n_pass, n_total = weighted_score(results, EQUAL)
+    assert (n_pass, n_total, pct) == (3, 4, 75.0)
+
+
+def test_empty_is_zero_not_crash():
+    assert weighted_score([], EQUAL) == (0.0, 0, 0)
+
+
+def test_scorecard_module_breakdown_and_no_cheating_row():
+    results = [_r("PASS", module="A"), _r("CHEATING", module="A"), _r("PASS", module="B")]
+    run = {"path": "x/results.json", "id": "x", "backend": "codex", "level": "level1", "results": results}
+    md = scorecard_md(run, EQUAL, "equal")
+    assert "CHEATING" not in md  # a cheat is folded into fail, never its own category
+    assert "| A | 1 | 2 | 50.0% |" in md
+    assert "| B | 1 | 1 | 100.0% |" in md
+    assert "| **Total** | **2** | **3** | **66.7%** |" in md
+    assert "**Pass rate**: 2/3 (66.7%)" in md
+
+
+def test_comparison_row_per_run():
+    runs = [
+        {"id": "r1", "backend": "codex", "level": "level1", "results": [_r("PASS"), _r("FAIL")]},
+        {"id": "r2", "backend": "claude_code", "level": "level1", "results": [_r("PASS"), _r("PASS")]},
+    ]
+    md = comparison_md(runs, EQUAL, "equal")
+    assert "Comparison — 2 runs" in md
+    assert "| r1 | codex | level1 | 50.0% | 1/2 |" in md
+    assert "| r2 | claude_code | level1 | 100.0% | 2/2 |" in md
+
+
+def test_load_run_from_dir(tmp_path):
+    d = tmp_path / "run"
+    d.mkdir()
+    (d / "results.json").write_text(json.dumps([_r("PASS", backend="codex", level="level1")]))
+    run = load_run(str(d))
+    assert run["backend"] == "codex"
+    assert run["level"] == "level1"
+    assert len(run["results"]) == 1


### PR DESCRIPTION
Adds `tlaps-bench score` to compute pass-rate scorecards from `results.json`, plus a pass-rate line in the run summary.

- `score <results.json|run-dir> [...]` — a single input prints a scorecard (overall pass rate + per-module breakdown + token/time cost); multiple inputs print a comparison table.
- A task passes iff `check_verdict == "PASS"`; FAIL / CHEATING / TIMEOUT / ERROR all count as not passed.
- Scoring is pluggable via `SCORERS` (default `equal`: every task weight 1, score = percentage passed).
- runner: `summary.md` now shows `**Pass rate**: N/total (X%)`.
