### PR TITLE
Add INFRA_ERROR termination classification (codex / claude_code / copilot)

### DIFF
--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -346,6 +346,7 @@ def run_single_benchmark(item: WorkItem):
         result["error"] = "quota exceeded (max waits reached); skipped"
         result["input_tokens"] = 0
         result["output_tokens"] = 0
+        result["termination_reason"] = TerminationReason.QUOTA_EXHAUSTED
         return result
 
     workspace = tempfile.mkdtemp(prefix=f"{backend.name}_bench_{name_no_ext}_")
@@ -443,18 +444,6 @@ def run_single_benchmark(item: WorkItem):
         result["input_tokens"] = input_tokens
         result["output_tokens"] = output_tokens
 
-        # Tag how the run terminated so an INFRA_ERROR (agent cut short by
-        # infrastructure, not a genuine attempt) is distinguishable from a real
-        # FAIL downstream. Classification only — no retry here.
-        result["termination_reason"] = classify(
-            TerminationContext(
-                backend=backend.name,
-                jsonl_path=agent_jsonl,
-                agent_exit=result.get("agent_exit"),
-                error=result.get("error", ""),
-            )
-        )
-
         with open(os.path.join(agent_dir, "transcript.txt"), "w") as f:
             f.write(f"Benchmark: {rel_path}\n")
             f.write(f"Time: {elapsed:.0f}s\n")
@@ -473,13 +462,29 @@ def run_single_benchmark(item: WorkItem):
         if quota_exhausted:
             # Provider hard-capped us past the retry budget. Mark ERROR (retriable
             # via --resume) and skip grading; the artifacts above keep the result
-            # dir consistent with a normal run.
+            # dir consistent with a normal run. Tag QUOTA_EXHAUSTED directly — the
+            # runner owns the quota signal — rather than running classify() on the
+            # no-work, truncated stream, which would misread it as INFRA_ERROR.
             result["agent_exit"] = -3
             result["check_verdict"] = "ERROR"
             result["error"] = "provider usage limit; exhausted quota retries"
+            result["termination_reason"] = TerminationReason.QUOTA_EXHAUSTED
             with open(os.path.join(result_dir, "result.json"), "w") as f:
                 json.dump(result, f, indent=2)
             return result
+
+        # Tag how the run terminated so an INFRA_ERROR (agent cut short by
+        # infrastructure, not a genuine attempt) is distinguishable from a real
+        # FAIL downstream. Only genuine, completed runs reach here — a quota-
+        # exhausted run returned above. Classification only — no retry here.
+        result["termination_reason"] = classify(
+            TerminationContext(
+                backend=backend.name,
+                jsonl_path=agent_jsonl,
+                agent_exit=result.get("agent_exit"),
+                error=result.get("error", ""),
+            )
+        )
 
         # Run grader
         check_result_path = os.path.join(grading_dir, "check.result")

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -37,6 +37,7 @@ from evaluator.backends import get_backend, list_backends
 from evaluator.backends.base import AgentBackend
 from evaluator.modes import get_mode, list_modes
 from evaluator.modes.base import Mode
+from evaluator.termination import TerminationContext, TerminationReason, classify
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # File at <repo>/src/evaluator/runner.py — ascend two levels for repo root.
@@ -331,6 +332,10 @@ def run_single_benchmark(item: WorkItem):
         "check_verdict": "ERROR",
         "time_secs": 0,
         "error": "",
