### PR TITLE
Allow api.github.com for Copilot auth and re-enable container preflight

### DIFF
--- a/src/common/container.py
+++ b/src/common/container.py
@@ -323,6 +323,36 @@ class ContainerRunner:
                 self.kill_by_id(cid)
             raise
 
+    def run_preflight(self, config: ContainerConfig, cmd: list[str], stdin_data: str, timeout: int = 180) -> None:
+        """Validate a backend end-to-end before a full run. Raises on failure.
+
+        Runs the real agent command (`cmd`) on a trivial prompt through the SAME
+        install + firewall path as a real run (build_composite_command applies
+        /opt/firewall.sh, then drops NET_ADMIN). This is what makes the check
+        meaningful: it exercises the actual network sandbox, so a broken model
+        id, an unknown CLI flag, missing credentials, or a firewall that blocks
+        the auth host all surface here — instead of silently producing a whole
+        sweep of 0-token FAILs. (The earlier preflight bypassed firewall.sh and
+        so could not have caught an auth-host block.)
+        """
+        docker_args, cid_file = self.build_docker_args(config)
+        composite = self.build_composite_command(cmd, config.install_script)
+        full_cmd = docker_args + ["bash", "-c", composite]
+        try:
+            result = subprocess.run(full_cmd, input=stdin_data, capture_output=True, text=True, timeout=timeout)
+        except subprocess.TimeoutExpired as e:
+            cid = self._read_cidfile(cid_file)
+            if cid:
+                self.kill_by_id(cid)
+            raise RuntimeError(f"preflight timed out after {timeout}s") from e
+        finally:
+            self.cleanup_credential_tmps()
+        if result.returncode != 0:
+            output = (result.stderr or result.stdout or "").strip()
+            if len(output) > 2000:
+                output = "... (truncated) ...\n" + output[-2000:]
+            raise RuntimeError(f"preflight failed (exit {result.returncode}):\n{output}")
+
     def kill(self, run: ContainerRun) -> None:
         """Kill a running container."""
         if run.container_id:

--- a/src/evaluator/backends/copilot.py
+++ b/src/evaluator/backends/copilot.py
@@ -105,7 +105,16 @@ class CopilotBackend(AgentBackend):
             return f"copilot: auth probe error: {e}"
 
     def firewall_hosts(self) -> list[str]:
-        return detect_firewall_hosts(self.model)
+        # GitHub Copilot validates/exchanges the GITHUB token at api.github.com
+        # (/copilot_internal/user + /copilot_internal/v2/token) BEFORE it can
+        # reach the inference API at api.githubcopilot.com. Unlike codex/claude —
+        # whose auth host and inference host are the same already-allowlisted
+        # provider domain — Copilot's auth host is distinct, so it must be added
+        # explicitly. Without it the firewall drops the auth request and the CLI
+        # exits before any model call (0 tokens). The agent's own tools still
+        # can't reach it: the GitHub MCP server is off (--disable-builtin-mcps)
+        # and web_fetch is excluded, so this only enables the auth handshake.
+        return detect_firewall_hosts(self.model) + ["api.github.com"]
 
     def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         lines: list[str] = []

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -814,6 +814,50 @@ def _parse_grader_result(exit_code: int, stdout: str, result: dict) -> None:
             result["obligations_total"] = int(fail_match.group(2))
 
 
+# A one-word prompt that needs no tools and no workspace files — keeps the
+# preflight model call as cheap and as deterministic as possible.
+PREFLIGHT_PROMPT = "Reply with the single word: ok. Do not use any tools."
+
+
+def _run_preflight(backend) -> None:
+    """Validate a backend end-to-end (install + auth + model + firewall) before
+    the run, aborting the process on failure.
+
+    Runs the backend's real build_command inside a throwaway container — same
+    install script, env, credentials and firewall as a real run — on a one-word
+    prompt. A broken model id, an unknown CLI flag, missing credentials, or an
+    auth host the firewall blocks all surface here in ~1 min, instead of as a
+    full sweep of silent 0-token FAILs.
+    """
+    runner = ContainerRunner()
+    workspace = tempfile.mkdtemp(prefix="preflight_ws_")
+    result_dir = tempfile.mkdtemp(prefix="preflight_res_")
+    # Mirror a real run's workspace: the per-benchmark flow git-inits it, and
+    # some CLIs (e.g. codex exec) refuse to run outside a git repo. Without this
+    # the preflight would false-fail for those backends.
+    subprocess.run(["git", "init"], capture_output=True, cwd=workspace)
+    try:
+        config = ContainerConfig(
+            workspace=workspace,
+            result_dir=result_dir,
+            env=forward_env(backend.env_keys, model=getattr(backend, "model", None)),
+            firewall_hosts=backend.firewall_hosts(),
+            install_script=backend.install_script,
+            credential_mounts=backend.get_credential_mounts(),
+        )
+        cmd = backend.build_command("/workspace", "/results")
+        print(f"Preflight: validating '{backend.name}' (install + auth + model + firewall)...", flush=True)
+        runner.run_preflight(config, cmd, PREFLIGHT_PROMPT)
+        print("Preflight: OK", flush=True)
+    except RuntimeError as e:
+        print(f"ERROR: {e}")
+        print("Aborting before the run. Re-run with --skip-preflight to bypass this check.")
+        sys.exit(1)
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+        shutil.rmtree(result_dir, ignore_errors=True)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Run an agent CLI on TLAPS benchmarks")
     parser.add_argument("--backend", default="codex", choices=list_backends(), help="Agent backend (default: codex)")
