### PR TITLE
Refactor quota gate into per-backend module with codex usage-limit retry

### DIFF
--- a/scripts/usage/claude.sh
+++ b/scripts/usage/claude.sh
@@ -6,9 +6,9 @@
 # quota gate (src/evaluator/runner.py) and runnable standalone.
 #
 # Usage:
-#   bash scripts/usage.sh              # JSON output (full endpoint response)
-#   bash scripts/usage.sh --check 80   # exit 1 if 5h/7d window > 80%
-#   bash scripts/usage.sh --summary    # one human-readable line per window
+#   bash scripts/usage/claude.sh              # JSON output (full endpoint response)
+#   bash scripts/usage/claude.sh --check 80   # exit 1 if 5h/7d window > 80%
+#   bash scripts/usage/claude.sh --summary    # one human-readable line per window
 #
 # Profile selection (first match wins):
 #   CLAUDE_CREDENTIALS   — explicit path to credentials.json

--- a/scripts/usage/codex.sh
+++ b/scripts/usage/codex.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Read Codex (ChatGPT) subscription usage from the local session rollouts.
+#
+# Codex records account-wide rate-limit snapshots in its session rollout files
+# ($CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl) as `token_count` events
+# whose payload carries a `rate_limits` object:
+#   primary   -> 5-hour window (window_minutes 300)
+#   secondary -> weekly window (window_minutes 10080)
+# each with `used_percent` and `resets_at` (unix epoch seconds).
+#
+# This emits the SAME JSON shape as scripts/usage/claude.sh, so the benchmark
+# runner's quota gate (src/evaluator/runner.py) consumes it unchanged:
+#   {"five_hour": {"utilization": N, "resets_at": "ISO"},
+#    "seven_day": {"utilization": N, "resets_at": "ISO"}}
+# mapping primary -> five_hour, secondary -> seven_day, used_percent -> utilization.
+#
+# A window whose resets_at is already in the past has rolled over since the
+# snapshot was written, so its used_percent is stale: we report 0 for it rather
+# than block on an expired number.
+#
+# Usage:
+#   bash scripts/usage/codex.sh              # JSON (same shape as claude.sh)
+#   bash scripts/usage/codex.sh --check 95   # exit 1 if 5h/7d window > 95%
+#   bash scripts/usage/codex.sh --summary    # one human-readable line per window
+#
+# Override the codex home with CODEX_HOME (default $HOME/.codex).
+#
+# Exit codes:
+#   0  ok (or under threshold in --check mode)
+#   1  over threshold (--check mode)
+#   2  no usage data (no session rollout with rate_limits found)
+
+set -euo pipefail
+
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+export USAGE_MODE="${1:-}"
+export USAGE_THRESHOLD="${2:-95}"
+
+python3 <<'PY'
+import glob
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+home = os.environ["CODEX_HOME"]
+mode = os.environ.get("USAGE_MODE", "")
+sessions = os.path.join(home, "sessions")
+
+
+def find_rate_limits(obj):
+    """Depth-first search for a `rate_limits` dict anywhere in an event."""
+    if isinstance(obj, dict):
+        rl = obj.get("rate_limits")
+        if isinstance(rl, dict):
+            return rl
+        for v in obj.values():
+            r = find_rate_limits(v)
+            if r:
+                return r
+    elif isinstance(obj, list):
+        for v in obj:
+            r = find_rate_limits(v)
+            if r:
+                return r
+    return None
+
+
+def last_rate_limits(path):
+    """The last rate_limits snapshot in one rollout file, or None."""
+    found = None
+    try:
+        with open(path) as f:
+            for line in f:
+                if '"rate_limits"' not in line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                rl = find_rate_limits(event)
+                if rl:
+                    found = rl
+    except OSError:
+        return None
+    return found
+
+
+# Newest-written rollout first; the freshest snapshot lives in the session
+# codex touched most recently. Scan a few in case the very newest session
+# crashed before emitting any token_count event.
+files = glob.glob(os.path.join(sessions, "**", "rollout-*.jsonl"), recursive=True)
+files.sort(key=os.path.getmtime, reverse=True)
+
+rate_limits = None
+for path in files[:10]:
+    rate_limits = last_rate_limits(path)
+    if rate_limits:
+        break
+
+if not rate_limits:
+    sys.stderr.write(f"error: no codex session usage data under {sessions}\n")
+    sys.exit(2)
+
+now = datetime.now(timezone.utc).timestamp()
+
+
+def window(obj):
+    obj = obj or {}
+    used = obj.get("used_percent")
+    resets = obj.get("resets_at")
+    iso = None
+    if isinstance(resets, (int, float)):
+        iso = datetime.fromtimestamp(resets, tz=timezone.utc).isoformat()
+        if resets <= now:
+            used = 0  # window already rolled over; the snapshot's percent is stale
+    return {"utilization": used if used is not None else 0, "resets_at": iso}
+
+
+out = {
+    "five_hour": window(rate_limits.get("primary")),
+    "seven_day": window(rate_limits.get("secondary")),
+}
+
+if mode == "--check":
+    threshold = float(os.environ.get("USAGE_THRESHOLD", "95"))
+    over = []
+    for name, key in (("5h", "five_hour"), ("7d", "seven_day")):
+        util = out[key].get("utilization") or 0
+        if util > threshold:
+            over.append(f"{name}={util}% resets_at={out[key].get('resets_at') or ''}")
+    if over:
+        print("\n".join(over))
+        sys.exit(1)
+    print("ok")
+elif mode == "--summary":
+    for name, key in (("5h ", "five_hour"), ("7d ", "seven_day")):
+        o = out[key]
+        print(f"{name}\t{o.get('utilization'):>5}%   resets_at={o.get('resets_at') or '-'}")
+else:
+    print(json.dumps(out))
+PY

--- a/scripts/usage/codex.sh
+++ b/scripts/usage/codex.sh
@@ -71,7 +71,10 @@ def last_rate_limits(path):
     """The last rate_limits snapshot in one rollout file, or None."""
     found = None
     try:
-        with open(path) as f:
+        # Rollouts are UTF-8 (serde_json); decode explicitly so a non-UTF-8 host
+        # locale doesn't raise UnicodeDecodeError on `for line in f` and silently
+        # disable the gate. errors="replace" keeps a stray byte from crashing us.
+        with open(path, encoding="utf-8", errors="replace") as f:
             for line in f:
                 if '"rate_limits"' not in line:
                     continue
@@ -82,7 +85,7 @@ def last_rate_limits(path):
                 rl = find_rate_limits(event)
                 if rl:
                     found = rl
-    except OSError:
+    except (OSError, ValueError):
         return None
     return found
 
@@ -115,6 +118,11 @@ def window(obj):
         iso = datetime.fromtimestamp(resets, tz=timezone.utc).isoformat()
         if resets <= now:
             used = 0  # window already rolled over; the snapshot's percent is stale
+    else:
+        # No usable reset epoch — we can't tell whether used_percent is fresh and
+        # the gate would have no resets_at to sleep until, so fail open (report 0)
+        # rather than block on a possibly-stale value with no recovery time.
+        used = 0
     return {"utilization": used if used is not None else 0, "resets_at": iso}
 
 