+        # How the agent run ended; reclassified after the run (see termination.py).
+        # INFRA_ERROR marks a result that was cut short by infrastructure rather
+        # than a genuine model attempt, so a FAIL can be filtered/retried.
+        "termination_reason": TerminationReason.OK,
     }
 
     if not quota.wait_for_quota(
@@ -437,6 +442,18 @@ def run_single_benchmark(item: WorkItem):
         transcript, input_tokens, output_tokens = backend.parse_output(agent_jsonl)
         result["input_tokens"] = input_tokens
         result["output_tokens"] = output_tokens
+
+        # Tag how the run terminated so an INFRA_ERROR (agent cut short by
+        # infrastructure, not a genuine attempt) is distinguishable from a real
+        # FAIL downstream. Classification only — no retry here.
+        result["termination_reason"] = classify(
+            TerminationContext(
+                backend=backend.name,
+                jsonl_path=agent_jsonl,
+                agent_exit=result.get("agent_exit"),
+                error=result.get("error", ""),
+            )
+        )
 
         with open(os.path.join(agent_dir, "transcript.txt"), "w") as f:
             f.write(f"Benchmark: {rel_path}\n")

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -150,12 +150,49 @@ def claude_code_result_error(ctx: TerminationContext) -> Optional[str]:
     return None
 
 
+def copilot_session_error(ctx: TerminationContext) -> Optional[str]:
+    """copilot rule: the run did not reach a clean terminal.
+
+    The GitHub Copilot CLI ends a clean run with a terminal event — ``result``
+    (carrying ``exitCode``) on the stdout JSON stream, or ``session.shutdown``
+    with ``shutdownType: "routine"``. Infrastructure problems surface as a
+    ``session.error`` event (``errorType`` e.g. ``"authentication"`` /
+    ``"quota"``), an ``abort``, or ``session.shutdown`` with
+    ``shutdownType == "error"``.
+
+    We flag INFRA_ERROR only on a WHOLESALE failure — the run reached no clean
+    terminal event. An intermittent ``session.error`` the agent then recovered
+    from (followed by a clean terminal) is NOT flagged. A per-tool failure
+    (``tool.execution_complete`` with ``success: false`` — e.g. tlapm rejecting
+    a proof) and a non-zero ``result`` ``exitCode`` (the proof simply not
+    verifying) are normal parts of an attempt and never count. (Event vocabulary
+    per the Copilot SDK streaming-events docs; no recorded copilot runs yet to
+    validate against.)
+    """
+    if ctx.backend != "copilot":
+        return None
+    events = ctx.events()
+    if not events:
+        return None
+    reached_clean_terminal = False
+    for ev in events:
+        t = ev.get("type")
+        if t == "result":
+            reached_clean_terminal = True
+        elif t == "session.shutdown" and ev.get("shutdownType") != "error":
+            reached_clean_terminal = True
+    if reached_clean_terminal:
+        return None
+    return TerminationReason.INFRA_ERROR
+
+
 # Registry of INFRA_ERROR criteria. One rule per backend today; append more here
 # (other backends, or additional patterns for an existing one) — classify()
 # returns the first that fires. This list IS the extension point.
 INFRA_RULES: list[Rule] = [
     codex_turn_failed,
     claude_code_result_error,
+    copilot_session_error,
 ]
 
 

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -42,6 +42,13 @@ class TerminationReason:
     # LIMIT (the model was working), NOT infrastructure. Detected the same way
     # for every backend so they agree (see is_wall_clock_timeout / classify).
     TIMEOUT = "TIMEOUT"
+    # A provider hard usage cap stopped the run — the proactive gate exhausted
+    # its waits, or the reactive retry gave up. The agent did no genuine work;
+    # the run is retriable once the quota window resets. Backend-independent, so
+    # every backend agrees. Set directly by the runner (which owns the quota
+    # signal), not by a classify() rule — distinct from INFRA_ERROR (retry
+    # immediately) and TIMEOUT (out of time).
+    QUOTA_EXHAUSTED = "QUOTA_EXHAUSTED"
 
 
 @dataclass

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -8,12 +8,14 @@ overload — the resulting FAIL says nothing about the model. We tag such runs
 with ``termination_reason = INFRA_ERROR`` so they can be filtered out (and,
 later, auto-retried) instead of being read as genuine failures.
 
-Detection is a registry of RULES (criteria). Each rule inspects a
-``TerminationContext`` and returns a reason if it fires, else ``None``; the
-first rule that fires wins (see :func:`classify`). Today there is exactly one
-rule — :func:`codex_turn_failed`. Add more (other backends, which branch on
-``ctx.backend`` and read their own event vocabulary; or other patterns) by
-appending to :data:`INFRA_RULES`.
+:func:`classify` first checks for a wall-clock timeout (a backend-independent
+LIMIT — the model was working, it just ran out of time — reported as TIMEOUT,
+never INFRA_ERROR), then runs a registry of INFRA RULES (criteria). Each rule
+inspects a ``TerminationContext`` and returns a reason if it fires, else
+``None``; the first that fires wins. There is one rule per backend today
+(:func:`codex_turn_failed`, :func:`claude_code_result_error`,
+:func:`copilot_session_error`), each branching on ``ctx.backend`` to read its
+own event vocabulary. Add more by appending to :data:`INFRA_RULES`.
 
 This module only CLASSIFIES. Acting on the classification (e.g. auto-retrying
 an INFRA_ERROR run) is intentionally left to the caller.
@@ -22,21 +24,24 @@ an INFRA_ERROR run) is intentionally left to the caller.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
 
 
 class TerminationReason:
     """How an agent run ended.
 
     Plain string constants so the value serializes verbatim into results.json.
-    Only OK and INFRA_ERROR exist today; extend with e.g. TIMEOUT / USAGE_LIMIT
-    as new rules are added — keep the values stable, downstream filters match
-    on them.
+    Extend with e.g. USAGE_LIMIT as new rules are added — keep the values
+    stable, downstream filters match on them.
     """
 
     OK = "OK"
     INFRA_ERROR = "INFRA_ERROR"
+    # The runner SIGKILLed the agent for exceeding its wall-clock budget: a time
+    # LIMIT (the model was working), NOT infrastructure. Detected the same way
+    # for every backend so they agree (see is_wall_clock_timeout / classify).
+    TIMEOUT = "TIMEOUT"
 
 
 @dataclass
@@ -51,10 +56,10 @@ class TerminationContext:
     """
 
     backend: str
-    jsonl_path: Optional[str]
-    agent_exit: Optional[int] = None
+    jsonl_path: str | None
+    agent_exit: int | None = None
     error: str = ""
-    _events: Optional[list] = None
+    _events: list | None = None
 
     def events(self) -> list:
         if self._events is None:
@@ -62,7 +67,7 @@ class TerminationContext:
         return self._events
 
 
-def _read_events(path: Optional[str]) -> list:
+def _read_events(path: str | None) -> list:
     """Parse a JSONL event stream into a list of dicts, tolerantly (skip blank
     and unparseable lines; empty list if the file is absent)."""
     if not path:
@@ -85,10 +90,10 @@ def _read_events(path: Optional[str]) -> list:
 
 # A rule inspects the context and returns a TerminationReason if it fires, else
 # None. Rules must be cheap and side-effect free.
-Rule = Callable[[TerminationContext], Optional[str]]
+Rule = Callable[[TerminationContext], str | None]
 
 
-def codex_turn_failed(ctx: TerminationContext) -> Optional[str]:
+def codex_turn_failed(ctx: TerminationContext) -> str | None:
     """codex rule: the run ended on a failed turn rather than a completed one.
 
     codex emits one ``turn.started`` … ``turn.completed`` per turn. An