@@ -867,6 +911,12 @@ def main():
         action="store_true",
         help="Force rebuild the Docker base image before running",
     )
+    parser.add_argument(
+        "--skip-preflight",
+        action="store_true",
+        help="Skip the container preflight check (validate install + auth + model + firewall "
+        "on a trivial prompt before the run). Container mode only.",
+    )
     args = parser.parse_args()
 
     backend = get_backend(args.backend, model=args.model)
@@ -890,6 +940,14 @@ def main():
 
         ensure_image(force=args.force_build)
         print("Container mode: ON (image: tlaps-bench-base)")
+
+        # Preflight: validate install + auth + model + firewall on a trivial
+        # prompt before committing to the full run. A broken backend (bad model
+        # id, unknown CLI flag, missing credentials, or an auth host the
+        # firewall blocks) otherwise produces a whole sweep of silent 0-token
+        # FAILs that look like honest "couldn't prove it" results.
+        if not args.skip_preflight:
+            _run_preflight(backend)
     else:
         # Local mode: require tlapm and checker on host
         ensure_tlapm()

--- a/tests/evaluator/test_container.py
+++ b/tests/evaluator/test_container.py
@@ -4,6 +4,8 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
 from common.container import ContainerConfig, ContainerRunner, forward_env
@@ -369,3 +371,46 @@ class TestKill:
         run = MagicMock(container_id="", proc=proc)
         runner.kill(run)
         proc.kill.assert_called_once()
+
+
+class TestCopilotFirewallHosts:
+    def test_includes_github_auth_host(self):
+        # Copilot exchanges its GITHUB token at api.github.com before reaching
+        # the inference API; without this host the firewall drops the auth call.
+        hosts = CopilotBackend().firewall_hosts()
+        assert "api.github.com" in hosts
+        assert "api.githubcopilot.com" in hosts  # inference host still present
+
+
+class TestRunPreflight:
+    @patch("subprocess.run")
+    def test_passes_through_install_and_firewall_path(self, mock_run):
+        # A passing probe must still be routed through the real install +
+        # firewall composite — that is what makes it able to catch an auth-host
+        # block. The old preflight bypassed firewall.sh and so could not.
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        runner = ContainerRunner()
+        config = ContainerConfig(
+            workspace="/tmp/ws",
+            result_dir="/tmp/res",
+            firewall_hosts=["api.githubcopilot.com", "api.github.com"],
+            install_script="install-copilot.sh",
+        )
+        runner.run_preflight(config, ["copilot", "-p", "ok"], "say ok")
+
+        composite = mock_run.call_args.args[0][-1]
+        assert "/opt/install-scripts/install-copilot.sh" in composite
+        assert "/opt/firewall.sh" in composite
+        assert mock_run.call_args.kwargs["input"] == "say ok"
+
+    @patch("subprocess.run")
+    def test_raises_on_nonzero_exit_with_output(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="Authentication token found but could not be validated.",
+        )
+        runner = ContainerRunner()
+        config = ContainerConfig(firewall_hosts=["api.githubcopilot.com"])
+        with pytest.raises(RuntimeError, match="preflight failed"):
+            runner.run_preflight(config, ["copilot"], "say ok")


### PR DESCRIPTION
## Problem

`--backend copilot` fails every task `❌ FAIL` in ~30s with `0/0 tok` — the agent never calls the model. `stderr.txt`:

```
Authentication token found but could not be validated.
... network fetch failed ... https://api.github.com/copilot_internal/user
```

The token is fine; the connection is blocked.

## Root cause

Copilot validates its GitHub token at `api.github.com` before reaching the inference API at `api.githubcopilot.com`. The firewall allowlist only had the inference host. codex/claude don't hit this (auth host == inference host); Copilot's auth host is distinct, so it was never reachable.

## Changes

1. `CopilotBackend.firewall_hosts()` adds `api.github.com`. Agent tools still can't use it (MCP off, `web_fetch` excluded) — only the auth handshake.
2. Re-enable a container preflight (default on, `--skip-preflight` to skip): runs the real `build_command` on a one-word prompt through the same install + firewall path, and aborts on failure. The old preflight bypassed `firewall.sh` and couldn't have caught this.