--- a/src/evaluator/backends/base.py
+++ b/src/evaluator/backends/base.py
@@ -114,3 +114,31 @@ class AgentBackend(ABC):
     def firewall_hosts(self) -> list[str]:
         """API hosts that must be reachable."""
         return []
+
+    def detect_quota_block(self, jsonl_path: str) -> int | None:
+        """If the run hit a hard provider usage/quota cap (the agent did no work),
+        return seconds to wait before retrying; else None.
+
+        This is distinct from the percentage usage gate: once a provider hard-caps
+        the account, the agent emits no usage events, so the gate's utilization
+        reading goes stale and never trips. Backends that can recognise the cap in
+        their own output override this so the runner pauses-and-retries instead of
+        grading a no-op run as a failure. Default: never blocks.
+        """
+        return None
+
+    def usage_script(self) -> str | None:
+        """Repo-relative path to this backend's usage probe, or None if it has
+        none. The probe prints subscription utilization as the JSON shape the
+        quota gate consumes (see scripts/usage/). Returning None disables the
+        proactive gate for this backend. Overrides replace the runner's old
+        name-based script selection so adding a backend needs no runner change.
+        """
+        return None
+
+    def default_quota(self) -> tuple[float, float]:
+        """Default (5h%, 7d%) thresholds for the proactive gate when the user
+        passes no --quota-5h/--quota-7d. (0, 0) leaves the gate off; a backend
+        with a usage_script overrides this with its subscription's sensible caps.
+        """
+        return (0.0, 0.0)

--- a/src/evaluator/backends/claude_code.py
+++ b/src/evaluator/backends/claude_code.py
@@ -136,6 +136,12 @@ class ClaudeCodeBackend(AgentBackend):
     def firewall_hosts(self) -> list[str]:
         return detect_firewall_hosts(self.model)
 
+    def usage_script(self) -> str | None:
+        return "scripts/usage/claude.sh"
+
+    def default_quota(self) -> tuple[float, float]:
+        return (80.0, 95.0)
+
     def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         lines: list[str] = []
         in_tok = 0

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -198,12 +198,16 @@ class CodexBackend(AgentBackend):
         return quota.secs_until_reset(when, clamp_hi=6 * 3600, fallback=1800)
 
     def _reset_at_from_probe(self) -> str | None:
-        """The 5h window's reset time (ISO) from the codex usage probe, or None.
+        """The reset time (ISO) of the window that hit its cap, from the codex
+        usage probe — or None.
 