@@ -121,7 +126,7 @@ def codex_turn_failed(ctx: TerminationContext) -> Optional[str]:
     return None
 
 
-def claude_code_result_error(ctx: TerminationContext) -> Optional[str]:
+def claude_code_result_error(ctx: TerminationContext) -> str | None:
     """claude_code rule: the run ended on an execution error (or never emitted a
     terminal result at all).
 
@@ -150,7 +155,7 @@ def claude_code_result_error(ctx: TerminationContext) -> Optional[str]:
     return None
 
 
-def copilot_session_error(ctx: TerminationContext) -> Optional[str]:
+def copilot_session_error(ctx: TerminationContext) -> str | None:
     """copilot rule: the run did not reach a clean terminal.
 
     The GitHub Copilot CLI ends a clean run with a terminal event — ``result``
@@ -177,9 +182,7 @@ def copilot_session_error(ctx: TerminationContext) -> Optional[str]:
     reached_clean_terminal = False
     for ev in events:
         t = ev.get("type")
-        if t == "result":
-            reached_clean_terminal = True
-        elif t == "session.shutdown" and ev.get("shutdownType") != "error":
+        if t == "result" or (t == "session.shutdown" and ev.get("shutdownType") != "error"):
             reached_clean_terminal = True
     if reached_clean_terminal:
         return None
@@ -196,8 +199,29 @@ INFRA_RULES: list[Rule] = [
 ]
 
 
+def is_wall_clock_timeout(ctx: TerminationContext) -> bool:
+    """Whether the runner SIGKILLed the agent for exceeding its wall-clock budget.
+
+    The runner records this identically for every backend — ``agent_exit == -1``
+    and ``error`` = ``"<backend> timeout after <N>s"`` — so the check is backend
+    independent. This is a time LIMIT, not infrastructure: the model was working,
+    it just didn't finish in the budget (TLAPS proofs are slow, so timeouts are
+    common). A SIGKILL also leaves a truncated event stream — no terminal turn /
+    result — which the per-backend INFRA rules would otherwise read as a cut-off;
+    classify() checks this first so a timeout is never mislabeled INFRA_ERROR.
+    """
+    return ctx.agent_exit == -1 and "timeout after" in (ctx.error or "")
+
+
 def classify(ctx: TerminationContext) -> str:
-    """Return the run's TerminationReason: the first INFRA rule that fires, else OK."""
+    """Return the run's TerminationReason.
+
+    A wall-clock timeout (a LIMIT, backend-independent) takes precedence over the
+    per-backend INFRA rules, so every backend agrees on it; otherwise the first
+    INFRA rule that fires wins, else OK.
+    """
+    if is_wall_clock_timeout(ctx):
+        return TerminationReason.TIMEOUT
     for rule in INFRA_RULES:
         reason = rule(ctx)
         if reason:

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -121,11 +121,41 @@ def codex_turn_failed(ctx: TerminationContext) -> Optional[str]:
     return None
 
 
