### PR TITLE
Add infra retry handling

### DIFF
--- a/docker/firewall.sh
+++ b/docker/firewall.sh
@@ -29,10 +29,20 @@ IFS=',' read -ra HOSTS <<< "$FIREWALL_HOSTS"
 for host in "${HOSTS[@]}"; do
     host=$(echo "$host" | xargs)  # trim whitespace
     HOST_COUNT=0
-    for ip in $(dig +short "$host" 2>/dev/null | grep -E '^[0-9]'); do
-        iptables -A OUTPUT -d "$ip" -p tcp --dport 443 -j ACCEPT
-        echo "[firewall] Allowed: $host -> $ip"
-        HOST_COUNT=$((HOST_COUNT + 1))
+    # Retry transient DNS misses — one empty dig answer for a single host must
+    # not abort the whole container.
+    for dns_attempt in 1 2 3; do
+        for ip in $(dig +short "$host" 2>/dev/null | grep -E '^[0-9]'); do
+            iptables -A OUTPUT -d "$ip" -p tcp --dport 443 -j ACCEPT
+            echo "[firewall] Allowed: $host -> $ip"
+            HOST_COUNT=$((HOST_COUNT + 1))
+        done
+        if [ "$HOST_COUNT" -gt 0 ]; then
+            break
+        fi
+        if [ "$dns_attempt" -lt 3 ]; then
+            sleep 2
+        fi
     done
     if [ "$HOST_COUNT" -eq 0 ]; then
         echo "[firewall] ERROR: no IPs resolved for host '$host'" >&2

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -147,7 +147,7 @@ uv run tlaps-bench score results/proof-from-scratch/pi/20260626_220712/results.j
 uv run tlaps-bench score results/proof-completion/*/results.json
 ```
 
-Pass rate = passed tasks / (total tasks minus skipped tasks). Cheating verdicts count as failures.
+Pass rate = passed tasks / scored tasks. `SKIP`, `INFRA_ERROR`, and `QUOTA_EXHAUSTED` results are excluded from scoring and reported separately; cheating verdicts count as failures.
 
 ### `tlaps-bench validate`
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -120,6 +120,7 @@ uv run tlaps-bench run [flags]
 | `--check-timeout` | `600` | Per-benchmark checker (tlapm) timeout in seconds |
 | `--output-dir` | auto-generated | Output directory |
 | `--resume` | off | Skip benchmarks already marked PASS |
+| `--infra-retries` | `3` | Extra attempts after a transient agent startup/infra failure (0 output tokens); `0` = no retries |
 | `--force-build` | off | Rebuild the Docker image |
 | `--no-container` | off | Run without Docker (requires native setup) |
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -119,8 +119,8 @@ uv run tlaps-bench run [flags]
 | `--timeout` | `28800` | Per-benchmark agent timeout in seconds |
 | `--check-timeout` | `600` | Per-benchmark checker (tlapm) timeout in seconds |
 | `--output-dir` | auto-generated | Output directory |
-| `--resume` | off | Skip benchmarks already marked PASS |
-| `--infra-retries` | `3` | Extra attempts after a transient agent startup/infra failure (0 output tokens); `0` = no retries |
+| `--resume` | off | Skip benchmarks already marked `SKIP` or genuine `PASS` |
+| `--infra-retries` | `3` | Extra attempts after a transient agent startup/infra failure (0 output tokens); `0` = no inline retries |
 | `--force-build` | off | Rebuild the Docker image |
 | `--no-container` | off | Run without Docker (requires native setup) |
 
@@ -203,7 +203,9 @@ If a run is interrupted or you want to retry only the failures:
 uv run tlaps-bench run --backend codex --model gpt-5.5 --output-dir results/proof-completion/codex/20260626_120000 --resume
 ```
 
-The runner skips any benchmark already recorded as PASS in that directory and reruns the rest.
+The runner skips benchmarks already recorded as `SKIP` or as a genuine `PASS` in that directory, and reruns the rest.
+
+Inline infra retries are intentionally short: the default `--infra-retries 3` gives the original attempt plus three retries with brief backoff. If a longer provider or network outage leaves `INFRA_ERROR` / `QUOTA_EXHAUSTED` results, rerun later with the same `--output-dir --resume`; those non-genuine results are not skipped.
 
 ---
 
@@ -340,4 +342,3 @@ This script runs inside the container with full network access before the firewa
 | `"claude"` | `~/.claude/` | `~/.claude/` |
 
 ---
-

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -18,6 +18,7 @@ import contextlib
 import fcntl
 import json
 import os
+import random
 import re
 import select
 import shlex
@@ -37,7 +38,7 @@ from evaluator.backends import get_backend, list_backends
 from evaluator.backends.base import AgentBackend
 from evaluator.modes import get_mode, list_modes
 from evaluator.modes.base import Mode
-from evaluator.termination import TerminationContext, TerminationReason, classify
+from evaluator.termination import TerminationContext, TerminationReason, classify, startup_error_snippet
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # File at <repo>/src/evaluator/runner.py — ascend two levels for repo root.
@@ -47,6 +48,10 @@ VERDICT_ICONS = {"PASS": "✅", "FAIL": "❌", "CHEATING": "⚠️", "TIMEOUT": 
 
 # Set to True to stream agent output to terminal during container runs
 STREAM_AGENT_OUTPUT = True
+
+# Backoff between infra retries (seconds); the last value repeats. Short: the
+# observed startup blips clear within seconds-to-minutes.
+INFRA_RETRY_BACKOFF = (15, 30, 60)
 
 
 def resolve_paths():
@@ -229,6 +234,21 @@ class WorkItem:
     min_free_gb: float = 0
     # Container mode: run agent inside Docker container
     use_container: bool = False
+    # Extra agent attempts after a transient startup/infra failure (INFRA_ERROR
+    # with 0 output tokens); 0 disables retrying (the failure still ends ERROR).
+    infra_retries: int = 3
+
+
+def _make_canonical_dir(name_no_ext: str, benchmark_path: str, basename: str, deps: list[str]) -> str:
+    canonical_dir = tempfile.mkdtemp(prefix=f"canon_{name_no_ext}_")
+    try:
+        shutil.copy2(benchmark_path, os.path.join(canonical_dir, basename))
+        for dep in deps:
+            shutil.copy2(dep, os.path.join(canonical_dir, os.path.basename(dep)))
+        return canonical_dir
+    except Exception:
+        shutil.rmtree(canonical_dir, ignore_errors=True)
+        raise
 
 
 def update_summary(results, output_dir, total_benchmarks, backend_name, mode_name):
@@ -349,7 +369,7 @@ def run_single_benchmark(item: WorkItem):
         result["termination_reason"] = TerminationReason.QUOTA_EXHAUSTED
         return result
 
-    workspace = tempfile.mkdtemp(prefix=f"{backend.name}_bench_{name_no_ext}_")
+    workspace = None
     canonical_dir = None
     try:
         # Resolve dependencies ONCE — the EXTENDS-closure walk parses files and may
@@ -357,47 +377,11 @@ def run_single_benchmark(item: WorkItem):
         # call would just repeat that work and double the stderr noise.
         deps = mode.get_dependencies(item.benchmark_path)
 
-        # Copy benchmark + dependencies into the isolated workspace
-        shutil.copy2(item.benchmark_path, os.path.join(workspace, basename))
-        for dep in deps:
-            shutil.copy2(dep, os.path.join(workspace, os.path.basename(dep)))
-
-        # Canonical snapshot: the SINGLE baseline that BOTH the agent's
-        # in-workspace self-check and the grader read, so the two oracles can't
-        # diverge (a git --amend / rm -rf .git in the workspace no longer weakens
-        # the self-check below the grader). Holds exactly the files the workspace
-        # started with ({target}.tla + deps) — NOT the whole module dir, which
-        # would leak sibling task files into the agent's sandbox. In container
-        # mode it is bind-mounted ``:ro`` (tamper-proof); on the host the agent
-        # could touch this copy, but since both oracles read it the verdicts stay
-        # consistent regardless. (Not chmod'd read-only: tlapm/SANY write a cache
-        # dir beside the source, which a read-only dir would break.)
-        canonical_dir = tempfile.mkdtemp(prefix=f"canon_{name_no_ext}_")
-        shutil.copy2(item.benchmark_path, os.path.join(canonical_dir, basename))
-        for dep in deps:
-            shutil.copy2(dep, os.path.join(canonical_dir, os.path.basename(dep)))
-
-        # Init git repo (baseline for cheating check)
-        subprocess.run(["git", "init"], capture_output=True, cwd=workspace)
-        subprocess.run(["git", "add", "."], capture_output=True, cwd=workspace)
-        subprocess.run(
-            ["git", "commit", "-m", "initial benchmark"],
-            capture_output=True,
-            cwd=workspace,
-            env={
-                **os.environ,
-                "GIT_AUTHOR_NAME": "bench",
-                "GIT_AUTHOR_EMAIL": "bench@bench",
-                "GIT_COMMITTER_NAME": "bench",
-                "GIT_COMMITTER_EMAIL": "bench@bench",
-            },
-        )
-
         checker_bin = mode.checker_binary_path()
 
         # Save input artifacts
         shutil.copy2(item.benchmark_path, os.path.join(input_dir, "benchmark.tla"))
-        for dep in mode.get_dependencies(item.benchmark_path):
+        for dep in deps:
             shutil.copy2(dep, os.path.join(input_dir, os.path.basename(dep)))
 
         # Build prompt
@@ -407,43 +391,130 @@ def run_single_benchmark(item: WorkItem):
 
         # Run the agent
         agent_jsonl = os.path.join(agent_dir, "output.jsonl")
+        agent_stderr = os.path.join(agent_dir, "stderr.txt")
 
-        wait_for_memory(item.min_free_gb, 120, log_prefix=f"[{name_no_ext}] ")
-
-        # Run the agent, sleeping through any hard provider usage-limit cap that
-        # the proactive gate (above) can't see (see quota.run_with_quota_retry).
         # _run_once accumulates only active agent time, so time_secs excludes the
-        # retry sleeps (which can be hours).
+        # quota retry sleeps (which can be hours) and the infra backoff below.
         active_secs = 0.0
 
-        def _run_once():
-            nonlocal active_secs
-            result["error"] = ""
-            t0 = time.time()
-            if item.use_container:
-                _run_agent_container(item, backend, workspace, agent_dir, agent_jsonl, prompt, result, canonical_dir)
-            else:
-                _run_agent_local(
-                    item, backend, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir
-                )
-            active_secs += time.time() - t0
+        # Infra retry loop: a run cut short before the model did ANY work
+        # (INFRA_ERROR + 0 output tokens) says nothing about the model, so it is
+        # retried on a fresh workspace instead of graded. Everything else gets
+        # exactly one attempt.
+        quota_exhausted = False
+        infra_retriable = False
+        infra_reasons: list[str] = []
+        for attempt in range(max(item.infra_retries, 0) + 1):
+            # Canonical snapshot for THIS attempt: both the agent self-check and
+            # grader read it, and retries get a fresh copy even in local mode
+            # where the agent can write to the host path.
+            canonical_dir = _make_canonical_dir(name_no_ext, item.benchmark_path, basename, deps)
 
-        quota_exhausted = not quota.run_with_quota_retry(
-            _run_once,
-            lambda: backend.detect_quota_block(agent_jsonl),
-            log_prefix=f"[{name_no_ext}] ",
-        )
+            # Copy benchmark + dependencies into a FRESH isolated workspace per
+            # attempt, so a failed attempt's partial edits can't leak into a retry.
+            workspace = tempfile.mkdtemp(prefix=f"{backend.name}_bench_{name_no_ext}_")
+            shutil.copy2(item.benchmark_path, os.path.join(workspace, basename))
+            for dep in deps:
+                shutil.copy2(dep, os.path.join(workspace, os.path.basename(dep)))
+
+            # Init git repo (baseline for cheating check)
+            subprocess.run(["git", "init"], capture_output=True, cwd=workspace)
+            subprocess.run(["git", "add", "."], capture_output=True, cwd=workspace)
+            subprocess.run(
+                ["git", "commit", "-m", "initial benchmark"],
+                capture_output=True,
+                cwd=workspace,
+                env={
+                    **os.environ,
+                    "GIT_AUTHOR_NAME": "bench",
+                    "GIT_AUTHOR_EMAIL": "bench@bench",
+                    "GIT_COMMITTER_NAME": "bench",
+                    "GIT_COMMITTER_EMAIL": "bench@bench",
+                },
+            )
+
+            wait_for_memory(item.min_free_gb, 120, log_prefix=f"[{name_no_ext}] ")
+
+            # Run the agent, sleeping through any hard provider usage-limit cap that
+            # the proactive gate (above) can't see (see quota.run_with_quota_retry).
+            # Defaults keep the closure bound to this outer infra attempt.
+            def _run_once(workspace=workspace, canonical_dir=canonical_dir):
+                nonlocal active_secs
+                result["error"] = ""
+                with contextlib.suppress(FileNotFoundError):
+                    os.remove(agent_stderr)
+                t0 = time.time()
+                if item.use_container:
+                    _run_agent_container(
+                        item, backend, workspace, agent_dir, agent_jsonl, prompt, result, canonical_dir
+                    )
+                else:
+                    _run_agent_local(
+                        item,
+                        backend,
+                        mode,
+                        workspace,
+                        agent_dir,
+                        agent_jsonl,
+                        prompt,
+                        result,
+                        checker_bin,
+                        canonical_dir,
+                    )
+                active_secs += time.time() - t0
+
+            quota_exhausted = not quota.run_with_quota_retry(
+                _run_once,
+                lambda: backend.detect_quota_block(agent_jsonl),
+                log_prefix=f"[{name_no_ext}] ",
+            )
+            result["time_secs"] = active_secs
+
+            # Parse agent output and save artifacts on every path — including quota
+            # exhaustion — so the result dir keeps a consistent shape and records any
+            # tokens the agent did emit (rather than forcing them to 0).
+            transcript, input_tokens, output_tokens = backend.parse_output(agent_jsonl)
+            result["input_tokens"] = input_tokens
+            result["output_tokens"] = output_tokens
+
+            if quota_exhausted:
+                break  # quota owns its own retry budget — never infra-retried
+
+            # Tag how the run terminated so an INFRA_ERROR (agent cut short by
+            # infrastructure, not a genuine attempt) is distinguishable from a
+            # real FAIL — and, when the model did no work, retried right here.
+            ctx = TerminationContext(
+                backend=backend.name,
+                jsonl_path=agent_jsonl,
+                agent_exit=result.get("agent_exit"),
+                error=result.get("error", ""),
+                stderr_path=agent_stderr,
+            )
+            result["termination_reason"] = classify(ctx)
+
+            # A genuine attempt (any output tokens) is never re-run.
+            infra_retriable = result["termination_reason"] == TerminationReason.INFRA_ERROR and output_tokens == 0
+            if not infra_retriable:
+                break
+            infra_reasons.append(startup_error_snippet(ctx))
+            if attempt >= item.infra_retries:
+                break  # out of retries — recorded below as ERROR, not graded
+
+            _stash_failed_attempt(agent_dir, attempt)
+            shutil.rmtree(workspace, ignore_errors=True)
+            workspace = None
+            shutil.rmtree(canonical_dir, ignore_errors=True)
+            canonical_dir = None
+            base = INFRA_RETRY_BACKOFF[min(attempt, len(INFRA_RETRY_BACKOFF) - 1)]
+            delay = base + random.uniform(0, base / 2)  # jitter: keep --jobs workers out of lockstep
+            print(
+                f"[{name_no_ext}] transient infra failure ({infra_reasons[-1]}) — "
+                f"retrying in {delay:.0f}s (retry {attempt + 1}/{item.infra_retries})",
+                flush=True,
+            )
+            time.sleep(delay)
 
         elapsed = active_secs
-        result["time_secs"] = elapsed
-
-        # Parse agent output and save artifacts on every path — including quota
-        # exhaustion — so the result dir keeps a consistent shape and records any
-        # tokens the agent did emit (rather than forcing them to 0).
-        transcript, input_tokens, output_tokens = backend.parse_output(agent_jsonl)
-        result["input_tokens"] = input_tokens
-        result["output_tokens"] = output_tokens
-
         with open(os.path.join(agent_dir, "transcript.txt"), "w") as f:
             f.write(f"Benchmark: {rel_path}\n")
             f.write(f"Time: {elapsed:.0f}s\n")
@@ -459,6 +530,10 @@ def run_single_benchmark(item: WorkItem):
         if os.path.isfile(agent_check_file):
             shutil.copy2(agent_check_file, os.path.join(grading_dir, "agent_check.result"))
 
+        if infra_reasons:
+            result["infra_retries"] = attempt  # retries performed (0-based final attempt index)
+            result["infra_retry_reasons"] = infra_reasons
+
         if quota_exhausted:
             # Provider hard-capped us past the retry budget. Mark ERROR (retriable
             # via --resume) and skip grading; the artifacts above keep the result
@@ -473,18 +548,15 @@ def run_single_benchmark(item: WorkItem):
                 json.dump(result, f, indent=2)
             return result
 
-        # Tag how the run terminated so an INFRA_ERROR (agent cut short by
-        # infrastructure, not a genuine attempt) is distinguishable from a real
-        # FAIL downstream. Only genuine, completed runs reach here — a quota-
-        # exhausted run returned above. Classification only — no retry here.
-        result["termination_reason"] = classify(
-            TerminationContext(
-                backend=backend.name,
-                jsonl_path=agent_jsonl,
-                agent_exit=result.get("agent_exit"),
-                error=result.get("error", ""),
-            )
-        )
+        if infra_retriable:
+            # Out of retries with no genuine attempt made: grading the untouched
+            # workspace would turn infra noise into a proof verdict (FAIL, or even
+            # a bogus PASS). Mark ERROR (retriable via --resume), skip the grader.
+            result["check_verdict"] = "ERROR"
+            result["error"] = f"startup/infra failure ({infra_reasons[-1]}); exhausted infra retries"
+            with open(os.path.join(result_dir, "result.json"), "w") as f:
+                json.dump(result, f, indent=2)
+            return result
 
         # Run grader
         check_result_path = os.path.join(grading_dir, "check.result")
@@ -498,11 +570,23 @@ def run_single_benchmark(item: WorkItem):
             json.dump(result, f, indent=2)
 
     finally:
-        shutil.rmtree(workspace, ignore_errors=True)
+        if workspace:
+            shutil.rmtree(workspace, ignore_errors=True)
         if canonical_dir:
             shutil.rmtree(canonical_dir, ignore_errors=True)
 
     return result
+
+
+def _stash_failed_attempt(agent_dir: str, attempt: int) -> None:
+    """Move a failed attempt's raw outputs to agent/attempts/attempt-N/: the
+    retry starts clean (no stale stderr.txt) and the evidence stays debuggable."""
+    dest = os.path.join(agent_dir, "attempts", f"attempt-{attempt}")
+    os.makedirs(dest, exist_ok=True)
+    for fname in ("output.jsonl", "stderr.txt"):
+        src = os.path.join(agent_dir, fname)
+        if os.path.isfile(src):
+            shutil.move(src, os.path.join(dest, fname))
 
 
 def _run_agent_container(
@@ -921,6 +1005,14 @@ def main():
         "(0 = off). Use on a no-swap host shared with another heavy run.",
     )
     parser.add_argument(
+        "--infra-retries",
+        type=int,
+        default=3,
+        help="Extra agent attempts after a transient startup/infrastructure failure "
+        "(agent died with 0 output tokens), so 3 = up to 4 attempts total "
+        "(default: 3; 0 = no retries, the failure still ends as ERROR)",
+    )
+    parser.add_argument(
         "--no-container",
         action="store_true",
         help="Run agent locally instead of inside a Docker container",
@@ -1068,6 +1160,7 @@ def main():
                 quota_max_waits=args.quota_max_waits,
                 min_free_gb=args.min_free_gb,
                 use_container=use_container,
+                infra_retries=args.infra_retries,
             )
         )
 

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -38,6 +38,7 @@ from evaluator.backends import get_backend, list_backends
 from evaluator.backends.base import AgentBackend
 from evaluator.modes import get_mode, list_modes
 from evaluator.modes.base import Mode
+from evaluator.score import SCORERS, is_non_genuine, is_pass, is_skipped, n_non_genuine, n_skipped, weighted_score
 from evaluator.termination import TerminationContext, TerminationReason, classify, startup_error_snippet
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -251,6 +252,15 @@ def _make_canonical_dir(name_no_ext: str, benchmark_path: str, basename: str, de
         raise
 
 
+def _resume_should_skip(result: dict) -> bool:
+    """Resume skips only completed genuine work: SKIP or a non-infra PASS."""
+    return is_skipped(result) or (is_pass(result) and not is_non_genuine(result))
+
+
+def _resume_done_benchmarks(results: list[dict]) -> set[str]:
+    return {r["benchmark"] for r in results if _resume_should_skip(r)}
+
+
 def update_summary(results, output_dir, total_benchmarks, backend_name, mode_name):
     """Incrementally update summary.md + results.json with current results."""
     with _summary_lock:
@@ -266,15 +276,16 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
         lines = []
         lines.append(f"# {backend_name} on {mode_name}\n")
         lines.append(f"**Date**: {time.strftime('%Y-%m-%d %H:%M:%S')}")
-        # SKIP = operator-excluded from scoring; drop it from the pass rate
-        # entirely (neither numerator nor denominator) rather than count it FAIL.
-        n_pass = verdicts.get("PASS", 0)
-        n_skip = verdicts.get("SKIP", 0)
-        scored = total - n_skip
-        pass_pct = (100.0 * n_pass / scored) if scored else 0.0
+        # Match `tlaps-bench score`: SKIP and non-genuine infra/quota-cut runs
+        # are excluded from the pass-rate numerator and denominator.
+        pass_pct, n_pass, scored = weighted_score(results, SCORERS["equal"])
+        n_skip = n_skipped(results)
+        non_genuine = n_non_genuine(results)
         pass_line = f"**Pass rate**: {n_pass}/{scored} ({pass_pct:.1f}%)"
         if n_skip:
             pass_line += f" · {n_skip} skipped"
+        if non_genuine:
+            pass_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
         lines.append(f"**Progress**: {total}/{total_benchmarks}")
         lines.append(pass_line)
         lines.append(f"**Total tokens**: {total_input:,} input / {total_output:,} output\n")
@@ -299,6 +310,9 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
             # canonical parser, vs a proof that simply didn't verify).
             if r.get("sany_valid") is False:
                 notes = ("SANY✗ " + notes).strip()
+            if is_non_genuine(r):
+                reason = r.get("termination_reason", "non-genuine")
+                notes = (f"{reason} (excluded — re-run) " + notes).strip()
             # Name the tamper/admit check(s) behind a CHEATING verdict so a cheat
             # is distinguishable from an honest incomplete FAIL at a glance.
             if r.get("check_verdict") == "CHEATING" and r.get("cheat_checks"):
@@ -1120,8 +1134,8 @@ def main():
     benchmark_files = mode.get_benchmark_files(args.filter)
     print(f"Found {len(benchmark_files)} benchmarks")
 
-    # Resume: reuse --output-dir, skip benchmarks already recorded PASS there,
-    # and seed `results` so the summary stays cumulative across the rerun.
+    # Resume: reuse --output-dir, skip benchmarks already genuinely completed
+    # there, and seed `results` so the summary stays cumulative across the rerun.
     results = []
     done_pass = set()
     if args.resume:
@@ -1129,13 +1143,18 @@ def main():
         if os.path.isfile(prev_json):
             with open(prev_json) as f:
                 results = json.load(f)
-            # Skip both PASS (already done) and SKIP (operator-marked frontier
-            # benchmarks deliberately excluded from retry, e.g. theorems known
-            # to time out for reasons outside the agent's control).
-            done_pass = {r["benchmark"] for r in results if r.get("check_verdict") in ("PASS", "SKIP")}
-            n_pass = sum(1 for r in results if r.get("check_verdict") == "PASS")
-            n_skip = len(done_pass) - n_pass
-            print(f"Resume: loaded {len(results)} prior results, skipping {n_pass} PASS + {n_skip} SKIP")
+            # Skip genuine PASS (already done) and SKIP (operator-marked
+            # frontier benchmarks deliberately excluded from retry). A PASS
+            # produced by INFRA_ERROR / QUOTA_EXHAUSTED is non-genuine and must
+            # be eligible for rerun.
+            done_pass = _resume_done_benchmarks(results)
+            n_pass = sum(1 for r in results if is_pass(r) and not is_non_genuine(r))
+            n_skip = n_skipped(results)
+            non_genuine = n_non_genuine(results)
+            msg = f"Resume: loaded {len(results)} prior results, skipping {n_pass} genuine PASS + {n_skip} SKIP"
+            if non_genuine:
+                msg += f"; {non_genuine} infra/quota-cut result(s) eligible for rerun"
+            print(msg)
         else:
             print(f"Resume: no prior results.json in {output_dir} — running all")
 

--- a/src/evaluator/score.py
+++ b/src/evaluator/score.py
@@ -9,11 +9,18 @@ PASS/FAIL: a task counts as passed iff its ``check_verdict`` is exactly
 ``"PASS"``. Every other verdict — FAIL, CHEATING, TIMEOUT, ERROR — counts as
 not passed. CHEATING is not a separate category here: a cheat is just a failure.
 
-SKIP is the one exception: an operator marks a benchmark ``SKIP`` to exclude it
-from scoring (e.g. a theorem known to time out for reasons outside the agent's
+SKIP is one exception: an operator marks a benchmark ``SKIP`` to exclude it from
+scoring (e.g. a theorem known to time out for reasons outside the agent's
 control). A skipped task is in neither the numerator nor the denominator — it is
-dropped from the pass rate entirely, not counted as a failure — and the count of
-skipped tasks is reported separately so nothing is hidden.
+dropped from the pass rate entirely, not counted as a failure — and the count is
+reported separately so nothing is hidden.
+
+Non-genuine runs are the other exception: a result whose ``termination_reason``
+is ``INFRA_ERROR`` or ``QUOTA_EXHAUSTED`` was cut short by infrastructure or a
+provider cap, so the verdict is not a capability signal. These are excluded from
+the numerator and denominator — like SKIP — and reported separately as needing a
+re-run. TIMEOUT is a limit, not infrastructure: the agent worked and is graded on
+what it left in the workspace, so it stays scored.
 
 Pluggable scoring: a scorer assigns a non-negative weight to each task; the
 score of a group of tasks is
@@ -37,6 +44,7 @@ from collections.abc import Callable
 
 PASS_VERDICT = "PASS"
 SKIP_VERDICT = "SKIP"
+NON_GENUINE_TERMINATIONS = {"INFRA_ERROR", "QUOTA_EXHAUSTED"}
 
 
 def is_pass(result: dict) -> bool:
@@ -49,9 +57,20 @@ def is_skipped(result: dict) -> bool:
     return result.get("check_verdict") == SKIP_VERDICT
 
 
+def is_non_genuine(result: dict) -> bool:
+    """A run cut short by infra/quota. Missing termination_reason means legacy
+    result files stay scored."""
+    return result.get("termination_reason") in NON_GENUINE_TERMINATIONS
+
+
 def n_skipped(results: list[dict]) -> int:
     """How many tasks were operator-excluded from scoring."""
     return sum(1 for r in results if is_skipped(r))
+
+
+def n_non_genuine(results: list[dict]) -> int:
+    """How many results are excluded as non-genuine (need a re-run)."""
+    return sum(1 for r in results if is_non_genuine(r))
 
 
 # A scorer maps one task result to a non-negative weight; the group score is the
@@ -65,10 +84,11 @@ SCORERS: dict[str, Callable[[dict], float]] = {
 def weighted_score(results: list[dict], weight: Callable[[dict], float]) -> tuple[float, int, int]:
     """Return (score_percent, n_passed, n_total) over the scored tasks.
 
-    SKIP tasks are dropped first, so ``n_total`` is the number of *scored* tasks
-    (skipped ones count toward neither the pass count nor the denominator).
+    SKIP and non-genuine tasks are dropped first, so ``n_total`` is the number
+    of *scored* tasks (excluded ones count toward neither the pass count nor the
+    denominator).
     """
-    scored = [r for r in results if not is_skipped(r)]
+    scored = [r for r in results if not is_skipped(r) and not is_non_genuine(r)]
     n_total = len(scored)
     n_pass = sum(1 for r in scored if is_pass(r))
     total_w = sum(max(weight(r), 0.0) for r in scored)
@@ -111,11 +131,14 @@ def scorecard_md(run: dict, weight: Callable[[dict], float], scoring_name: str) 
     results = run["results"]
     pct, n_pass, n_total = weighted_score(results, weight)
     skipped = n_skipped(results)
+    non_genuine = n_non_genuine(results)
     in_tok, out_tok, secs = _cost(results)
 
     pass_line = f"**Pass rate**: {n_pass}/{n_total} ({pct:.1f}%)"
     if skipped:
         pass_line += f" · {skipped} skipped"
+    if non_genuine:
+        pass_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
     lines = [
         f"# Scorecard — {run['backend']} / {run['mode']}",
         "",
@@ -134,8 +157,8 @@ def scorecard_md(run: dict, weight: Callable[[dict], float], scoring_name: str) 
     ]
     by_module: dict[str, list[dict]] = defaultdict(list)
     for r in results:
-        if is_skipped(r):
-            continue  # fully-skipped modules drop out of the table entirely
+        if is_skipped(r) or is_non_genuine(r):
+            continue  # fully-excluded modules drop out of the table entirely
         by_module[r.get("module") or "?"].append(r)
     for module in sorted(by_module):
         mpct, mp, mt = weighted_score(by_module[module], weight)
@@ -161,6 +184,9 @@ def comparison_md(runs: list[dict], weight: Callable[[dict], float], scoring_nam
         skipped = n_skipped(run["results"])
         if skipped:
             passed_total += f" (+{skipped} skipped)"
+        non_genuine = n_non_genuine(run["results"])
+        if non_genuine:
+            passed_total += f" (+{non_genuine} infra-cut)"
         lines.append(
             f"| {run['id']} | {run['backend']} | {run['mode']} | {pct:.1f}% | "
             f"{passed_total} | {in_tok:,}/{out_tok:,} | {secs:,.0f}s |"

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -5,20 +5,23 @@ A benchmark verdict (PASS/FAIL) is a capability signal only if the agent
 actually got to make a genuine attempt. When the run is cut short by
 infrastructure — a corrupted/refused API request, a dropped stream, a server
 overload — the resulting FAIL says nothing about the model. We tag such runs
-with ``termination_reason = INFRA_ERROR`` so they can be filtered out (and,
-later, auto-retried) instead of being read as genuine failures.
+with ``termination_reason = INFRA_ERROR`` so they can be filtered out (and
+auto-retried by the runner when the model did no work) instead of being read
+as genuine failures.
 
 :func:`classify` first checks for a wall-clock timeout (a backend-independent
 LIMIT — the model was working, it just ran out of time — reported as TIMEOUT,
 never INFRA_ERROR), then runs a registry of INFRA RULES (criteria). Each rule
 inspects a ``TerminationContext`` and returns a reason if it fires, else
-``None``; the first that fires wins. There is one rule per backend today
+``None``; the first that fires wins. There is one rule per backend
 (:func:`codex_turn_failed`, :func:`claude_code_result_error`,
 :func:`copilot_session_error`), each branching on ``ctx.backend`` to read its
-own event vocabulary. Add more by appending to :data:`INFRA_RULES`.
+own event vocabulary, plus one backend-independent startup rule
+(:func:`agent_startup_failure`) for the CLI dying before emitting a single
+event. Add more by appending to :data:`INFRA_RULES`.
 
-This module only CLASSIFIES. Acting on the classification (e.g. auto-retrying
-an INFRA_ERROR run) is intentionally left to the caller.
+This module only CLASSIFIES. Acting on the classification (the runner auto-
+retries an INFRA_ERROR run whose model did no work) is left to the caller.
 """
 
 from __future__ import annotations
@@ -60,18 +63,27 @@ class TerminationContext:
     (empty list on a missing/unreadable file), so rules that don't need it pay
     nothing. ``agent_exit`` and ``error`` are the runner's already-recorded
     fields, available to rules that key off them instead of the stream.
+    ``stderr()`` lazily reads the agent's stderr dump ("" when absent), where a
+    startup failure often leaves its only evidence.
     """
 
     backend: str
     jsonl_path: str | None
     agent_exit: int | None = None
     error: str = ""
+    stderr_path: str | None = None
     _events: list | None = None
+    _stderr: str | None = None
 
     def events(self) -> list:
         if self._events is None:
             self._events = _read_events(self.jsonl_path)
         return self._events
+
+    def stderr(self) -> str:
+        if self._stderr is None:
+            self._stderr = _read_text(self.stderr_path)
+        return self._stderr
 
 
 def _read_events(path: str | None) -> list:
@@ -93,6 +105,17 @@ def _read_events(path: str | None) -> list:
     except FileNotFoundError:
         return []
     return out
+
+
+def _read_text(path: str | None) -> str:
+    """Contents of a text file, tolerantly ("" when unset/absent/unreadable)."""
+    if not path:
+        return ""
+    try:
+        with open(path) as f:
+            return f.read()
+    except OSError:
+        return ""
 
 
 # A rule inspects the context and returns a TerminationReason if it fires, else
@@ -196,13 +219,39 @@ def copilot_session_error(ctx: TerminationContext) -> str | None:
     return TerminationReason.INFRA_ERROR
 
 
-# Registry of INFRA_ERROR criteria. One rule per backend today; append more here
-# (other backends, or additional patterns for an existing one) — classify()
-# returns the first that fires. This list IS the extension point.
+def agent_startup_failure(ctx: TerminationContext) -> str | None:
+    """Backend-independent rule: the CLI died before emitting a single event
+    (observed on Copilot: transient model-list/auth/DNS startup failures with a
+    0-byte stream, nonzero exit, and the error only on stderr). Keys on that
+    shape alone — never on the stderr wording — covering the per-backend rules'
+    empty-stream blind spot for every backend. A wall-clock timeout leaves the
+    same shape; classify() checks it first.
+    """
+    if ctx.events():
+        return None
+    if not ctx.agent_exit:  # 0 or None: clean/unknown exit, not a startup death
+        return None
+    return TerminationReason.INFRA_ERROR
+
+
+def startup_error_snippet(ctx: TerminationContext) -> str:
+    """Label for ``infra_retry_reasons``: the first stderr line mentioning
+    "error", else the last non-empty line. Diagnostic only — never gates a retry."""
+    lines = [ln.strip() for ln in ctx.stderr().splitlines() if ln.strip()]
+    if not lines:
+        return "no stderr"
+    return next((ln for ln in lines if "error" in ln.lower()), lines[-1])[:120]
+
+
+# Registry of INFRA_ERROR criteria. One rule per backend, then the backend-
+# independent startup rule as fallback; append more here (other backends, or
+# additional patterns for an existing one) — classify() returns the first that
+# fires. This list IS the extension point.
 INFRA_RULES: list[Rule] = [
     codex_turn_failed,
     claude_code_result_error,
     copilot_session_error,
+    agent_startup_failure,
 ]
 
 

--- a/tests/common/test_firewall_dns.py
+++ b/tests/common/test_firewall_dns.py
@@ -1,0 +1,64 @@
+"""firewall.sh DNS hardening — retry dig before declaring a host unresolvable.
+
+A single transient DNS miss on ANY allowlisted host used to abort the whole
+agent container (observed: one empty dig answer for q.eu-central-1.amazonaws.com
+killed a Copilot run before the agent started — a host that backend doesn't
+even use). The script must retry dig a few times and only then hard-fail.
+dig/iptables/sleep are stubbed on PATH, so no root or network is needed.
+
+Run: uv run python -m pytest tests/common/test_firewall_dns.py -v
+"""
+
+import os
+import stat
+import subprocess
+
+FIREWALL_SH = os.path.join(os.path.dirname(__file__), "..", "..", "docker", "firewall.sh")
+
+
+def _stub(bindir, name, body):
+    path = bindir / name
+    path.write_text(f"#!/bin/bash\n{body}\n")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def _run_firewall(tmp_path, fail_digs):
+    """Run firewall.sh with stubbed tools: dig answers nothing for the first
+    `fail_digs` calls, then resolves. Returns (proc, dig call count)."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    counter = tmp_path / "dig_calls"
+    counter.write_text("0")
+    _stub(
+        bindir,
+        "dig",
+        f'n=$(cat "{counter}"); n=$((n + 1)); echo "$n" > "{counter}"; '
+        f'if [ "$n" -gt {fail_digs} ]; then echo 1.2.3.4; fi',
+    )
+    _stub(bindir, "iptables", "exit 0")
+    _stub(bindir, "ip6tables", "exit 0")
+    _stub(bindir, "sleep", "exit 0")  # keep the retry backoff instant
+    env = {**os.environ, "PATH": f"{bindir}:{os.environ['PATH']}", "FIREWALL_HOSTS": "api.example.com"}
+    proc = subprocess.run(["bash", FIREWALL_SH], capture_output=True, text=True, env=env, timeout=30)
+    return proc, int(counter.read_text())
+
+
+def test_first_try_resolution_needs_no_retry(tmp_path):
+    proc, dig_calls = _run_firewall(tmp_path, fail_digs=0)
+    assert proc.returncode == 0, proc.stderr
+    assert dig_calls == 1
+    assert "Allowed: api.example.com -> 1.2.3.4" in proc.stdout
+
+
+def test_transient_dns_miss_is_retried(tmp_path):
+    proc, dig_calls = _run_firewall(tmp_path, fail_digs=2)
+    assert proc.returncode == 0, proc.stderr
+    assert dig_calls == 3
+    assert "Allowed: api.example.com -> 1.2.3.4" in proc.stdout
+
+
+def test_persistent_dns_failure_still_fails_after_retries(tmp_path):
+    proc, dig_calls = _run_firewall(tmp_path, fail_digs=99)
+    assert proc.returncode == 1
+    assert dig_calls == 3  # all retries spent before giving up
+    assert "no IPs resolved for host 'api.example.com'" in proc.stderr

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -129,6 +129,46 @@ def _no_sleep(monkeypatch):
     return sleeps
 
 
+def _result(benchmark, verdict, termination_reason="OK", **kw):
+    out = {
+        "benchmark": benchmark,
+        "check_verdict": verdict,
+        "time_secs": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "termination_reason": termination_reason,
+    }
+    out.update(kw)
+    return out
+
+
+def test_summary_excludes_non_genuine_results_from_pass_rate(tmp_path):
+    results = [
+        _result("genuine-pass.tla", "PASS"),
+        _result("genuine-fail.tla", "FAIL"),
+        _result("infra-pass.tla", "PASS", termination_reason=TerminationReason.INFRA_ERROR),
+        _result("quota-error.tla", "ERROR", termination_reason=TerminationReason.QUOTA_EXHAUSTED),
+        _result("skipped.tla", "SKIP"),
+    ]
+    runner.update_summary(results, str(tmp_path), total_benchmarks=5, backend_name="copilot", mode_name="proof-completion")
+    summary = (tmp_path / "summary.md").read_text()
+    assert "**Pass rate**: 1/2 (50.0%) · 1 skipped · 2 infra/quota-cut (excluded — re-run)" in summary
+    assert "`infra-pass.tla` | ✅ PASS" in summary
+    assert "INFRA_ERROR (excluded — re-run)" in summary
+
+
+def test_resume_does_not_skip_non_genuine_pass_results():
+    results = [
+        _result("genuine-pass.tla", "PASS"),
+        _result("legacy-pass.tla", "PASS", termination_reason=None),
+        _result("infra-pass.tla", "PASS", termination_reason=TerminationReason.INFRA_ERROR),
+        _result("quota-pass.tla", "PASS", termination_reason=TerminationReason.QUOTA_EXHAUSTED),
+        _result("skipped.tla", "SKIP"),
+        _result("failed.tla", "FAIL"),
+    ]
+    assert runner._resume_done_benchmarks(results) == {"genuine-pass.tla", "legacy-pass.tla", "skipped.tla"}
+
+
 def test_startup_failure_retried_and_final_attempt_graded(tmp_path, monkeypatch):
     backend = _ScriptedBackend()
     agent = _install_agent(monkeypatch, backend, [STARTUP, GENUINE_FAIL])

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -1,0 +1,307 @@
+"""runner infra-retry loop — retry transient startup failures, never real attempts.
+
+A startup failure (INFRA_ERROR + 0 output tokens: the CLI died before the model
+did any work) must be retried on a fresh workspace, and only the final genuine
+attempt graded; exhaustion is ERROR/INFRA_ERROR, never a proof FAIL. Fakes stand
+in for the agent and grader, so no container, real backend or tlapm is needed.
+
+Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_infra_retry.py
+"""
+
+import json
+import os
+
+from evaluator import runner
+from evaluator.termination import TerminationReason
+
+BENCH_TEXT = "---- MODULE Bar ----\n====\n"
+
+# One clean copilot terminal event: classifies as a genuine, completed run.
+CLEAN_EVENTS = [{"type": "result", "exitCode": 0}]
+
+# The observed startup shape: nonzero exit, no events, error only on stderr.
+STARTUP = {"exit": 1, "stderr": "Error: Failed to load models\n\nError: Failed to list models\n"}
+# A genuine attempt whose proof simply didn't verify.
+GENUINE_FAIL = {"exit": 0, "events": CLEAN_EVENTS, "out_tokens": 500}
+
+
+class _ScriptedBackend:
+    """Backend whose per-attempt behavior is scripted (see _install_agent)."""
+
+    name = "copilot"
+
+    def __init__(self):
+        self.out_tokens = 0  # set by the fake agent for the current attempt
+
+    def parse_output(self, jsonl_path):
+        return ("", 0, self.out_tokens)
+
+    def detect_quota_block(self, jsonl_path):
+        return None
+
+
+class _FakeMode:
+    name = "proof-completion"
+
+    def __init__(self, bench_dir):
+        self._bench_dir = bench_dir
+
+    def benchmark_dir(self):
+        return self._bench_dir
+
+    def get_dependencies(self, benchmark_path):
+        return []
+
+    def checker_binary_path(self):
+        return "/bin/true"
+
+    def build_prompt(self, basename, tlapm_path, tlapm_lib):
+        return "prove it"
+
+
+def _work_item(tmp_path, backend, infra_retries=3):
+    bench_dir = tmp_path / "bench"
+    bench_path = bench_dir / "Foo" / "Bar.tla"
+    os.makedirs(bench_path.parent, exist_ok=True)
+    bench_path.write_text(BENCH_TEXT)
+    return runner.WorkItem(
+        benchmark_path=str(bench_path),
+        output_dir=str(tmp_path / "out"),
+        timeout=10,
+        check_timeout=10,
+        backend=backend,  # ty:ignore[invalid-argument-type]
+        mode=_FakeMode(str(bench_dir)),  # ty:ignore[invalid-argument-type]
+        tlapm_path="/bin/true",
+        tlapm_lib="",
+        infra_retries=infra_retries,
+    )
+
+
+def _install_agent(monkeypatch, backend, attempts):
+    """Patch _run_agent_local with a scripted agent: one spec dict per attempt
+    ({"exit": int, "events": [...], "stderr": str, "out_tokens": int,
+    "error": str, "mutate": fn(workspace)})."""
+    calls = {"n": 0, "workspaces": [], "canonical_dirs": []}
+
+    def fake_run(
+        item, backend_, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir=None
+    ):
+        spec = attempts[calls["n"]]
+        calls["n"] += 1
+        calls["workspaces"].append(workspace)
+        calls["canonical_dirs"].append(canonical_dir)
+        with open(agent_jsonl, "w") as f:
+            for ev in spec.get("events", []):
+                f.write(json.dumps(ev) + "\n")
+        if spec.get("stderr"):
+            with open(os.path.join(agent_dir, "stderr.txt"), "w") as f:
+                f.write(spec["stderr"])
+        result["agent_exit"] = spec.get("exit", 0)
+        if spec.get("error"):
+            result["error"] = spec["error"]
+        backend.out_tokens = spec.get("out_tokens", 0)
+        if "mutate" in spec:
+            spec["mutate"](workspace)
+        if "mutate_canonical" in spec:
+            spec["mutate_canonical"](canonical_dir)
+
+    monkeypatch.setattr(runner, "_run_agent_local", fake_run)
+    return calls
+
+
+def _install_grader(monkeypatch, verdict="FAIL", inspect_canonical=None):
+    calls = {"n": 0, "canonical_dirs": []}
+
+    def fake_grader(item, workspace, basename, grading_dir, check_result_path, result, canonical_dir=None):
+        calls["n"] += 1
+        calls["canonical_dirs"].append(canonical_dir)
+        if inspect_canonical:
+            inspect_canonical(canonical_dir)
+        result["check_verdict"] = verdict
+
+    monkeypatch.setattr(runner, "_run_grader_local", fake_grader)
+    return calls
+
+
+def _no_sleep(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(runner.time, "sleep", lambda s: sleeps.append(s))
+    return sleeps
+
+
+def test_startup_failure_retried_and_final_attempt_graded(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [STARTUP, GENUINE_FAIL])
+    grader = _install_grader(monkeypatch, verdict="FAIL")
+    sleeps = _no_sleep(monkeypatch)
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend))
+    assert agent["n"] == 2
+    assert grader["n"] == 1  # only the genuine attempt is graded
+    assert result["check_verdict"] == "FAIL"
+    assert result["termination_reason"] == TerminationReason.OK
+    assert result["infra_retries"] == 1
+    assert result["infra_retry_reasons"] == ["Error: Failed to load models"]
+    assert len(sleeps) == 1 and sleeps[0] >= 15  # first backoff step (plus jitter)
+    # Failed attempt's evidence is stashed; the retry metadata reaches disk.
+    out = tmp_path / "out" / "Foo" / "Bar"
+    assert "Failed to load models" in (out / "agent" / "attempts" / "attempt-0" / "stderr.txt").read_text()
+    saved = json.loads((out / "result.json").read_text())
+    assert saved["infra_retries"] == 1
+
+
+def test_retry_exhaustion_is_error_not_fail(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [STARTUP] * 3)
+    grader = _install_grader(monkeypatch)
+    _no_sleep(monkeypatch)
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, infra_retries=2))
+    assert agent["n"] == 3
+    assert grader["n"] == 0  # never grade a run the model never attempted
+    assert result["check_verdict"] == "ERROR"
+    assert result["termination_reason"] == TerminationReason.INFRA_ERROR
+    assert result["infra_retries"] == 2
+    assert result["infra_retry_reasons"] == ["Error: Failed to load models"] * 3
+    assert "exhausted infra retries" in result["error"]
+
+
+def test_genuine_attempt_never_retried(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [GENUINE_FAIL])
+    grader = _install_grader(monkeypatch)
+    sleeps = _no_sleep(monkeypatch)
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend))
+    assert agent["n"] == 1 and grader["n"] == 1
+    assert result["check_verdict"] == "FAIL"
+    assert "infra_retries" not in result
+    assert sleeps == []
+
+
+def test_midrun_infra_with_tokens_not_retried(tmp_path, monkeypatch):
+    # INFRA_ERROR but the model DID work (tokens > 0): classified for downstream
+    # filtering, but never re-run — the attempt was genuine.
+    cut_off = {"exit": 1, "events": [{"type": "assistant.message", "data": {"content": "working"}}], "out_tokens": 42}
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [cut_off])
+    grader = _install_grader(monkeypatch)
+    _no_sleep(monkeypatch)
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend))
+    assert agent["n"] == 1 and grader["n"] == 1
+    assert result["termination_reason"] == TerminationReason.INFRA_ERROR
+    assert "infra_retries" not in result
+
+
+def test_wall_clock_timeout_not_retried(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    timeout = {"exit": -1, "error": "copilot timeout after 10s"}
+    agent = _install_agent(monkeypatch, backend, [timeout])
+    grader = _install_grader(monkeypatch)
+    sleeps = _no_sleep(monkeypatch)
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend))
+    assert agent["n"] == 1 and grader["n"] == 1
+    assert result["termination_reason"] == TerminationReason.TIMEOUT
+    assert sleeps == []
+
+
+def test_infra_retries_zero_disables_retrying(tmp_path, monkeypatch):
+    # 0 = no retries, but the no-attempt run still ends ERROR, never a proof FAIL.
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [STARTUP])
+    grader = _install_grader(monkeypatch)
+    sleeps = _no_sleep(monkeypatch)
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, infra_retries=0))
+    assert agent["n"] == 1 and grader["n"] == 0
+    assert result["check_verdict"] == "ERROR"
+    assert result["termination_reason"] == TerminationReason.INFRA_ERROR
+    assert result["infra_retries"] == 0
+    assert sleeps == []
+
+
+def test_retry_runs_on_fresh_workspace(tmp_path, monkeypatch):
+    # A failed attempt's partial edits must not leak into the retry: attempt 1
+    # scribbles on the benchmark, attempt 2 must see a pristine copy.
+    seen = []
+
+    def scribble(workspace):
+        path = os.path.join(workspace, "Bar.tla")
+        with open(path) as f:
+            seen.append(f.read())
+        with open(path, "w") as f:
+            f.write("TAMPERED")
+
+    def check(workspace):
+        with open(os.path.join(workspace, "Bar.tla")) as f:
+            seen.append(f.read())
+
+    backend = _ScriptedBackend()
+    attempts = [dict(STARTUP, mutate=scribble), dict(GENUINE_FAIL, mutate=check)]
+    agent = _install_agent(monkeypatch, backend, attempts)
+    _install_grader(monkeypatch)
+    _no_sleep(monkeypatch)
+    runner.run_single_benchmark(_work_item(tmp_path, backend))
+    assert agent["workspaces"][0] != agent["workspaces"][1]
+    assert seen == [BENCH_TEXT, BENCH_TEXT]
+
+
+def test_retry_runs_on_fresh_canonical_snapshot(tmp_path, monkeypatch):
+    # In local mode the agent can write to TLAPS_BENCHMARK_DIR. A failed
+    # attempt's canonical snapshot must not leak into the retry or grader.
+    seen = []
+
+    def taint(canonical_dir):
+        path = os.path.join(canonical_dir, "Bar.tla")
+        with open(path) as f:
+            seen.append(f.read())
+        with open(path, "w") as f:
+            f.write("TAINTED")
+
+    def check(canonical_dir):
+        with open(os.path.join(canonical_dir, "Bar.tla")) as f:
+            seen.append(f.read())
+
+    backend = _ScriptedBackend()
+    attempts = [dict(STARTUP, mutate_canonical=taint), dict(GENUINE_FAIL, mutate_canonical=check)]
+    agent = _install_agent(monkeypatch, backend, attempts)
+    grader = _install_grader(monkeypatch, inspect_canonical=check)
+    _no_sleep(monkeypatch)
+
+    runner.run_single_benchmark(_work_item(tmp_path, backend))
+
+    assert agent["canonical_dirs"][0] != agent["canonical_dirs"][1]
+    assert grader["canonical_dirs"] == [agent["canonical_dirs"][1]]
+    assert seen == [BENCH_TEXT, BENCH_TEXT, BENCH_TEXT]
+
+
+def test_quota_exhaustion_is_not_infra_retried(tmp_path, monkeypatch):
+    # Quota owns its own retry budget: once it reports exhaustion the infra loop
+    # must stop dead — no reclassification, no extra attempts.
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [STARTUP] * 4)
+    grader = _install_grader(monkeypatch)
+    _no_sleep(monkeypatch)
+    monkeypatch.setattr(runner.quota, "run_with_quota_retry", lambda run, block, **k: False)
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend))
+    assert agent["n"] == 0  # the quota stub swallowed the run entirely
+    assert grader["n"] == 0
+    assert result["check_verdict"] == "ERROR"
+    assert result["termination_reason"] == TerminationReason.QUOTA_EXHAUSTED
+    assert "infra_retries" not in result
+
+
+def test_quota_retry_clears_stale_stderr_before_final_run(tmp_path, monkeypatch):
+    # quota.run_with_quota_retry can invoke the agent multiple times inside one
+    # infra attempt. Stderr from the quota-blocked run must not label the final run.
+    backend = _ScriptedBackend()
+    blocks = iter([1, None])
+    monkeypatch.setattr(backend, "detect_quota_block", lambda _jsonl: next(blocks))
+    agent = _install_agent(monkeypatch, backend, [{"exit": 1, "stderr": "old quota/stderr noise\n"}, {"exit": 1}])
+    grader = _install_grader(monkeypatch)
+    _no_sleep(monkeypatch)
+
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, infra_retries=0))
+
+    assert agent["n"] == 2
+    assert grader["n"] == 0
+    assert result["check_verdict"] == "ERROR"
+    assert result["termination_reason"] == TerminationReason.INFRA_ERROR
+    assert result["infra_retry_reasons"] == ["no stderr"]
+    assert not (tmp_path / "out" / "Foo" / "Bar" / "agent" / "stderr.txt").exists()

--- a/tests/evaluator/test_score.py
+++ b/tests/evaluator/test_score.py
@@ -19,6 +19,7 @@ from evaluator.score import (
     is_skipped,
     load_run,
     main,
+    n_non_genuine,
     n_skipped,
     scorecard_md,
     weighted_score,
@@ -109,6 +110,43 @@ def test_all_skip_is_zero_not_crash():
     results = [_r("SKIP"), _r("SKIP")]
     assert weighted_score(results, EQUAL) == (0.0, 0, 0)
     assert n_skipped(results) == 2
+
+
+def test_non_genuine_terminations_are_excluded_either_verdict():
+    # A startup failure can leave a no-op workspace that grades PASS on a
+    # defective task. INFRA_ERROR / QUOTA_EXHAUSTED results must count neither
+    # as passes nor failures; they need a rerun.
+    results = [
+        _r("PASS"),
+        _r("FAIL"),
+        _r("PASS", termination_reason="INFRA_ERROR"),
+        _r("FAIL", termination_reason="INFRA_ERROR"),
+        _r("ERROR", termination_reason="QUOTA_EXHAUSTED"),
+    ]
+    pct, n_pass, n_total = weighted_score(results, EQUAL)
+    assert (n_pass, n_total, pct) == (1, 2, 50.0)
+    assert n_non_genuine(results) == 3
+
+
+def test_ok_timeout_and_legacy_results_stay_scored():
+    # TIMEOUT is a limit (graded on workspace artifacts); a missing
+    # termination_reason is a pre-classification run. Both stay scored.
+    results = [
+        _r("PASS", termination_reason="OK"),
+        _r("FAIL", termination_reason="TIMEOUT"),
+        _r("FAIL"),
+    ]
+    pct, n_pass, n_total = weighted_score(results, EQUAL)
+    assert (n_pass, n_total) == (1, 3)
+    assert n_non_genuine(results) == 0
+
+
+def test_scorecard_reports_non_genuine_count():
+    results = [_r("PASS"), _r("PASS", termination_reason="INFRA_ERROR")]
+    run = {"path": "x", "id": "r", "backend": "copilot", "mode": "proof-completion", "results": results}
+    card = scorecard_md(run, EQUAL, "equal")
+    assert "**Pass rate**: 1/1 (100.0%)" in card
+    assert "1 infra/quota-cut (excluded — re-run)" in card
 
 
 def test_scorecard_excludes_skip_and_reports_it():

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -17,11 +17,13 @@ from evaluator.termination import (
     INFRA_RULES,
     TerminationContext,
     TerminationReason,
+    agent_startup_failure,
     classify,
     claude_code_result_error,
     codex_turn_failed,
     copilot_session_error,
     is_wall_clock_timeout,
+    startup_error_snippet,
 )
 
 # codex stream cut short by a corrupted/refused request (no turn.completed).
@@ -146,6 +148,7 @@ def test_registry_is_the_extension_point():
     assert codex_turn_failed in INFRA_RULES
     assert claude_code_result_error in INFRA_RULES
     assert copilot_session_error in INFRA_RULES
+    assert agent_startup_failure in INFRA_RULES
 
 
 # --- quota exhaustion: runner-owned, never produced by classify() -----------
@@ -371,3 +374,86 @@ def test_copilot_truncated_is_infra(tmp_path):
 def test_copilot_rule_only_applies_to_copilot(tmp_path):
     p = _write_jsonl(tmp_path / "trunc.jsonl", CP_TRUNCATED)
     assert copilot_session_error(_ctx(p, backend="codex")) is None
+
+
+# --- backend-independent startup rule (empty stream + nonzero exit) ----------
+
+# The observed Copilot startup failures: a 0-byte output.jsonl, agent_exit 1,
+# and the real error only in stderr, wrapped in install/firewall noise.
+COPILOT_STARTUP_STDERR = """\
+added 3 packages in 8s
+[firewall] Allowed: api.githubcopilot.com -> 140.82.113.22
+Error: Failed to load models
+
+Error: Failed to list models
+"""
+
+
+def _startup_ctx(tmp_path, stderr=None, backend="copilot", agent_exit=1, error=""):
+    # A 0-byte event stream, exactly as the observed startup failures left it.
+    jsonl = tmp_path / "output.jsonl"
+    jsonl.write_text("")
+    stderr_path = None
+    if stderr is not None:
+        p = tmp_path / "stderr.txt"
+        p.write_text(stderr)
+        stderr_path = str(p)
+    return TerminationContext(
+        backend=backend, jsonl_path=str(jsonl), agent_exit=agent_exit, error=error, stderr_path=stderr_path
+    )
+
+
+def test_startup_failure_is_infra_for_every_backend(tmp_path):
+    # The rule keys on the failure's shape, not a backend's event vocabulary.
+    for backend in ("copilot", "codex", "claude_code", "litellm"):
+        ctx = _startup_ctx(tmp_path, COPILOT_STARTUP_STDERR, backend=backend)
+        assert classify(ctx) == TerminationReason.INFRA_ERROR, backend
+
+
+def test_startup_error_snippet_quotes_the_real_error(tmp_path):
+    # The label is the actual error line from stderr (first line mentioning
+    # "error"), skipping the npm/firewall noise around it — no hardcoded
+    # signature list to go stale.
+    assert startup_error_snippet(_startup_ctx(tmp_path, COPILOT_STARTUP_STDERR)) == "Error: Failed to load models"
+    dns_stderr = "[firewall] ERROR: no IPs resolved for host 'q.eu-central-1.amazonaws.com'"
+    assert startup_error_snippet(_startup_ctx(tmp_path, dns_stderr)) == dns_stderr
+    # No "error" wording anywhere: fall back to the last non-empty line.
+    assert (
+        startup_error_snippet(_startup_ctx(tmp_path, "added 3 packages in 8s\nAuthentication token rejected\n"))
+        == "Authentication token rejected"
+    )
+    assert startup_error_snippet(_startup_ctx(tmp_path, None)) == "no stderr"
+
+
+def test_reworded_startup_error_is_still_infra(tmp_path):
+    # The snippet labels, it never gates: a reworded CLI error must not
+    # silently turn startup failures back into proof FAILs.
+    ctx = _startup_ctx(tmp_path, "models are having a bad day\n")
+    assert classify(ctx) == TerminationReason.INFRA_ERROR
+    assert startup_error_snippet(ctx) == "models are having a bad day"
+
+
+def test_startup_failure_without_stderr_is_still_infra(tmp_path):
+    # No stderr dump at all (e.g. the container died before writing one).
+    assert classify(_startup_ctx(tmp_path, None)) == TerminationReason.INFRA_ERROR
+
+
+def test_clean_exit_with_empty_stream_is_not_startup_failure(tmp_path):
+    assert classify(_startup_ctx(tmp_path, COPILOT_STARTUP_STDERR, agent_exit=0)) == TerminationReason.OK
+
+
+def test_startup_rule_never_overrides_timeout(tmp_path):
+    # A SIGKILLed run can also leave an empty stream + nonzero exit; the
+    # wall-clock timeout precheck must win.
+    ctx = _startup_ctx(tmp_path, None, agent_exit=-1, error="copilot timeout after 300s")
+    assert classify(ctx) == TerminationReason.TIMEOUT
+
+
+def test_noisy_stderr_on_clean_run_is_ok(tmp_path):
+    # install/firewall noise on stderr is normal — a run that reached a clean
+    # terminal event stays OK regardless of what stderr says.
+    p = _write_jsonl(tmp_path / "done.jsonl", CP_COMPLETED)
+    sp = tmp_path / "stderr.txt"
+    sp.write_text(COPILOT_STARTUP_STDERR)  # worst case: even a scary stderr
+    ctx = TerminationContext(backend="copilot", jsonl_path=p, agent_exit=0, stderr_path=str(sp))
+    assert classify(ctx) == TerminationReason.OK


### PR DESCRIPTION
## Summary

- Retry infrastructure failures that happen before the model does any work (`INFRA_ERROR` with zero output tokens), including agent CLIs that crash during startup before emitting their first event.
- Do not infra-retry genuine attempts with output tokens, wall-clock timeouts, or quota exhaustion.
- Start each retry with a fresh workspace and canonical benchmark snapshot, while preserving failed output and stderr under `agent/attempts/`.
- If all retries are exhausted, record `ERROR` / `INFRA_ERROR` and skip grading instead of reporting a proof failure.
- Add `--infra-retries` (default: `3`, for up to four total attempts) with jittered backoff.
- Retry firewall DNS resolution up to three times before failing container startup.

## Validation

- One real native Codex benchmark run passed on its first attempt.
- One simulated startup failure triggered an infra retry and then passed, with retry metadata and artifacts verified.
- Full test suite passed: `192 passed, 3 skipped`