-        This is the structured ``resets_at`` epoch codex writes to its session
-        rollout — far more reliable than the human time in the cap message. The 5h
-        window is codex's usual hard cap; when the probe can't be read (no repo
-        script, no ~/.codex, API-key auth) the caller falls back to the prose time.
+        Codex records a structured ``resets_at`` epoch per window in its session
+        rollout, far more reliable than the human time in the cap message. The
+        binding window is the one at its cap (utilization >= 100); when both the 5h
+        and weekly windows are capped we wait for the later reset, so a weekly cap
+        with a fresh 5h window doesn't make us retry-thrash until the 5h resets.
+        Falls back to the most-utilized window, then to None (prose time) when the
+        probe can't be read (no repo script, no ~/.codex, API-key auth).
         """
         rel = self.usage_script()
         if not rel:
@@ -211,7 +215,14 @@ class CodexBackend(AgentBackend):
         usage = quota.fetch_usage(os.path.join(_REPO_ROOT, rel))
         if not usage:
             return None
-        return (usage.get("five_hour") or {}).get("resets_at")
+        windows = [usage.get("five_hour") or {}, usage.get("seven_day") or {}]
+        capped = [w for w in windows if (w.get("utilization") or 0) >= 100 and w.get("resets_at")]
+        if capped:
+            return max(w["resets_at"] for w in capped)  # wait past the last-clearing cap
+        with_reset = [w for w in windows if w.get("resets_at")]
+        if not with_reset:
+            return None
+        return max(with_reset, key=lambda w: w.get("utilization") or 0)["resets_at"]
 
     @staticmethod
     def _parse_retry_time(msg: str) -> datetime | None:

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -29,6 +29,10 @@ DEFAULT_MODEL = "gpt-5.5"
 _USAGE_LIMIT_RE = re.compile(r"usage limit", re.IGNORECASE)
 _RETRY_AT_RE = re.compile(r"try again at\s+(\d{1,2}):(\d{2})\s*([AaPp][Mm])")
 
+# detect_quota_block runs host-side (after the agent container exits) where the
+# repo and ~/.codex are available, so it can reuse the usage probe's precise reset.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
 
 class CodexBackend(AgentBackend):
     name = "codex"
@@ -185,9 +189,29 @@ class CodexBackend(AgentBackend):
             return None
         if msg is None:
             return None
-        return quota.secs_until_reset(
-            self._parse_retry_time(msg), clamp_hi=6 * 3600, fallback=1800
-        )
+        # Prefer the precise reset epoch codex records in its session rollout (what
+        # the usage probe reads) over parsing the human "try again at 7:24 PM"
+        # string, which is timezone- and boundary-fragile. Fall back to the prose
+        # time only when the probe has no data.
+        reset_at = self._reset_at_from_probe()
+        when = reset_at if reset_at is not None else self._parse_retry_time(msg)
+        return quota.secs_until_reset(when, clamp_hi=6 * 3600, fallback=1800)
+
+    def _reset_at_from_probe(self) -> str | None:
+        """The 5h window's reset time (ISO) from the codex usage probe, or None.
+
+        This is the structured ``resets_at`` epoch codex writes to its session
+        rollout — far more reliable than the human time in the cap message. The 5h
+        window is codex's usual hard cap; when the probe can't be read (no repo
+        script, no ~/.codex, API-key auth) the caller falls back to the prose time.
+        """
+        rel = self.usage_script()
+        if not rel:
+            return None
+        usage = quota.fetch_usage(os.path.join(_REPO_ROOT, rel))
+        if not usage:
+            return None
+        return (usage.get("five_hour") or {}).get("resets_at")
 
     @staticmethod
     def _parse_retry_time(msg: str) -> datetime | None:

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import tomllib
+from datetime import datetime, timedelta
 from pathlib import Path
+
+from evaluator import quota
 
 from .base import (
     AgentBackend,
@@ -19,6 +23,11 @@ from .base import (
 )
 
 DEFAULT_MODEL = "gpt-5.5"
+
+# ChatGPT's hard usage cap surfaces as an `error` / `turn.failed` event whose
+# message reads e.g. "You've hit your usage limit. ... try again at 7:24 PM."
+_USAGE_LIMIT_RE = re.compile(r"usage limit", re.IGNORECASE)
+_RETRY_AT_RE = re.compile(r"try again at\s+(\d{1,2}):(\d{2})\s*([AaPp][Mm])")
 
 
 class CodexBackend(AgentBackend):
@@ -136,6 +145,73 @@ class CodexBackend(AgentBackend):
 
     def firewall_hosts(self) -> list[str]:
         return detect_firewall_hosts(self.model)
+
+    def usage_script(self) -> str | None:
+        return "scripts/usage/codex.sh"
+
+    def default_quota(self) -> tuple[float, float]:
+        return (95.0, 95.0)
+
+    def detect_quota_block(self, jsonl_path: str) -> int | None:
+        """Detect ChatGPT's hard 'usage limit' cap and return seconds to wait.
+
+        The percentage gate cannot see this: once capped, codex's turns fail
+        instantly with no `usage` event, so the rolling utilization the gate reads
+        goes stale/low and never trips — every subsequent task fails in ~3s and is
+        misgraded as FAIL. We scan the run's own events for the explicit usage-limit
+        error and sleep until the stated reset instead. Returns None if no cap.
+        """
+        msg = None
+        try:
+            with open(jsonl_path) as f:
+                for raw in f:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        ev = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    t = ev.get("type", "")
+                    if t == "error":
+                        m = ev.get("message", "")
+                    elif t == "turn.failed":
+                        m = (ev.get("error") or {}).get("message", "")
+                    else:
+                        continue
+                    if m and _USAGE_LIMIT_RE.search(m):
+                        msg = m  # keep the last occurrence
+        except FileNotFoundError:
+            return None
+        if msg is None:
+            return None
+        return quota.secs_until_reset(
+            self._parse_retry_time(msg), clamp_hi=6 * 3600, fallback=1800
+        )
+
+    @staticmethod
+    def _parse_retry_time(msg: str) -> datetime | None:
+        """Parse 'try again at 7:24 PM' from a usage-limit message into a datetime
+        (today, or tomorrow if that time already passed), or None if absent. Waking
+        too early (timezone skew) is self-correcting: the retry re-hits the cap and
+        re-sleeps on the fresh error.
+        """
+        m = _RETRY_AT_RE.search(msg)
+        if not m:
+            return None
+        try:
+            hh, mm, ap = int(m.group(1)), int(m.group(2)), m.group(3).upper()
+            if ap == "PM" and hh != 12:
+                hh += 12
+            elif ap == "AM" and hh == 12:
+                hh = 0
+            now = datetime.now()
+            target = now.replace(hour=hh, minute=mm, second=0, microsecond=0)
+            if target <= now:
+                target += timedelta(days=1)
+            return target
+        except Exception:
+            return None
 
     def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         lines: list[str] = []

--- a/src/evaluator/quota.py
+++ b/src/evaluator/quota.py
@@ -146,6 +146,10 @@ def run_with_quota_retry(
         block_secs = detect_block()
         if block_secs is None:
             return True
+        if attempt == max_retries - 1:
+            # Last attempt: the verdict is already "give up", so don't sleep
+            # through a reset (up to 6h) we'll never use.
+            break
         print(
             f"{log_prefix}provider usage limit hit — sleeping {block_secs}s then "
             f"retrying (attempt {attempt + 1}/{max_retries})",

--- a/src/evaluator/quota.py
+++ b/src/evaluator/quota.py
@@ -1,0 +1,155 @@
+"""Subscription usage measurement and the quota gate.
+
+Two complementary mechanisms keep a run from being misgraded when a provider
+limits the account:
+
+- Proactive gate (``wait_for_quota``): before launching an agent, read the
+  backend's subscription utilization (via its usage probe, see ``scripts/usage/``)
+  and sleep until the window resets when it is over threshold.
+- Reactive retry (``run_with_quota_retry``): after a run, if the backend reports
+  a hard usage cap — the agent did no work (``AgentBackend.detect_quota_block``) —
+  sleep until the stated reset and retry rather than grade the no-op run as FAIL.
+
+Both share ``secs_until_reset``, the single "how long until this resets" helper.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from datetime import datetime
+
+
+def secs_until_reset(when, *, clamp_hi: int = 3600, buffer: int = 120, fallback: int = 600) -> int:
+    """Seconds from now until ``when``, plus ``buffer``, clamped to [60, clamp_hi].
+
+    ``when`` may be an ISO-8601 string, a ``datetime``, or ``None``; returns
+    ``fallback`` when it is missing or unparseable. The upper clamp guards against
+    a skewed system clock computing an absurd sleep (this host has shown corrupt
+    process times); callers re-poll after sleeping, so a low clamp only costs an
+    extra check, never a missed resume. The two call sites differ deliberately:
+    the proactive gate caps at 1h (it re-reads usage cheaply), the reactive retry
+    caps at 6h (the provider's stated reset is authoritative).
+    """
+    if when is None:
+        return fallback
+    try:
+        dt = when if isinstance(when, datetime) else datetime.fromisoformat(when)
+        secs = int(dt.timestamp() - time.time()) + buffer
+        return min(max(secs, 60), clamp_hi)
+    except Exception:
+        return fallback
+
+
+def fetch_usage(usage_script: str | None) -> dict | None:
+    """Return the parsed usage JSON from a backend's probe, or None if unavailable.
+
+    Fails open (returns None) on any error — missing script, no subscription/OAuth
+    token, network failure, bad JSON. Callers treat None as "can't tell, proceed",
+    so the gate never blocks a run it can't measure (e.g. the API-key path).
+    """
+    if not usage_script or not os.path.isfile(usage_script):
+        return None
+    try:
+        r = subprocess.run(["bash", usage_script], capture_output=True, text=True, timeout=30)
+    except Exception:
+        return None
+    if r.returncode != 0 or not r.stdout.strip():
+        return None
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _usage_over(usage: dict, quota_5h: float, quota_7d: float):
+    """Return (list of "5h=NN% (limit MM%)" strings, earliest resets_at) for any
+    window over its limit. A limit <= 0 disables that window's check."""
+    over = []
+    resets = []
+    for key, limit in (("five_hour", quota_5h), ("seven_day", quota_7d)):
+        if limit <= 0:
+            continue
+        obj = usage.get(key) or {}
+        util = obj.get("utilization") or 0
+        if util > limit:
+            over.append(f"{key}={util}% (limit {limit}%)")
+            ra = obj.get("resets_at")
+            if ra:
+                resets.append(ra)
+    earliest = sorted(resets)[0] if resets else None
+    return over, earliest
+
+
+def wait_for_quota(usage_script, quota_5h, quota_7d, max_waits, log_prefix: str = "") -> bool:
+    """Block until subscription 5h/7d usage is under threshold.
+
+    Polls ``usage_script``; if a window is over its limit, sleeps until that
+    window's resets_at (+buffer), then re-checks. Returns True once under
+    threshold (or when gating is disabled / usage can't be measured), or False
+    after exceeding ``max_waits`` resets (caller should abort the benchmark).
+    """
+    if not usage_script or (quota_5h <= 0 and quota_7d <= 0):
+        return True
+    waits = 0
+    while True:
+        usage = fetch_usage(usage_script)
+        if usage is None:
+            return True  # fail open — can't measure, don't block
+        over, reset_at = _usage_over(usage, quota_5h, quota_7d)
+        if not over:
+            return True
+        waits += 1
+        if waits > max_waits:
+            print(
+                f"{log_prefix}quota over after {max_waits} waits "
+                f"({', '.join(over)}); aborting this benchmark",
+                flush=True,
+            )
+            return False
+        sleep_secs = secs_until_reset(reset_at, clamp_hi=3600)
+        when = reset_at or f"+{sleep_secs}s"
+        print(
+            f"{log_prefix}quota over: {', '.join(over)} — sleeping "
+            f"{sleep_secs}s until {when} (wait {waits}/{max_waits})",
+            flush=True,
+        )
+        time.sleep(sleep_secs)
+
+
+# Max times to sleep-through a hard provider usage cap for a single benchmark
+# before giving up. Each sleep is the provider's stated reset, so a handful covers
+# any real outage; the cap is just a runaway backstop.
+MAX_QUOTA_RETRIES = 12
+
+
+def run_with_quota_retry(
+    run_once, detect_block, *, max_retries: int = MAX_QUOTA_RETRIES, log_prefix: str = ""
+) -> bool:
+    """Run the agent, sleeping through any hard provider usage-limit cap.
+
+    The proactive gate (``wait_for_quota``) cannot see this cap: once hard-capped,
+    the agent emits no usage events, so utilization reads stale and never trips,
+    and every task would fail in ~3s and be misgraded FAIL. After each run we ask
+    the backend (``detect_block``) whether the run hit the cap and how long to
+    wait, then retry rather than grade a no-op run.
+
+    ``run_once``: () -> None — launches the agent, writing its output.
+    ``detect_block``: () -> int | None — seconds to wait, or None when no cap.
+    Returns True if a run completed without hitting the cap, False if the cap
+    persisted past ``max_retries``.
+    """
+    for attempt in range(max_retries):
+        run_once()
+        block_secs = detect_block()
+        if block_secs is None:
+            return True
+        print(
+            f"{log_prefix}provider usage limit hit — sleeping {block_secs}s then "
+            f"retrying (attempt {attempt + 1}/{max_retries})",
+            flush=True,
+        )
+        time.sleep(block_secs)
+    return False

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -32,6 +32,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 
 from common.container import ContainerConfig, ContainerRunner, ensure_image, forward_env