-# Registry of INFRA_ERROR criteria. ONE rule today; append more here (rules for
-# other backends, or other codex patterns) — classify() returns the first that
-# fires. This list IS the extension point.
+def claude_code_result_error(ctx: TerminationContext) -> Optional[str]:
+    """claude_code rule: the run ended on an execution error (or never emitted a
+    terminal result at all).
+
+    Claude Code closes a run with one ``type == "result"`` event whose
+    ``subtype`` is ``success`` on a clean finish, or an ``error_*`` value
+    otherwise (observed: ``error_during_execution``). We flag INFRA_ERROR for
+    such an execution error, or when the stream has events but no terminal
+    ``result`` (cut off mid-run). ``error_max_turns`` — the agent exhausting its
+    turn budget — is a LIMIT, not infrastructure, so it is NOT flagged here.
+    """
+    if ctx.backend != "claude_code":
+        return None
+    events = ctx.events()
+    if not events:
+        return None
+    last_result = None
+    for ev in events:
+        if ev.get("type") == "result":
+            last_result = ev
+    if last_result is None:
+        # Had a stream but no terminal result event: cut off mid-run.
+        return TerminationReason.INFRA_ERROR
+    subtype = last_result.get("subtype", "")
+    if subtype.startswith("error") and subtype != "error_max_turns":
+        return TerminationReason.INFRA_ERROR
+    return None
+
+
+# Registry of INFRA_ERROR criteria. One rule per backend today; append more here
+# (other backends, or additional patterns for an existing one) — classify()
+# returns the first that fires. This list IS the extension point.
 INFRA_RULES: list[Rule] = [
     codex_turn_failed,
+    claude_code_result_error,
 ]
 
 

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -1,0 +1,138 @@
+"""Classify how an agent run terminated — in particular, whether a benchmark
+result is trustworthy or was cut short by INFRA_ERROR.
+
+A benchmark verdict (PASS/FAIL) is a capability signal only if the agent
+actually got to make a genuine attempt. When the run is cut short by
+infrastructure — a corrupted/refused API request, a dropped stream, a server
+overload — the resulting FAIL says nothing about the model. We tag such runs
+with ``termination_reason = INFRA_ERROR`` so they can be filtered out (and,
+later, auto-retried) instead of being read as genuine failures.
+
+Detection is a registry of RULES (criteria). Each rule inspects a
+``TerminationContext`` and returns a reason if it fires, else ``None``; the
+first rule that fires wins (see :func:`classify`). Today there is exactly one
+rule — :func:`codex_turn_failed`. Add more (other backends, which branch on
+``ctx.backend`` and read their own event vocabulary; or other patterns) by
+appending to :data:`INFRA_RULES`.
+
+This module only CLASSIFIES. Acting on the classification (e.g. auto-retrying
+an INFRA_ERROR run) is intentionally left to the caller.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+
+class TerminationReason:
+    """How an agent run ended.
+
+    Plain string constants so the value serializes verbatim into results.json.
+    Only OK and INFRA_ERROR exist today; extend with e.g. TIMEOUT / USAGE_LIMIT
+    as new rules are added — keep the values stable, downstream filters match
+    on them.
+    """
+
+    OK = "OK"
+    INFRA_ERROR = "INFRA_ERROR"
+
+
+@dataclass
+class TerminationContext:
+    """The evidence a rule may inspect.
+
+    ``backend`` lets a rule apply only to the backend whose event format it
+    understands. ``events()`` lazily parses the agent's JSONL event stream
+    (empty list on a missing/unreadable file), so rules that don't need it pay
+    nothing. ``agent_exit`` and ``error`` are the runner's already-recorded
+    fields, available to rules that key off them instead of the stream.
+    """
+
+    backend: str
+    jsonl_path: Optional[str]
+    agent_exit: Optional[int] = None
+    error: str = ""
+    _events: Optional[list] = None
+
+    def events(self) -> list:
+        if self._events is None:
+            self._events = _read_events(self.jsonl_path)
+        return self._events
+
+
+def _read_events(path: Optional[str]) -> list:
+    """Parse a JSONL event stream into a list of dicts, tolerantly (skip blank
+    and unparseable lines; empty list if the file is absent)."""
+    if not path:
+        return []
+    out: list = []
+    try:
+        with open(path) as f:
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    out.append(json.loads(raw))
+                except json.JSONDecodeError:
+                    continue
+    except FileNotFoundError:
+        return []
+    return out
+
+
+# A rule inspects the context and returns a TerminationReason if it fires, else
+# None. Rules must be cheap and side-effect free.
+Rule = Callable[[TerminationContext], Optional[str]]
+
+
+def codex_turn_failed(ctx: TerminationContext) -> Optional[str]:
+    """codex rule: the run ended on a failed turn rather than a completed one.
+
+    codex emits one ``turn.started`` … ``turn.completed`` per turn. An
+    infrastructure error — a corrupted/refused request, a dropped stream, a
+    server overload — instead surfaces as ``error`` events and a terminal
+    ``turn.failed`` with no following ``turn.completed``. A genuine "I couldn't
+    prove it" run, by contrast, ends with ``turn.completed`` (the model ran to
+    a normal stop; its proof simply didn't verify).
+
+    We flag INFRA_ERROR when the last terminal turn event is a failure, or when
+    the run errored without ever completing a turn. A run that hit a transient
+    error mid-way but recovered and completed a turn is NOT flagged.
+    """
+    if ctx.backend != "codex":
+        return None
+    last_terminal = None  # "completed" | "failed"
+    saw_error = False
+    for ev in ctx.events():
+        t = ev.get("type")
+        if t == "turn.completed":
+            last_terminal = "completed"
+        elif t == "turn.failed":
+            last_terminal = "failed"
+        elif t == "error":
+            saw_error = True
+    if last_terminal == "failed":
+        return TerminationReason.INFRA_ERROR
+    if last_terminal is None and saw_error:
+        return TerminationReason.INFRA_ERROR
+    return None
+
+
+# Registry of INFRA_ERROR criteria. ONE rule today; append more here (rules for
+# other backends, or other codex patterns) — classify() returns the first that
+# fires. This list IS the extension point.
+INFRA_RULES: list[Rule] = [
+    codex_turn_failed,
+]
+
+
+def classify(ctx: TerminationContext) -> str:
+    """Return the run's TerminationReason: the first INFRA rule that fires, else OK."""
+    for rule in INFRA_RULES:
+        reason = rule(ctx)
+        if reason:
+            return reason
+    return TerminationReason.OK

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -147,6 +147,24 @@ def test_registry_is_the_extension_point():
     assert copilot_session_error in INFRA_RULES
 
 
+# --- quota exhaustion: runner-owned, never produced by classify() -----------
+
+def test_quota_exhausted_is_a_distinct_reason():
+    # QUOTA_EXHAUSTED is its own category, distinct from OK/INFRA_ERROR/TIMEOUT.
+    reasons = {TerminationReason.OK, TerminationReason.INFRA_ERROR, TerminationReason.TIMEOUT}
+    assert TerminationReason.QUOTA_EXHAUSTED not in reasons
+
+
+def test_classify_never_returns_quota_exhausted(tmp_path):
+    # The runner sets QUOTA_EXHAUSTED directly (it owns the quota signal); no
+    # classify() rule may spontaneously produce it. A quota-blocked run leaves a
+    # no-work, truncated stream — classify() reads that as INFRA_ERROR/OK, never
+    # QUOTA_EXHAUSTED — which is exactly why the runner tags it before classify().
+    for backend, stream in TRUNCATED_BY_BACKEND.items():
+        p = _write_jsonl(tmp_path / f"{backend}.jsonl", stream)
+        assert classify(_ctx(p, backend=backend)) != TerminationReason.QUOTA_EXHAUSTED
+
+
 # --- claude_code rule -------------------------------------------------------
 
 # claude_code closes with a `result` event; subtype `success` vs `error_*`.

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -19,6 +19,7 @@ from evaluator.termination import (
     claude_code_result_error,
     classify,
     codex_turn_failed,
+    copilot_session_error,
 )
 
 # codex stream cut short by a corrupted/refused request (no turn.completed).