+from evaluator import quota
 from evaluator.backends import get_backend, list_backends
 from evaluator.backends.base import AgentBackend
 from evaluator.modes import get_mode, list_modes
@@ -84,101 +85,6 @@ def find_tlapm_lib(tlapm_path: str) -> str | None:
         if os.path.isdir(path):
             return path
     return None
-
-
-def fetch_usage(usage_script: str) -> dict | None:
-    """Return the parsed OAuth usage JSON, or None if unavailable.
-
-    Fails open (returns None) on any error — missing script, API-key-only auth
-    with no OAuth token, network failure, bad JSON. Callers treat None as
-    "can't tell, proceed", so the quota gate never blocks a run it can't
-    measure (e.g. the docker / API-key path).
-    """
-    if not usage_script or not os.path.isfile(usage_script):
-        return None
-    try:
-        r = subprocess.run(["bash", usage_script], capture_output=True, text=True, timeout=30)
-    except Exception:
-        return None
-    if r.returncode != 0 or not r.stdout.strip():
-        return None
-    try:
-        return json.loads(r.stdout)
-    except json.JSONDecodeError:
-        return None
-
-
-def _usage_over(usage: dict, quota_5h: float, quota_7d: float):
-    """Return (list of "5h=NN% (limit MM%)" strings, earliest resets_at) for
-    any window over its limit. A limit <= 0 disables that window's check."""
-    over = []
-    resets = []
-    for key, limit in (("five_hour", quota_5h), ("seven_day", quota_7d)):
-        if limit <= 0:
-            continue
-        obj = usage.get(key) or {}
-        util = obj.get("utilization") or 0
-        if util > limit:
-            over.append(f"{key}={util}% (limit {limit}%)")
-            ra = obj.get("resets_at")
-            if ra:
-                resets.append(ra)
-    earliest = sorted(resets)[0] if resets else None
-    return over, earliest
-
-
-def _secs_until(resets_at: str) -> int:
-    """Seconds from now until an ISO-8601 resets_at, + 120s buffer.
-
-    Clamped to [60, 3600]. The 1h cap is a safety net against a skewed system
-    clock (this host has shown corrupt process times): a bad time.time() could
-    otherwise compute a multi-day sleep. The gate re-polls after each sleep, so
-    capping just means an extra usage check, never a missed resume.
-    """
-    try:
-        from datetime import datetime
-
-        dt = datetime.fromisoformat(resets_at)
-        secs = int(dt.timestamp() - time.time()) + 120
-        return min(max(secs, 60), 3600)
-    except Exception:
-        return 600
-
-
-def wait_for_quota(item: "WorkItem", log_prefix: str = "") -> bool:
-    """Block until the subscription's 5h/7d usage is under threshold.
-
-    Polls usage_script; if a window is over its limit, sleeps until that
-    window's resets_at (+2min), then re-checks. Returns True once under
-    threshold (or when gating is disabled / usage can't be measured), or
-    False after exceeding quota_max_waits resets (caller should abort).
-    """
-    if not item.usage_script or (item.quota_5h <= 0 and item.quota_7d <= 0):
-        return True
-    waits = 0
-    while True:
-        usage = fetch_usage(item.usage_script)
-        if usage is None:
-            return True  # fail open — can't measure, don't block
-        over, reset_at = _usage_over(usage, item.quota_5h, item.quota_7d)
-        if not over:
-            return True
-        waits += 1
-        if waits > item.quota_max_waits:
-            print(
-                f"{log_prefix}quota over after {item.quota_max_waits} waits "
-                f"({', '.join(over)}); aborting this benchmark",
-                flush=True,
-            )
-            return False
-        sleep_secs = _secs_until(reset_at) if reset_at else 600
-        when = reset_at or f"+{sleep_secs}s"
-        print(
-            f"{log_prefix}quota over: {', '.join(over)} — sleeping "
-            f"{sleep_secs}s until {when} (wait {waits}/{item.quota_max_waits})",
-            flush=True,
-        )
-        time.sleep(sleep_secs)
 
 
 def _proc_descendants(root_pid: int) -> list:
@@ -427,7 +333,10 @@ def run_single_benchmark(item: WorkItem):
         "error": "",
     }
 
-    if not wait_for_quota(item, log_prefix=f"[{name_no_ext}] "):
+    if not quota.wait_for_quota(
+        item.usage_script, item.quota_5h, item.quota_7d, item.quota_max_waits,
+        log_prefix=f"[{name_no_ext}] ",
+    ):
         result["agent_exit"] = -3
         result["error"] = "quota exceeded (max waits reached); skipped"
         result["input_tokens"] = 0
@@ -496,15 +405,35 @@ def run_single_benchmark(item: WorkItem):
         wait_for_memory(item.min_free_gb, 120, log_prefix=f"[{name_no_ext}] ")
         start_time = time.time()
 
-        if item.use_container:
-            _run_agent_container(item, backend, workspace, agent_dir, agent_jsonl, prompt, result, canonical_dir)
-        else:
-            _run_agent_local(
-                item, backend, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir
-            )
+        # Run the agent, sleeping through any hard provider usage-limit cap that
+        # the proactive gate (above) can't see. See quota.run_with_quota_retry.
+        def _run_once():
+            result["error"] = ""
+            if item.use_container:
+                _run_agent_container(item, backend, workspace, agent_dir, agent_jsonl, prompt, result, canonical_dir)
+            else:
+                _run_agent_local(
+                    item, backend, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir
+                )
+
+        quota_exhausted = not quota.run_with_quota_retry(
+            _run_once,
+            lambda: backend.detect_quota_block(agent_jsonl),
+            log_prefix=f"[{name_no_ext}] ",
+        )
 
         elapsed = time.time() - start_time
         result["time_secs"] = elapsed
+
+        if quota_exhausted:
+            result["agent_exit"] = -3
+            result["check_verdict"] = "ERROR"
+            result["error"] = "provider usage limit; exhausted quota retries"
+            result["input_tokens"] = result.get("input_tokens", 0)
+            result["output_tokens"] = result.get("output_tokens", 0)
+            with open(os.path.join(result_dir, "result.json"), "w") as f:
+                json.dump(result, f, indent=2)
+            return result
 
         # Parse agent output
         transcript, input_tokens, output_tokens = backend.parse_output(agent_jsonl)
@@ -924,14 +853,21 @@ def main():
         "--check-timeout", type=int, default=600, help="Checker timeout per benchmark in seconds (default: 600)"
     )
     parser.add_argument("--output-dir", default=None, help="Output directory")
-    # Quota gate (claude_code + Claude Max subscription only). Pauses before
-    # launching an agent when subscription usage is over threshold, sleeping
-    # until the window resets. 0 disables a window's check.
+    # Proactive quota gate. Before launching an agent, pause when the backend's
+    # subscription usage is over threshold, sleeping until the window resets. The
+    # backend supplies its own usage probe and default thresholds; --quota-5h/7d
+    # override them, 0 disables a window's check.
     parser.add_argument(
-        "--quota-5h", type=float, default=80, help="Pause when 5-hour usage exceeds this %% (default: 80; 0 = off)"
+        "--quota-5h",
+        type=float,
+        default=None,
+        help="Pause when 5-hour usage exceeds this %% (default: backend-specific; 0 = off)",
     )
     parser.add_argument(
-        "--quota-7d", type=float, default=95, help="Pause when 7-day usage exceeds this %% (default: 95; 0 = off)"
+        "--quota-7d",
+        type=float,
+        default=None,
+        help="Pause when 7-day usage exceeds this %% (default: backend-specific; 0 = off)",
     )
     parser.add_argument(
         "--quota-max-waits",
@@ -939,7 +875,11 @@ def main():
         default=6,
         help="Max window resets to sleep through before aborting a benchmark (default: 6)",
     )
-    parser.add_argument("--usage-script", default=None, help="Path to usage.sh (default: <repo>/scripts/usage.sh)")
+    parser.add_argument(
+        "--usage-script",
+        default=None,
+        help="Override the backend's usage probe with a custom script path",
+    )
     parser.add_argument(
         "--resume", action="store_true", help="Reuse --output-dir: skip benchmarks already PASS there, run the rest"
     )
@@ -1026,28 +966,33 @@ def main():
     print(f"Mode:   {mode.name} — {mode.description}")
     print(f"Output:  {output_dir}")
 
-    # Quota gate: only meaningful for claude_code on a Claude Max subscription.
-    # For other backends, or when usage.sh / OAuth creds are absent, it stays
-    # disabled and never blocks a run.
+    # Proactive quota gate. The backend supplies its usage probe and default
+    # thresholds; --quota-5h/7d override them. Gating stays off when the backend
+    # has no probe, both thresholds are 0, or the probe can't read usage (API-key
+    # auth, no subscription) — it never blocks a run it can't measure.
+    b5, b7 = backend.default_quota()
+    quota_5h = b5 if args.quota_5h is None else args.quota_5h
+    quota_7d = b7 if args.quota_7d is None else args.quota_7d
     usage_script = None
-    if backend.name == "claude_code" and (args.quota_5h > 0 or args.quota_7d > 0):
-        candidate = args.usage_script or os.path.join(REPO_ROOT, "scripts", "usage.sh")
+    script_rel = backend.usage_script()
+    candidate = args.usage_script or (os.path.join(REPO_ROOT, script_rel) if script_rel else None)
+    if candidate and (quota_5h > 0 or quota_7d > 0):
         if os.path.isfile(candidate):
-            usage = fetch_usage(candidate)
+            usage = quota.fetch_usage(candidate)
             if usage is not None:
                 usage_script = candidate
                 u5 = (usage.get("five_hour") or {}).get("utilization", 0)
                 u7 = (usage.get("seven_day") or {}).get("utilization", 0)
                 print(
-                    f"Quota:   gate ON — now 5h={u5}% (limit {args.quota_5h}%), "
-                    f"7d={u7}% (limit {args.quota_7d}%), max-waits={args.quota_max_waits}"
+                    f"Quota:   gate ON — now 5h={u5}% (limit {quota_5h}%), "
+                    f"7d={u7}% (limit {quota_7d}%), max-waits={args.quota_max_waits}"
                 )
             else:
                 print(
-                    "Quota:   gate OFF — usage endpoint unavailable "
-                    "(API-key auth or no OAuth token at ~/.claude/.credentials.json)"
+                    "Quota:   gate OFF — usage probe returned no data "
+                    "(API-key auth or no subscription usage to read)"
                 )
-        elif args.usage_script:
+        else:
             print(f"Quota:   gate OFF — usage script not found at {candidate}")
 
     benchmark_files = mode.get_benchmark_files(args.filter)
@@ -1088,8 +1033,8 @@ def main():
                 tlapm_path=tlapm_root,
                 tlapm_lib=tlapm_lib,
                 usage_script=usage_script,
-                quota_5h=args.quota_5h,
-                quota_7d=args.quota_7d,
+                quota_5h=quota_5h,
+                quota_7d=quota_7d,
                 quota_max_waits=args.quota_max_waits,
                 min_free_gb=args.min_free_gb,
                 use_container=use_container,

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -403,18 +403,24 @@ def run_single_benchmark(item: WorkItem):
         agent_jsonl = os.path.join(agent_dir, "output.jsonl")
 
         wait_for_memory(item.min_free_gb, 120, log_prefix=f"[{name_no_ext}] ")
-        start_time = time.time()
 
         # Run the agent, sleeping through any hard provider usage-limit cap that
-        # the proactive gate (above) can't see. See quota.run_with_quota_retry.
+        # the proactive gate (above) can't see (see quota.run_with_quota_retry).
+        # _run_once accumulates only active agent time, so time_secs excludes the
+        # retry sleeps (which can be hours).
+        active_secs = 0.0
+
         def _run_once():
+            nonlocal active_secs
             result["error"] = ""