@@ -101,6 +102,7 @@ def test_registry_is_the_extension_point():
     # The interface contract: classify() runs INFRA_RULES in order.
     assert codex_turn_failed in INFRA_RULES
     assert claude_code_result_error in INFRA_RULES
+    assert copilot_session_error in INFRA_RULES
 
 
 # --- claude_code rule -------------------------------------------------------
@@ -150,3 +152,80 @@ def test_cc_rule_only_applies_to_claude_code(tmp_path):
     # codex stream through the claude rule must abstain.
     p = _write_jsonl(tmp_path / "infra.jsonl", INFRA_STREAM)
     assert claude_code_result_error(_ctx(p, backend="codex")) is None
+
+
+# --- copilot rule (event vocabulary per Copilot SDK streaming-events docs) ---
+
+# A clean run: per-tool failure is normal (tlapm rejecting a proof), terminal
+# `result` with a non-zero exitCode is the proof failing — neither is infra.
+CP_COMPLETED = [
+    {"type": "assistant.message", "data": {"content": "hi"}},
+    {"type": "tool.execution_complete", "data": {"result": {"success": False}}},
+    {"type": "result", "exitCode": 1, "usage": {"premiumRequests": 1}},
+]
+CP_SESSION_ERROR = [  # dedicated infra error event (auth/quota/network)
+    {"type": "assistant.message", "data": {"content": "hi"}},
+    {"type": "session.error", "errorType": "quota", "message": "rate limited", "statusCode": 429},
+]
+CP_ABORT = [
+    {"type": "assistant.message", "data": {"content": "hi"}},
+    {"type": "abort"},
+]
+CP_SHUTDOWN_ERROR = [
+    {"type": "session.shutdown", "shutdownType": "error", "errorReason": "stream closed"},
+]
+CP_SHUTDOWN_OK = [
+    {"type": "session.shutdown", "shutdownType": "routine"},
+]
+CP_RECOVERED = [  # intermittent session.error, then recovered to a clean terminal
+    {"type": "assistant.message", "data": {"content": "hi"}},
+    {"type": "session.error", "errorType": "quota", "message": "transient 429"},
+    {"type": "assistant.message", "data": {"content": "retrying"}},
+    {"type": "result", "exitCode": 0, "usage": {"premiumRequests": 2}},
+]
+CP_TRUNCATED = [  # cut off before any terminal event
+    {"type": "assistant.message", "data": {"content": "working"}},
+    {"type": "tool.execution_start", "data": {}},
+]
+
+
+def test_copilot_completed_is_ok(tmp_path):
+    p = _write_jsonl(tmp_path / "done.jsonl", CP_COMPLETED)
+    assert classify(_ctx(p, backend="copilot")) == TerminationReason.OK
+
+
+def test_copilot_session_error_is_infra(tmp_path):
+    p = _write_jsonl(tmp_path / "serr.jsonl", CP_SESSION_ERROR)
+    assert classify(_ctx(p, backend="copilot")) == TerminationReason.INFRA_ERROR
+
+
+def test_copilot_abort_is_infra(tmp_path):
+    p = _write_jsonl(tmp_path / "abort.jsonl", CP_ABORT)
+    assert classify(_ctx(p, backend="copilot")) == TerminationReason.INFRA_ERROR
+
+
+def test_copilot_shutdown_error_is_infra(tmp_path):
+    p = _write_jsonl(tmp_path / "sd.jsonl", CP_SHUTDOWN_ERROR)
+    assert classify(_ctx(p, backend="copilot")) == TerminationReason.INFRA_ERROR
+
+
+def test_copilot_shutdown_routine_is_ok(tmp_path):
+    p = _write_jsonl(tmp_path / "sdok.jsonl", CP_SHUTDOWN_OK)
+    assert classify(_ctx(p, backend="copilot")) == TerminationReason.OK
+
+
+def test_copilot_recovered_session_error_is_ok(tmp_path):
+    # Only a WHOLESALE failure counts: a session.error the run recovered from
+    # (followed by a clean terminal) must NOT be flagged.
+    p = _write_jsonl(tmp_path / "recov.jsonl", CP_RECOVERED)
+    assert classify(_ctx(p, backend="copilot")) == TerminationReason.OK
+
+
+def test_copilot_truncated_is_infra(tmp_path):
+    p = _write_jsonl(tmp_path / "trunc.jsonl", CP_TRUNCATED)
+    assert classify(_ctx(p, backend="copilot")) == TerminationReason.INFRA_ERROR
+
+
+def test_copilot_rule_only_applies_to_copilot(tmp_path):
+    p = _write_jsonl(tmp_path / "trunc.jsonl", CP_TRUNCATED)
+    assert copilot_session_error(_ctx(p, backend="codex")) is None

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -11,6 +11,7 @@ Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_termination.py
 """
 
 import json
+import os
 
 from evaluator.termination import (
     INFRA_RULES,
@@ -163,6 +164,87 @@ def test_classify_never_returns_quota_exhausted(tmp_path):
     for backend, stream in TRUNCATED_BY_BACKEND.items():
         p = _write_jsonl(tmp_path / f"{backend}.jsonl", stream)
         assert classify(_ctx(p, backend=backend)) != TerminationReason.QUOTA_EXHAUSTED
+
+
+# QUOTA_EXHAUSTED is the one reason the runner sets directly (not classify()), so
+# it's only covered by driving run_single_benchmark. Both quota paths short-
+# circuit before the AI agent / grader run, so stubbing the quota gate reaches
+# them without a real backend, tlapm, or API key.
+
+
+class _FakeBackend:
+    name = "codex"
+
+    def parse_output(self, jsonl_path):
+        return ("", 0, 0)  # transcript, input_tokens, output_tokens
+
+    def detect_quota_block(self, jsonl_path):
+        return None
+
+
+class _FakeMode:
+    name = "proof-completion"
+
+    def __init__(self, bench_dir):
+        self._bench_dir = bench_dir
+
+    def benchmark_dir(self):
+        return self._bench_dir
+
+    def get_dependencies(self, benchmark_path):
+        return []
+
+    def checker_binary_path(self):
+        return "/bin/true"
+
+    def build_prompt(self, basename, tlapm_path, tlapm_lib):
+        return "prove it"
+
+
+def _quota_work_item(tmp_path):
+    from evaluator.runner import WorkItem
+
+    bench_dir = tmp_path / "bench"
+    bench_path = bench_dir / "Foo" / "Bar.tla"
+    os.makedirs(bench_path.parent)
+    bench_path.write_text("---- MODULE Bar ----\n====\n")
+    return WorkItem(
+        benchmark_path=str(bench_path),
+        output_dir=str(tmp_path / "out"),
+        timeout=10,
+        check_timeout=10,
+        backend=_FakeBackend(),  # ty:ignore[invalid-argument-type]
+        mode=_FakeMode(str(bench_dir)),  # ty:ignore[invalid-argument-type]
+        tlapm_path="/bin/true",
+        tlapm_lib="",
+        usage_script="dummy",  # enables the quota gate
+        quota_max_waits=1,
+    )
+
+
+def test_runner_prerun_quota_skip_tags_quota_exhausted(tmp_path, monkeypatch):
+    # Proactive gate gives up before the agent runs (max waits reached): the
+    # early return must carry QUOTA_EXHAUSTED, not the seeded OK default.
+    from evaluator import runner
+
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *a, **k: False)
+    result = runner.run_single_benchmark(_quota_work_item(tmp_path))
+    assert result["agent_exit"] == -3
+    assert result["termination_reason"] == TerminationReason.QUOTA_EXHAUSTED
+
+
+def test_runner_duringrun_quota_exhausted_tags_quota_exhausted(tmp_path, monkeypatch):
+    # Agent runs, then the provider hard-caps us and the retry budget is spent:
+    # run_with_quota_retry returns falsy -> quota_exhausted block (agent never
+    # actually invoked, grading skipped).
+    from evaluator import runner
+
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *a, **k: True)
+    monkeypatch.setattr(runner.quota, "run_with_quota_retry", lambda run, block, **k: False)
+    result = runner.run_single_benchmark(_quota_work_item(tmp_path))
+    assert result["agent_exit"] == -3
+    assert result["check_verdict"] == "ERROR"
+    assert result["termination_reason"] == TerminationReason.QUOTA_EXHAUSTED
 
 
 # --- claude_code rule -------------------------------------------------------

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -16,6 +16,7 @@ from evaluator.termination import (
     INFRA_RULES,
     TerminationContext,
     TerminationReason,
+    claude_code_result_error,
     classify,
     codex_turn_failed,
 )
@@ -84,11 +85,11 @@ def test_errored_without_completing_a_turn_is_infra(tmp_path):
 
 
 def test_rule_only_applies_to_its_backend(tmp_path):
-    # Same failing stream, but a non-codex backend: the codex rule must abstain,
-    # so it classifies OK (until that backend's own rule is added).
+    # The codex rule keys off codex's event vocabulary and must abstain for any
+    # other backend; a backend with no rule of its own classifies OK.
     p = _write_jsonl(tmp_path / "infra.jsonl", INFRA_STREAM)
     assert codex_turn_failed(_ctx(p, backend="claude_code")) is None
-    assert classify(_ctx(p, backend="claude_code")) == TerminationReason.OK
+    assert classify(_ctx(p, backend="litellm")) == TerminationReason.OK
 
 
 def test_missing_stream_is_ok(tmp_path):
@@ -97,5 +98,55 @@ def test_missing_stream_is_ok(tmp_path):
 
 
 def test_registry_is_the_extension_point():
-    # The interface contract: classify() runs INFRA_RULES in order. One rule today.
+    # The interface contract: classify() runs INFRA_RULES in order.
     assert codex_turn_failed in INFRA_RULES
+    assert claude_code_result_error in INFRA_RULES
+
+
+# --- claude_code rule -------------------------------------------------------
+
+# claude_code closes with a `result` event; subtype `success` vs `error_*`.
+CC_SUCCESS = [
+    {"type": "system", "subtype": "init"},
+    {"type": "assistant", "message": {"role": "assistant"}},
+    {"type": "result", "subtype": "success", "is_error": False, "result": "done"},
+]
+CC_EXEC_ERROR = [
+    {"type": "system", "subtype": "init"},
+    {"type": "result", "subtype": "error_during_execution", "is_error": True},
+]
+CC_MAX_TURNS = [
+    {"type": "system", "subtype": "init"},
+    {"type": "result", "subtype": "error_max_turns", "is_error": True},
+]
+CC_TRUNCATED = [  # stream cut off before the terminal result event
+    {"type": "system", "subtype": "init"},
+    {"type": "assistant", "message": {"role": "assistant"}},
+]
+
+
+def test_cc_success_is_ok(tmp_path):
+    p = _write_jsonl(tmp_path / "ok.jsonl", CC_SUCCESS)
+    assert classify(_ctx(p, backend="claude_code")) == TerminationReason.OK
+
+
+def test_cc_exec_error_is_infra(tmp_path):
+    p = _write_jsonl(tmp_path / "err.jsonl", CC_EXEC_ERROR)
+    assert classify(_ctx(p, backend="claude_code")) == TerminationReason.INFRA_ERROR
+
+
+def test_cc_max_turns_is_not_infra(tmp_path):
+    # error_max_turns is a turn-budget LIMIT, not infrastructure — must NOT flag.
+    p = _write_jsonl(tmp_path / "maxturns.jsonl", CC_MAX_TURNS)
+    assert classify(_ctx(p, backend="claude_code")) == TerminationReason.OK
+
+
+def test_cc_truncated_is_infra(tmp_path):
+    p = _write_jsonl(tmp_path / "trunc.jsonl", CC_TRUNCATED)
+    assert classify(_ctx(p, backend="claude_code")) == TerminationReason.INFRA_ERROR
+
+
+def test_cc_rule_only_applies_to_claude_code(tmp_path):
+    # codex stream through the claude rule must abstain.
+    p = _write_jsonl(tmp_path / "infra.jsonl", INFRA_STREAM)
+    assert claude_code_result_error(_ctx(p, backend="codex")) is None

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -1,0 +1,101 @@
+"""termination.classify — tag a run as INFRA_ERROR vs OK.
+
+A FAIL is only a capability signal if the agent made a genuine attempt. The
+codex rule reads the agent's event stream: a run that ends on a terminal
+``turn.failed`` (or errors without ever completing a turn) was cut short by
+infrastructure — corrupted/refused request, dropped stream, server overload —
+and is tagged INFRA_ERROR; a run that ends with ``turn.completed`` is OK
+(genuine, even if its proof didn't verify).
+
+Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_termination.py
+"""
+
+import json
+
+from evaluator.termination import (
+    INFRA_RULES,
+    TerminationContext,
+    TerminationReason,
+    classify,
+    codex_turn_failed,
+)
+
+# codex stream cut short by a corrupted/refused request (no turn.completed).
+INFRA_STREAM = [
+    {"type": "thread.started", "thread_id": "t1"},
+    {"type": "turn.started"},
+    {"type": "item.completed", "item": {"id": "i0", "type": "command_execution"}},
+    {"type": "error", "message": "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\"}}"},
+    {"type": "turn.failed", "error": {"message": "invalid_request_error"}},
+]
+
+# codex stream that ran to a normal stop (proof may still have failed grading).
+GENUINE_STREAM = [
+    {"type": "thread.started", "thread_id": "t2"},
+    {"type": "turn.started"},
+    {"type": "item.completed", "item": {"id": "i0", "type": "agent_message", "text": "couldn't finish"}},
+    {"type": "turn.completed", "usage": {"input_tokens": 100, "output_tokens": 10}},
+]
+
+# transient error mid-run, then recovered and completed → still OK.
+RECOVERED_STREAM = [
+    {"type": "turn.started"},
+    {"type": "error", "message": "Reconnecting... 1/5 (stream disconnected before completion)"},
+    {"type": "item.completed", "item": {"id": "i0", "type": "agent_message"}},
+    {"type": "turn.completed", "usage": {"input_tokens": 50, "output_tokens": 5}},
+]
+
+# stream truncated after errors with no terminal turn event (killed mid-turn).
+ERRORED_NO_TURN_STREAM = [
+    {"type": "turn.started"},
+    {"type": "error", "message": "stream disconnected before completion"},
+]
+
+
+def _write_jsonl(path, events):
+    with open(path, "w") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+    return str(path)
+
+
+def _ctx(path, backend="codex"):
+    return TerminationContext(backend=backend, jsonl_path=path)
+
+
+def test_turn_failed_is_infra(tmp_path):
+    p = _write_jsonl(tmp_path / "infra.jsonl", INFRA_STREAM)
+    assert classify(_ctx(p)) == TerminationReason.INFRA_ERROR
+
+
+def test_turn_completed_is_ok(tmp_path):
+    p = _write_jsonl(tmp_path / "genuine.jsonl", GENUINE_STREAM)
+    assert classify(_ctx(p)) == TerminationReason.OK
+
+
+def test_recovered_midrun_error_is_ok(tmp_path):
+    p = _write_jsonl(tmp_path / "recovered.jsonl", RECOVERED_STREAM)
+    assert classify(_ctx(p)) == TerminationReason.OK
+
+
+def test_errored_without_completing_a_turn_is_infra(tmp_path):
+    p = _write_jsonl(tmp_path / "killed.jsonl", ERRORED_NO_TURN_STREAM)
+    assert classify(_ctx(p)) == TerminationReason.INFRA_ERROR
+
+
+def test_rule_only_applies_to_its_backend(tmp_path):
+    # Same failing stream, but a non-codex backend: the codex rule must abstain,
+    # so it classifies OK (until that backend's own rule is added).
+    p = _write_jsonl(tmp_path / "infra.jsonl", INFRA_STREAM)
+    assert codex_turn_failed(_ctx(p, backend="claude_code")) is None
+    assert classify(_ctx(p, backend="claude_code")) == TerminationReason.OK
+
+
+def test_missing_stream_is_ok(tmp_path):
+    # No event file (e.g. agent never launched) must not crash and is not INFRA.
+    assert classify(_ctx(str(tmp_path / "nope.jsonl"))) == TerminationReason.OK
+
+
+def test_registry_is_the_extension_point():
+    # The interface contract: classify() runs INFRA_RULES in order. One rule today.
+    assert codex_turn_failed in INFRA_RULES

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -16,10 +16,11 @@ from evaluator.termination import (
     INFRA_RULES,
     TerminationContext,
     TerminationReason,
-    claude_code_result_error,
     classify,
+    claude_code_result_error,
     codex_turn_failed,
     copilot_session_error,
+    is_wall_clock_timeout,
 )
 
 # codex stream cut short by a corrupted/refused request (no turn.completed).
@@ -61,8 +62,8 @@ def _write_jsonl(path, events):
     return str(path)
 
 
-def _ctx(path, backend="codex"):
-    return TerminationContext(backend=backend, jsonl_path=path)
+def _ctx(path, backend="codex", agent_exit=None, error=""):
+    return TerminationContext(backend=backend, jsonl_path=path, agent_exit=agent_exit, error=error)
 
 
 def test_turn_failed_is_infra(tmp_path):
@@ -96,6 +97,47 @@ def test_rule_only_applies_to_its_backend(tmp_path):
 def test_missing_stream_is_ok(tmp_path):
     # No event file (e.g. agent never launched) must not crash and is not INFRA.
     assert classify(_ctx(str(tmp_path / "nope.jsonl"))) == TerminationReason.OK
+
+
+# --- wall-clock timeout: a LIMIT, consistent across backends, never INFRA -----
+
+# A SIGKILLed run leaves a truncated stream (no terminal turn/result) — exactly
+# what each INFRA rule would otherwise read as a cut-off — plus the runner's
+# agent_exit == -1 and "<backend> timeout after <N>s" error.
+TRUNCATED_BY_BACKEND = {
+    "codex": [{"type": "thread.started"}, {"type": "turn.started"}],
+    "claude_code": [{"type": "system", "subtype": "init"}, {"type": "assistant", "message": {}}],
+    "copilot": [{"type": "assistant.message", "data": {"content": "working"}}],
+}
+
+
+def test_is_wall_clock_timeout_signal():
+    ctx = TerminationContext(backend="codex", jsonl_path=None, agent_exit=-1, error="codex timeout after 7200s")
+    assert is_wall_clock_timeout(ctx) is True
+    # a non-timeout error, or a clean exit, is not a timeout
+    assert is_wall_clock_timeout(TerminationContext("codex", None, agent_exit=1, error="")) is False
+    assert is_wall_clock_timeout(TerminationContext("codex", None, agent_exit=-1, error="provider usage limit")) is False
+
+
+def test_timeout_is_timeout_not_infra_for_every_backend(tmp_path):
+    # Same wall-clock timeout, every backend → TIMEOUT (not INFRA, not OK) — the
+    # truncated stream alone would read as a cut-off, but the timeout wins.
+    for backend, stream in TRUNCATED_BY_BACKEND.items():
+        p = _write_jsonl(tmp_path / f"{backend}.jsonl", stream)
+        err = f"{backend} timeout after 7200s"
+        verdict = classify(_ctx(p, backend=backend, agent_exit=-1, error=err))
+        assert verdict == TerminationReason.TIMEOUT, f"{backend}: {verdict}"
+
+
+def test_same_truncation_without_timeout_is_still_infra(tmp_path):
+    # Without the timeout signal, a truncated stream is a genuine cut-off (crash /
+    # dropped connection) → INFRA_ERROR. Asserts the timeout precheck is the only
+    # thing reclassifying these, and only for codex does a clean SIGKILL-less
+    # truncation read as OK (no error/turn.failed to key on).
+    expected = {"codex": TerminationReason.OK, "claude_code": TerminationReason.INFRA_ERROR, "copilot": TerminationReason.INFRA_ERROR}
+    for backend, stream in TRUNCATED_BY_BACKEND.items():
+        p = _write_jsonl(tmp_path / f"{backend}.jsonl", stream)
+        assert classify(_ctx(p, backend=backend)) == expected[backend], backend
 
 
 def test_registry_is_the_extension_point():


### PR DESCRIPTION
Tags each run's `result.json` with a `termination_reason` (`OK` / `INFRA_ERROR` / `TIMEOUT`) so a FAIL caused by infrastructure (corrupted/refused request, dropped stream, server overload) is distinguishable from a genuine model failure. Classification only — no retry.

- Rule registry in `evaluator/termination.py` (`INFRA_RULES`); add a criterion by appending a rule. One rule per backend: codex (terminal `turn.failed`), claude_code (final `result` error subtype, excluding `error_max_turns`), copilot (no clean terminal — `session.error` / `abort` / `shutdown` error / truncation).
- A wall-clock timeout (`agent_exit == -1`) is a backend-independent LIMIT, reported as `TIMEOUT` ahead of the INFRA rules — never INFRA_ERROR — so all backends agree (TLAPS proofs are slow; timeouts are normal).
- Only a wholesale failure is flagged: a run that hit an intermittent error then recovered to a clean finish stays `OK`.
- codex / claude_code rules validated against real run data; the copilot rule follows the documented Copilot SDK event vocabulary (no recorded copilot run to validate against yet).