+            t0 = time.time()
             if item.use_container:
                 _run_agent_container(item, backend, workspace, agent_dir, agent_jsonl, prompt, result, canonical_dir)
             else:
                 _run_agent_local(
                     item, backend, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir
                 )
+            active_secs += time.time() - t0
 
         quota_exhausted = not quota.run_with_quota_retry(
             _run_once,
@@ -422,25 +428,16 @@ def run_single_benchmark(item: WorkItem):
             log_prefix=f"[{name_no_ext}] ",
         )
 
-        elapsed = time.time() - start_time
+        elapsed = active_secs
         result["time_secs"] = elapsed
 
-        if quota_exhausted:
-            result["agent_exit"] = -3
-            result["check_verdict"] = "ERROR"
-            result["error"] = "provider usage limit; exhausted quota retries"
-            result["input_tokens"] = result.get("input_tokens", 0)
-            result["output_tokens"] = result.get("output_tokens", 0)
-            with open(os.path.join(result_dir, "result.json"), "w") as f:
-                json.dump(result, f, indent=2)
-            return result
-
-        # Parse agent output
+        # Parse agent output and save artifacts on every path — including quota
+        # exhaustion — so the result dir keeps a consistent shape and records any
+        # tokens the agent did emit (rather than forcing them to 0).
         transcript, input_tokens, output_tokens = backend.parse_output(agent_jsonl)
         result["input_tokens"] = input_tokens
         result["output_tokens"] = output_tokens
 
-        # Save agent artifacts
         with open(os.path.join(agent_dir, "transcript.txt"), "w") as f:
             f.write(f"Benchmark: {rel_path}\n")
             f.write(f"Time: {elapsed:.0f}s\n")
@@ -455,6 +452,17 @@ def run_single_benchmark(item: WorkItem):
         agent_check_file = os.path.join(workspace, name_no_ext + ".result")
         if os.path.isfile(agent_check_file):
             shutil.copy2(agent_check_file, os.path.join(grading_dir, "agent_check.result"))
+
+        if quota_exhausted:
+            # Provider hard-capped us past the retry budget. Mark ERROR (retriable
+            # via --resume) and skip grading; the artifacts above keep the result
+            # dir consistent with a normal run.
+            result["agent_exit"] = -3
+            result["check_verdict"] = "ERROR"
+            result["error"] = "provider usage limit; exhausted quota retries"
+            with open(os.path.join(result_dir, "result.json"), "w") as f:
+                json.dump(result, f, indent=2)
+            return result
 
         # Run grader
         check_result_path = os.path.join(grading_dir, "check.result")

--- a/tests/evaluator/test_codex_quota_block.py
+++ b/tests/evaluator/test_codex_quota_block.py
@@ -36,12 +36,45 @@ def _write_jsonl(path, events):
             f.write(json.dumps(e) + "\n")
 
 
-def test_usage_limit_blocks(tmp_path):
+def _write_rollout(codex_home, primary, secondary):
+    """Write one codex session rollout carrying a rate_limits snapshot."""
+    d = os.path.join(codex_home, "sessions", "2026", "06", "26")
+    os.makedirs(d, exist_ok=True)
+    event = {
+        "type": "event_msg",
+        "payload": {"type": "token_count", "rate_limits": {"primary": primary, "secondary": secondary}},
+    }
+    with open(os.path.join(d, "rollout-2026-06-26T17-51-58-abc.jsonl"), "w") as f:
+        f.write(json.dumps(event) + "\n")
+
+
+def test_usage_limit_blocks(tmp_path, monkeypatch):
+    # No session data -> probe returns None -> falls back to parsing the prose time.
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "empty"))
     p = os.path.join(tmp_path, "out.jsonl")
     _write_jsonl(p, USAGE_LIMIT_STREAM)
     secs = CodexBackend().detect_quota_block(p)
     assert isinstance(secs, int)
     assert 60 <= secs <= 6 * 3600
+
+
+def test_prefers_probe_reset_over_prose(tmp_path, monkeypatch):
+    # The probe's precise 5h reset epoch (~2h out) must win over the prose
+    # "try again at 7:24 PM" in the message — solving the tz/boundary fragility.
+    import time
+
+    home = str(tmp_path / "codex")
+    future = int(time.time()) + 2 * 3600
+    _write_rollout(
+        home,
+        {"used_percent": 100.0, "window_minutes": 300, "resets_at": future},
+        {"used_percent": 5.0, "window_minutes": 10080, "resets_at": future + 999},
+    )
+    monkeypatch.setenv("CODEX_HOME", home)
+    p = os.path.join(tmp_path, "out.jsonl")
+    _write_jsonl(p, USAGE_LIMIT_STREAM)
+    secs = CodexBackend().detect_quota_block(p)
+    assert 2 * 3600 - 300 <= secs <= 2 * 3600 + 300  # tracks the probe, not the prose
 
 
 def test_normal_run_does_not_block(tmp_path):

--- a/tests/evaluator/test_codex_quota_block.py
+++ b/tests/evaluator/test_codex_quota_block.py
@@ -77,6 +77,26 @@ def test_prefers_probe_reset_over_prose(tmp_path, monkeypatch):
     assert 2 * 3600 - 300 <= secs <= 2 * 3600 + 300  # tracks the probe, not the prose
 
 
+def test_probe_targets_capped_window_not_just_5h(tmp_path, monkeypatch):
+    # Weekly window is the one at its cap while the 5h window is fresh: we must
+    # wait for the weekly reset, not the nearer 5h reset (else we retry-thrash).
+    import time
+
+    home = str(tmp_path / "codex")
+    near = int(time.time()) + 600  # 5h resets soon, but it is NOT capped
+    far = int(time.time()) + 3 * 3600  # weekly is the capped one, resets later
+    _write_rollout(
+        home,
+        {"used_percent": 20.0, "window_minutes": 300, "resets_at": near},
+        {"used_percent": 100.0, "window_minutes": 10080, "resets_at": far},
+    )
+    monkeypatch.setenv("CODEX_HOME", home)
+    p = os.path.join(tmp_path, "out.jsonl")
+    _write_jsonl(p, USAGE_LIMIT_STREAM)
+    secs = CodexBackend().detect_quota_block(p)
+    assert 3 * 3600 - 300 <= secs <= 3 * 3600 + 300  # weekly reset, not the ~10min 5h one
+
+
 def test_normal_run_does_not_block(tmp_path):
     p = os.path.join(tmp_path, "out.jsonl")
     _write_jsonl(p, NORMAL_STREAM)

--- a/tests/evaluator/test_codex_quota_block.py
+++ b/tests/evaluator/test_codex_quota_block.py
@@ -1,0 +1,75 @@
+"""CodexBackend.detect_quota_block — recognise ChatGPT's hard usage cap.
+
+The percentage quota gate is blind to the hard cap: once rate-limited, codex's
+turns fail instantly with no usage event, so the rolling utilization the gate
+reads goes stale and never trips. The runner instead asks the backend, after each
+agent run, whether the run hit the cap (via the agent's own `error`/`turn.failed`
+events) and sleeps until the stated reset rather than grading a no-op run as FAIL.
+
+Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_codex_quota_block.py
+"""
+
+import json
+import os
+
+from evaluator.backends.codex import CodexBackend
+
+# The exact event stream codex emits when the account is capped.
+USAGE_LIMIT_STREAM = [
+    {"type": "thread.started", "thread_id": "t1"},
+    {"type": "turn.started"},
+    {"type": "error", "message": "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 7:24 PM."},
+    {"type": "turn.failed", "error": {"message": "You've hit your usage limit. ... try again at 7:24 PM."}},
+]
+
+NORMAL_STREAM = [
+    {"type": "thread.started", "thread_id": "t2"},
+    {"type": "turn.started"},
+    {"type": "item.completed", "item": {"id": "i0", "type": "agent_message", "text": "done"}},
+    {"type": "turn.completed", "usage": {"input_tokens": 100, "output_tokens": 10}},
+]
+
+
+def _write_jsonl(path, events):
+    with open(path, "w") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+
+
+def test_usage_limit_blocks(tmp_path):
+    p = os.path.join(tmp_path, "out.jsonl")
+    _write_jsonl(p, USAGE_LIMIT_STREAM)
+    secs = CodexBackend().detect_quota_block(p)
+    assert isinstance(secs, int)
+    assert 60 <= secs <= 6 * 3600
+
+
+def test_normal_run_does_not_block(tmp_path):
+    p = os.path.join(tmp_path, "out.jsonl")
+    _write_jsonl(p, NORMAL_STREAM)
+    assert CodexBackend().detect_quota_block(p) is None
+
+
+def test_missing_file_does_not_block(tmp_path):
+    assert CodexBackend().detect_quota_block(os.path.join(tmp_path, "nope.jsonl")) is None
+
+
+def test_parse_retry_time_returns_future_datetime():
+    from datetime import datetime
+
+    b = CodexBackend()
+    # any AM/PM clock time parses to a today-or-tomorrow datetime (never past);
+    # the seconds clamp lives in quota.secs_until_reset (see test_quota.py).
+    for s in (
+        "try again at 11:30 AM.",
+        "try again at 7:24 PM.",
+        "try again at 12:00 AM.",  # 12-hour edge cases must not raise
+        "try again at 12:00 PM.",
+    ):
+        dt = b._parse_retry_time(s)
+        assert isinstance(dt, datetime)
+        assert dt >= datetime.now()
+
+
+def test_unparseable_time_returns_none():
+    assert CodexBackend()._parse_retry_time("usage limit, no reset time") is None

--- a/tests/evaluator/test_codex_usage.py
+++ b/tests/evaluator/test_codex_usage.py
@@ -1,0 +1,93 @@
+"""scripts/usage/codex.sh — read codex rate limits from session rollouts.
+
+It maps codex's local `rate_limits` snapshot (primary -> five_hour, secondary ->
+seven_day, used_percent -> utilization) into the same JSON shape scripts/usage/
+claude.sh emits, so the runner's quota gate consumes it unchanged. A window whose
+resets_at is already in the past is reported as 0% (the snapshot's percent is stale).
+
+Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_codex_usage.py
+"""
+
+import json
+import os
+import subprocess
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SCRIPT = os.path.join(REPO_ROOT, "scripts", "usage", "codex.sh")
+
+PAST = 1_000_000_000  # 2001 — always in the past
+FUTURE = 4_102_444_800  # 2100 — always in the future
+
+
+def _write_rollout(codex_home, primary, secondary):
+    """Write one session rollout with a single token_count rate_limits event."""
+    d = os.path.join(codex_home, "sessions", "2026", "06", "26")
+    os.makedirs(d, exist_ok=True)
+    event = {
+        "timestamp": "2026-06-26T17:51:58.000Z",
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {"total_token_usage": {"total_tokens": 1}},
+            "rate_limits": {"primary": primary, "secondary": secondary},
+        },
+    }
+    with open(os.path.join(d, "rollout-2026-06-26T17-51-58-abc.jsonl"), "w") as f:
+        f.write(json.dumps(event) + "\n")
+
+
+def _run(codex_home, *args):
+    return subprocess.run(
+        ["bash", SCRIPT, *args],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CODEX_HOME": codex_home},
+    )
+
+
+def test_maps_windows_and_zeroes_stale(tmp_path):
+    home = str(tmp_path / "codex")
+    # primary already reset (stale 100%) -> reported 0; secondary live at 28%.
+    _write_rollout(
+        home,
+        {"used_percent": 100.0, "window_minutes": 300, "resets_at": PAST},
+        {"used_percent": 28.0, "window_minutes": 10080, "resets_at": FUTURE},
+    )
+    r = _run(home)
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["five_hour"]["utilization"] == 0  # stale window zeroed
+    assert out["seven_day"]["utilization"] == 28.0  # live window preserved
+    assert out["seven_day"]["resets_at"].startswith("2100-")  # epoch -> ISO
+
+
+def test_check_mode_exit_codes(tmp_path):
+    home = str(tmp_path / "codex")
+    _write_rollout(
+        home,
+        {"used_percent": 10.0, "window_minutes": 300, "resets_at": FUTURE},
+        {"used_percent": 28.0, "window_minutes": 10080, "resets_at": FUTURE},
+    )
+    assert _run(home, "--check", "95").returncode == 0  # both under
+    over = _run(home, "--check", "20")  # 7d=28 > 20
+    assert over.returncode == 1
+    assert "7d=28" in over.stdout
+
+
+def test_no_session_data_exits_2(tmp_path):
+    home = str(tmp_path / "codex")
+    os.makedirs(os.path.join(home, "sessions"), exist_ok=True)  # empty, no rollouts
+    r = _run(home)
+    assert r.returncode == 2  # runner treats this as "can't measure" -> fail open
+
+
+def test_missing_used_percent_is_zero_not_crash(tmp_path):
+    home = str(tmp_path / "codex")
+    _write_rollout(
+        home,
+        {"window_minutes": 300, "resets_at": FUTURE},  # no used_percent
+        {"used_percent": 5.0, "window_minutes": 10080, "resets_at": FUTURE},
+    )
+    out = json.loads(_run(home).stdout)
+    assert out["five_hour"]["utilization"] == 0
+    assert out["seven_day"]["utilization"] == 5.0

--- a/tests/evaluator/test_codex_usage.py
+++ b/tests/evaluator/test_codex_usage.py
@@ -91,3 +91,45 @@ def test_missing_used_percent_is_zero_not_crash(tmp_path):
     out = json.loads(_run(home).stdout)
     assert out["five_hour"]["utilization"] == 0
     assert out["seven_day"]["utilization"] == 5.0
+
+
+def test_window_without_reset_epoch_fails_open(tmp_path):
+    # A high used_percent with no resets_at can't be checked for freshness and
+    # gives the gate no recovery time, so it must report 0 (fail open), not block.
+    home = str(tmp_path / "codex")
+    _write_rollout(
+        home,
+        {"used_percent": 99.0, "window_minutes": 300},  # no resets_at
+        {"used_percent": 5.0, "window_minutes": 10080, "resets_at": FUTURE},
+    )
+    out = json.loads(_run(home).stdout)
+    assert out["five_hour"]["utilization"] == 0
+    assert out["five_hour"]["resets_at"] is None
+    assert out["seven_day"]["utilization"] == 5.0
+
+
+def test_non_utf8_locale_does_not_crash(tmp_path):
+    # Rollouts are real UTF-8 (serde_json). Under a non-UTF-8 host locale with
+    # Python's UTF-8 mode off, `for line in f` would raise UnicodeDecodeError and
+    # silently disable the gate unless the script decodes UTF-8 explicitly.
+    home = str(tmp_path / "codex")
+    d = os.path.join(home, "sessions", "2026", "06", "26")
+    os.makedirs(d, exist_ok=True)
+    event = {
+        "type": "event_msg",
+        "note": "café résumé déjà",  # multibyte UTF-8, written as raw bytes
+        "payload": {
+            "type": "token_count",
+            "rate_limits": {
+                "primary": {"used_percent": 12.0, "window_minutes": 300, "resets_at": FUTURE},
+                "secondary": {"used_percent": 5.0, "window_minutes": 10080, "resets_at": FUTURE},
+            },
+        },
+    }
+    with open(os.path.join(d, "rollout-utf8.jsonl"), "w", encoding="utf-8") as f:
+        f.write(json.dumps(event, ensure_ascii=False) + "\n")
+    env = {**os.environ, "CODEX_HOME": home, "LC_ALL": "C", "LANG": "C", "PYTHONUTF8": "0"}
+    r = subprocess.run(["bash", SCRIPT], capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["five_hour"]["utilization"] == 12.0

--- a/tests/evaluator/test_quota.py
+++ b/tests/evaluator/test_quota.py
@@ -1,0 +1,91 @@
+"""evaluator.quota — the shared usage/quota policy layer.
+
+Covers secs_until_reset (the single "time until reset" helper that both the
+proactive gate and the reactive hard-cap retry now share), the gate's fail-open
+paths, and run_with_quota_retry's sleep-and-retry loop. The bash usage probes are
+exercised separately (test_codex_usage.py); here we test the pure-Python policy.
+
+Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_quota.py
+"""
+
+from datetime import datetime, timedelta
+
+from evaluator import quota
+
+
+def test_secs_until_reset_future_iso_is_buffered_and_clamped():
+    when = (datetime.now() + timedelta(minutes=10)).isoformat()
+    secs = quota.secs_until_reset(when, clamp_hi=3600)
+    assert 60 <= secs <= 3600
+    assert 600 <= secs <= 800  # ~10min + 120s buffer, well under the 1h clamp
+
+
+def test_secs_until_reset_accepts_datetime():
+    secs = quota.secs_until_reset(datetime.now() + timedelta(hours=5), clamp_hi=6 * 3600)
+    assert 60 <= secs <= 6 * 3600
+
+
+def test_secs_until_reset_clamps_high():
+    # a far-future reset is capped to clamp_hi, not a multi-day sleep
+    assert quota.secs_until_reset(datetime.now() + timedelta(days=3), clamp_hi=3600) == 3600
+
+
+def test_secs_until_reset_past_floors_to_60():
+    assert quota.secs_until_reset((datetime.now() - timedelta(hours=1)).isoformat()) == 60
+
+
+def test_secs_until_reset_none_and_garbage_fall_back():
+    assert quota.secs_until_reset(None, fallback=1800) == 1800
+    assert quota.secs_until_reset("not-a-time", fallback=600) == 600
+
+
+def test_usage_over_flags_only_breached_windows():
+    usage = {
+        "five_hour": {"utilization": 90, "resets_at": "2030-01-01T00:00:00"},
+        "seven_day": {"utilization": 50, "resets_at": "2030-01-02T00:00:00"},
+    }
+    over, earliest = quota._usage_over(usage, quota_5h=80, quota_7d=80)
+    assert any("five_hour" in s for s in over)
+    assert not any("seven_day" in s for s in over)
+    assert earliest == "2030-01-01T00:00:00"
+
+
+def test_usage_over_limit_zero_disables_window():
+    usage = {"five_hour": {"utilization": 99}, "seven_day": {"utilization": 99}}
+    over, earliest = quota._usage_over(usage, quota_5h=0, quota_7d=0)
+    assert over == []
+    assert earliest is None
+
+
+def test_wait_for_quota_disabled_returns_true():
+    assert quota.wait_for_quota(None, 80, 95, 6) is True  # no probe -> gate off
+    assert quota.wait_for_quota("scripts/usage/claude.sh", 0, 0, 6) is True  # both 0 -> off
+
+
+def test_fetch_usage_missing_script_is_none():
+    assert quota.fetch_usage(None) is None
+    assert quota.fetch_usage("/no/such/script.sh") is None
+
+
+def test_run_with_quota_retry_no_cap_runs_once():
+    calls = []
+    ok = quota.run_with_quota_retry(lambda: calls.append(1), lambda: None)
+    assert ok is True
+    assert len(calls) == 1
+
+
+def test_run_with_quota_retry_retries_then_succeeds(monkeypatch):
+    monkeypatch.setattr(quota.time, "sleep", lambda s: None)
+    calls = []
+    blocks = [10, None]  # capped once, then clear
+    ok = quota.run_with_quota_retry(lambda: calls.append(1), lambda: blocks.pop(0))
+    assert ok is True
+    assert len(calls) == 2
+
+
+def test_run_with_quota_retry_exhausts(monkeypatch):
+    monkeypatch.setattr(quota.time, "sleep", lambda s: None)
+    calls = []
+    ok = quota.run_with_quota_retry(lambda: calls.append(1), lambda: 10, max_retries=3)
+    assert ok is False
+    assert len(calls) == 3

--- a/tests/evaluator/test_quota.py
+++ b/tests/evaluator/test_quota.py
@@ -84,8 +84,11 @@ def test_run_with_quota_retry_retries_then_succeeds(monkeypatch):
 
 
 def test_run_with_quota_retry_exhausts(monkeypatch):
-    monkeypatch.setattr(quota.time, "sleep", lambda s: None)
+    slept = []
+    monkeypatch.setattr(quota.time, "sleep", lambda s: slept.append(s))
     calls = []
     ok = quota.run_with_quota_retry(lambda: calls.append(1), lambda: 10, max_retries=3)
     assert ok is False
     assert len(calls) == 3
+    # last attempt must NOT sleep through a reset it will never use
+    assert len(slept) == 2


### PR DESCRIPTION
Unifies usage/quota handling so each backend owns its own probe.

- Backends declare `usage_script()` and `default_quota()`; the runner selects the probe per backend. Wires up the codex gate (previously unused) and keeps claude's behavior unchanged.
- Adds a hard usage-cap retry: when a provider returns a "usage limit" error (the agent does no work), sleep until the stated reset and retry, instead of misgrading the run as FAIL.
- Moves all quota logic into `evaluator/quota.py` and merges the two duplicate "sleep until reset" helpers into one.
- Renames `scripts/usage.sh` → `scripts/usage/claude.sh`, `scripts/codex_usage.sh` → `scripts/usage/codex.sh`.
