### PR TITLE
Add max-continuations runner support

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -119,8 +119,9 @@ uv run tlaps-bench run [flags]
 | `--timeout` | `28800` | Per-benchmark agent timeout in seconds |
 | `--check-timeout` | `600` | Per-benchmark checker (tlapm) timeout in seconds |
 | `--output-dir` | auto-generated | Output directory |
-| `--resume` | off | Skip benchmarks already marked `SKIP` or genuine `PASS` |
+| `--resume` | off | Skip benchmarks already marked `SKIP` or genuine `PASS` (first-attempt or continuation) |
 | `--infra-retries` | `3` | Extra attempts after a transient agent startup/infra failure (0 output tokens); `0` = no inline retries |
+| `--max-continuations` | `0` | Run up to N same-workspace continuation attempts after the first attempt completes without PASS (see [Continuation runs](#continuation-runs)) |
 | `--force-build` | off | Rebuild the Docker image |
 | `--no-container` | off | Run without Docker (requires native setup) |
 
@@ -193,6 +194,8 @@ results/<mode>/<backend>/<timestamp>/
         └── agent_check.result  # Agent's own in-workspace check, if it ran one
 ```
 
+With `--max-continuations`, each continuation round also writes a `continuations/round-N/` directory with that round's prompt, output, solution, and checker result.
+
 ---
 
 ## Resuming a Run
@@ -203,9 +206,23 @@ If a run is interrupted or you want to retry only the failures:
 uv run tlaps-bench run --backend codex --model gpt-5.5 --output-dir results/proof-completion/codex/20260626_120000 --resume
 ```
 
-The runner skips benchmarks already recorded as `SKIP` or as a genuine `PASS` in that directory, and reruns the rest.
+The runner skips benchmarks already recorded as `SKIP` or as a genuine `PASS` in that directory (first-attempt or via a continuation round), and reruns the rest.
 
 Inline infra retries are intentionally short: the default `--infra-retries 3` gives the original attempt plus three retries with brief backoff. If a longer provider or network outage leaves `INFRA_ERROR` / `QUOTA_EXHAUSTED` results, rerun later with the same `--output-dir --resume`; those non-genuine results are not skipped.
+
+---
+
+## Continuation Runs
+
+Use `--max-continuations N` to give the agent extra chances to finish a proof it already started:
+
+```bash
+uv run tlaps-bench run --backend codex --model gpt-5.5 --max-continuations 3
+```
+
+Each benchmark still starts with the normal first attempt. If that attempt completes without PASS, the runner starts up to `N` more attempts in the same workspace. Each continuation sees the partial proof from the previous attempt. The chain stops once a continuation passes or the limit is reached.
+
+The first-attempt verdict stays in `check_verdict`. Continuation rounds are saved under `continuations` in `results.json`, and reports show them separately as `Pass rate with continuations (≤N)`.
 
 ---
 

--- a/src/evaluator/modes/base.py
+++ b/src/evaluator/modes/base.py
@@ -174,6 +174,16 @@ class Mode(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; sub
             tlapm_lib=tlapm_lib,
         )
 
+    def build_continuation_prompt(self, benchmark_basename: str, tlapm_path: str, tlapm_lib: str) -> str:
+        """Prompt for a continuation round (--max-continuations): the shared
+        preamble — this continues your own incomplete attempt; keep what works,
+        fix the rest — followed by the full first-run prompt, since each round
+        is a fresh CLI session with no memory of the previous one."""
+        preamble_path = os.path.join(os.path.dirname(self.prompt_template_path()), "continuation-preamble.txt")
+        with open(preamble_path) as f:
+            preamble = f.read().format(benchmark_basename=benchmark_basename)
+        return preamble + "\n" + self.build_prompt(benchmark_basename, tlapm_path, tlapm_lib)
+
     def checker_command(
         self, workspace: str, benchmark_basename: str, output_path: str, timeout: int, benchmark_dir: str | None = None
     ) -> list[str]:

--- a/src/evaluator/modes/base.py
+++ b/src/evaluator/modes/base.py
@@ -181,7 +181,7 @@ class Mode(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; sub
         is a fresh CLI session with no memory of the previous one."""
         preamble_path = os.path.join(os.path.dirname(self.prompt_template_path()), "continuation-preamble.txt")
         with open(preamble_path) as f:
-            preamble = f.read().format(benchmark_basename=benchmark_basename)
+            preamble = f.read().format(benchmark_basename=benchmark_basename, mode=self.name)
         return preamble + "\n" + self.build_prompt(benchmark_basename, tlapm_path, tlapm_lib)
 
     def checker_command(

--- a/src/evaluator/prompts/continuation-preamble.txt
+++ b/src/evaluator/prompts/continuation-preamble.txt
@@ -1,0 +1,6 @@
+# Continuation
+
+This session continues your own earlier, incomplete attempt at the task below.
+{benchmark_basename} in the working directory already contains the partial proof from that attempt; it does not fully verify yet.
+Read the file's current state first, keep the parts of the proof that already work, and repair or replace the parts that fail — do not discard the previous work and restart unless the existing approach is unsalvageable.
+Everything below (task, tools, constraints) applies unchanged.

--- a/src/evaluator/prompts/continuation-preamble.txt
+++ b/src/evaluator/prompts/continuation-preamble.txt
@@ -1,6 +1,8 @@
 # Continuation
 
-This session continues your own earlier, incomplete attempt at the task below.
-{benchmark_basename} in the working directory already contains the partial proof from that attempt; it does not fully verify yet.
-Read the file's current state first, keep the parts of the proof that already work, and repair or replace the parts that fail — do not discard the previous work and restart unless the existing approach is unsalvageable.
+This session continues your own earlier attempt at the task below.
+{benchmark_basename} in the working directory already contains the work from that attempt, but it is not accepted yet: `check_proof_bin {benchmark_basename} --mode {mode}` does not report PASS.
+Run that check first to see exactly what is wrong.
+Note that tlapm alone may show no errors even when the checker rejects the file (for example when a helper lemma is admitted rather than proved): the only completion signal that counts is check_proof_bin reporting PASS.
+Keep the parts of your previous work that are correct, and repair or replace the parts the checker rejects — do not discard the previous work and restart unless the existing approach is unsalvageable.
 Everything below (task, tools, constraints) applies unchanged.

--- a/src/evaluator/prompts/proof-completion.txt
+++ b/src/evaluator/prompts/proof-completion.txt
@@ -11,6 +11,7 @@ The tlapm standard library is at {tlapm_lib} — you may read and reference the 
 You can run tlapm directly: `{tlapm_path}/bin/tlapm -I {tlapm_lib} {benchmark_basename}`.
 Keep editing your proof until tlapm shows no errors — do not give up or stop early.
 If a proof attempt fails, try a different strategy.
+If you must stop before the proof is complete, leave your best partial proof in {benchmark_basename} — never delete your incomplete work or revert the file to its original placeholder.
 Keep iterating until `check_proof_bin {benchmark_basename} --mode proof-completion` reports PASS.
 
 Your solution must also parse under the standard TLA+ parser (SANY): the checker rejects a file SANY cannot parse (reported as `[SANY-INVALID]`), so avoid constructs SANY rejects such as an operator parameter or bound variable that shadows a declared CONSTANT/VARIABLE; you can check just the syntax in seconds (without a full proof run) via `check_proof_bin {benchmark_basename} --sany-only`.

--- a/src/evaluator/prompts/proof-from-scratch.txt
+++ b/src/evaluator/prompts/proof-from-scratch.txt
@@ -12,6 +12,7 @@ The tlapm standard library is at {tlapm_lib} — you may read and reference the 
 You can run tlapm directly: `{tlapm_path}/bin/tlapm -I {tlapm_lib} {benchmark_basename}`.
 Keep editing your proof until tlapm shows no errors — do not give up or stop early.
 If a proof attempt fails, try a different strategy (different invariants, finer-grained lemmas, alternative proof tactics).
+If you must stop before the proof is complete, leave your best partial proof in {benchmark_basename} — never delete your incomplete work or revert the file to its original placeholder.
 Keep iterating until `check_proof_bin {benchmark_basename} --mode proof-from-scratch` reports PASS.
 
 Your solution must also parse under the standard TLA+ parser (SANY): the checker rejects a file SANY cannot parse (reported as `[SANY-INVALID]`), so avoid constructs SANY rejects such as an operator parameter or bound variable that shadows a declared CONSTANT/VARIABLE; you can check just the syntax in seconds (without a full proof run) via `check_proof_bin {benchmark_basename} --sany-only`.

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -38,7 +38,17 @@ from evaluator.backends import get_backend, list_backends
 from evaluator.backends.base import AgentBackend
 from evaluator.modes import get_mode, list_modes
 from evaluator.modes.base import Mode
-from evaluator.score import SCORERS, is_non_genuine, is_pass, is_skipped, n_non_genuine, n_skipped, weighted_score
+from evaluator.score import (
+    SCORERS,
+    continuation_interrupted,
+    continuation_rate_line,
+    is_non_genuine,
+    is_pass_with_continuations,
+    is_skipped,
+    n_non_genuine,
+    n_skipped,
+    weighted_score,
+)
 from evaluator.termination import TerminationContext, TerminationReason, classify, startup_error_snippet
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -238,6 +248,10 @@ class WorkItem:
     # Extra agent attempts after a transient startup/infra failure (INFRA_ERROR
     # with 0 output tokens); 0 disables retrying (the failure still ends ERROR).
     infra_retries: int = 3
+    # Continuation rounds after a genuine non-PASS: re-run the agent in the SAME
+    # workspace so it builds on its own partial proof (see _run_continuations).
+    # 0 disables. pass@1 (check_verdict) is unaffected either way.
+    max_continuations: int = 0
 
 
 def _make_canonical_dir(name_no_ext: str, benchmark_path: str, basename: str, deps: list[str]) -> str:
@@ -252,13 +266,213 @@ def _make_canonical_dir(name_no_ext: str, benchmark_path: str, basename: str, de
         raise
 
 
+def _make_workspace(backend_name: str, name_no_ext: str, benchmark_path: str, basename: str, deps: list[str]) -> str:
+    """Fresh isolated workspace: benchmark + dependencies in a git repo (the
+    baseline commit is the cheating check's reference point)."""
+    workspace = tempfile.mkdtemp(prefix=f"{backend_name}_bench_{name_no_ext}_")
+    try:
+        shutil.copy2(benchmark_path, os.path.join(workspace, basename))
+        for dep in deps:
+            shutil.copy2(dep, os.path.join(workspace, os.path.basename(dep)))
+        subprocess.run(["git", "init"], capture_output=True, cwd=workspace)
+        subprocess.run(["git", "add", "."], capture_output=True, cwd=workspace)
+        subprocess.run(
+            ["git", "commit", "-m", "initial benchmark"],
+            capture_output=True,
+            cwd=workspace,
+            env={
+                **os.environ,
+                "GIT_AUTHOR_NAME": "bench",
+                "GIT_AUTHOR_EMAIL": "bench@bench",
+                "GIT_COMMITTER_NAME": "bench",
+                "GIT_COMMITTER_EMAIL": "bench@bench",
+            },
+        )
+        return workspace
+    except Exception:
+        shutil.rmtree(workspace, ignore_errors=True)
+        raise
+
+
+@dataclass
+class AgentRunOutcome:
+    """What _run_agent_with_retries leaves behind for the caller to grade/record."""
+
+    workspace: str
+    canonical_dir: str
+    transcript: str
+    quota_exhausted: bool
+    infra_retriable: bool  # still a 0-token infra failure after all retries
+    infra_reasons: list[str]
+
+
+def _run_agent_with_retries(
+    item: WorkItem,
+    prompt: str,
+    agent_dir: str,
+    agent_jsonl: str,
+    agent_stderr: str,
+    result: dict,
+    checker_bin: str,
+    deps: list[str],
+    basename: str,
+    name_no_ext: str,
+    fixed_workspace: str | None = None,
+) -> AgentRunOutcome:
+    """One agent-run lifecycle, shared by the first attempt and continuation
+    rounds: run the agent (sleeping through hard provider quota caps, see
+    quota.run_with_quota_retry), parse its output, classify the termination,
+    and retry with backoff while the run died before the model did ANY work
+    (INFRA_ERROR + 0 output tokens). A genuine attempt (any output tokens) is
+    never re-run.
+
+    Every attempt gets a fresh canonical snapshot: both the agent self-check
+    and grader read it, and in local mode the agent can write to the host path,
+    so a failed attempt's copy must never leak into a retry or the grader.
+    With fixed_workspace=None each attempt also gets a fresh workspace (a
+    failed first attempt's partial edits can't leak into a retry); a
+    continuation round passes its existing workspace instead — the partial
+    proof in it IS the input, and a 0-token startup death can't have touched it.
+
+    Fills result's time_secs / input_tokens / output_tokens / agent_exit /
+    error / termination_reason (plus infra_retries / infra_retry_reasons after
+    any retries); the caller owns quota/infra exhaustion verdicts and messages.
+    time_secs counts only active agent time — quota-retry sleeps (which can be
+    hours) and the infra backoff are excluded. Returns the final attempt's
+    workspace + canonical snapshot, which the caller must clean up (earlier
+    attempts' dirs are cleaned here, including when an attempt raises).
+    """
+    backend = item.backend
+    mode = item.mode
+    workspace = fixed_workspace
+    canonical_dir = None
+    active_secs = 0.0
+    quota_exhausted = False
+    infra_retriable = False
+    infra_reasons: list[str] = []
+    transcript = ""
+    try:
+        for attempt in range(max(item.infra_retries, 0) + 1):
+            canonical_dir = _make_canonical_dir(name_no_ext, item.benchmark_path, basename, deps)
+            if fixed_workspace is None:
+                workspace = _make_workspace(backend.name, name_no_ext, item.benchmark_path, basename, deps)
+
+            wait_for_memory(item.min_free_gb, 120, log_prefix=f"[{name_no_ext}] ")
+
+            # Defaults keep the closure bound to this attempt.
+            def _run_once(workspace=workspace, canonical_dir=canonical_dir):
+                nonlocal active_secs
+                result["error"] = ""
+                with contextlib.suppress(FileNotFoundError):
+                    os.remove(agent_stderr)
+                t0 = time.time()
+                if item.use_container:
+                    _run_agent_container(
+                        item, backend, workspace, agent_dir, agent_jsonl, prompt, result, canonical_dir
+                    )
+                else:
+                    _run_agent_local(
+                        item,
+                        backend,
+                        mode,
+                        workspace,
+                        agent_dir,
+                        agent_jsonl,
+                        prompt,
+                        result,
+                        checker_bin,
+                        canonical_dir,
+                    )
+                active_secs += time.time() - t0
+
+            quota_exhausted = not quota.run_with_quota_retry(
+                _run_once,
+                lambda: backend.detect_quota_block(agent_jsonl),
+                log_prefix=f"[{name_no_ext}] ",
+            )
+            result["time_secs"] = active_secs
+
+            # Parse agent output on every path — including quota exhaustion — so
+            # the result records any tokens the agent did emit (rather than
+            # forcing them to 0).
+            transcript, input_tokens, output_tokens = backend.parse_output(agent_jsonl)
+            result["input_tokens"] = input_tokens
+            result["output_tokens"] = output_tokens
+
+            if quota_exhausted:
+                break  # quota owns its own retry budget — never infra-retried
+
+            # Tag how the run terminated so an INFRA_ERROR (agent cut short by
+            # infrastructure, not a genuine attempt) is distinguishable from a
+            # real FAIL — and, when the model did no work, retried right here.
+            ctx = TerminationContext(
+                backend=backend.name,
+                jsonl_path=agent_jsonl,
+                agent_exit=result.get("agent_exit"),
+                error=result.get("error", ""),
+                stderr_path=agent_stderr,
+            )
+            result["termination_reason"] = classify(ctx)
+
+            # A genuine attempt (any output tokens) is never re-run.
+            infra_retriable = result["termination_reason"] == TerminationReason.INFRA_ERROR and output_tokens == 0
+            if not infra_retriable:
+                break
+            infra_reasons.append(startup_error_snippet(ctx))
+            if attempt >= item.infra_retries:
+                break  # out of retries — the caller records the exhaustion
+
+            _stash_failed_attempt(agent_dir, attempt)
+            if fixed_workspace is None:
+                shutil.rmtree(workspace, ignore_errors=True)
+                workspace = None
+            shutil.rmtree(canonical_dir, ignore_errors=True)
+            canonical_dir = None
+            base = INFRA_RETRY_BACKOFF[min(attempt, len(INFRA_RETRY_BACKOFF) - 1)]
+            delay = base + random.uniform(0, base / 2)  # jitter: keep --jobs workers out of lockstep
+            print(
+                f"[{name_no_ext}] transient infra failure ({infra_reasons[-1]}) — "
+                f"retrying in {delay:.0f}s (retry {attempt + 1}/{item.infra_retries})",
+                flush=True,
+            )
+            time.sleep(delay)
+    except BaseException:
+        # An attempt blew up mid-flight: the caller only ever owns what we
+        # return, so don't leak this attempt's dirs (never a fixed workspace).
+        if fixed_workspace is None and workspace:
+            shutil.rmtree(workspace, ignore_errors=True)
+        if canonical_dir:
+            shutil.rmtree(canonical_dir, ignore_errors=True)
+        raise
+
+    if infra_reasons:
+        result["infra_retries"] = attempt  # retries performed (0-based final attempt index)
+        result["infra_retry_reasons"] = infra_reasons
+    return AgentRunOutcome(workspace, canonical_dir, transcript, quota_exhausted, infra_retriable, infra_reasons)
+
+
 def _resume_should_skip(result: dict) -> bool:
-    """Resume skips only completed genuine work: SKIP or a non-infra PASS."""
-    return is_skipped(result) or (is_pass(result) and not is_non_genuine(result))
+    """Resume skips genuine completed work: SKIP, first-attempt PASS, or continuation PASS."""
+    return is_skipped(result) or (is_pass_with_continuations(result) and not is_non_genuine(result))
 
 
 def _resume_done_benchmarks(results: list[dict]) -> set[str]:
     return {r["benchmark"] for r in results if _resume_should_skip(r)}
+
+
+def _continuation_note(result: dict) -> str:
+    """One-phrase outcome of a result's continuation rounds ("" without any):
+    the round that recovered a PASS, a chain infra/quota-cut before resolving,
+    or how many genuine rounds still didn't pass."""
+    rounds = result.get("continuations") or []
+    if not rounds:
+        return ""
+    passed = next((r["round"] for r in rounds if r.get("check_verdict") == "PASS"), None)
+    if passed is not None:
+        return f"PASS on continuation {passed}"
+    if continuation_interrupted(result):
+        return f"continuation chain cut at round {len(rounds)} (excluded — re-run)"
+    return f"no PASS after {len(rounds)} continuation(s)"
 
 
 def update_summary(results, output_dir, total_benchmarks, backend_name, mode_name):
@@ -288,6 +502,10 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
             pass_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
         lines.append(f"**Progress**: {total}/{total_benchmarks}")
         lines.append(pass_line)
+        # Separate, clearly-labeled metric — the pass rate above stays pass@1.
+        cont_line = continuation_rate_line(results, SCORERS["equal"], n_pass)
+        if cont_line:
+            lines.append(cont_line)
         lines.append(f"**Total tokens**: {total_input:,} input / {total_output:,} output\n")
 
         lines.append("## Summary\n")
@@ -317,6 +535,9 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
             # is distinguishable from an honest incomplete FAIL at a glance.
             if r.get("check_verdict") == "CHEATING" and r.get("cheat_checks"):
                 notes = (",".join(r["cheat_checks"]) + " " + notes).strip()
+            cont = _continuation_note(r)
+            if cont:
+                notes = (cont + " " + notes).strip()
             tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
             if "obligations" in r:
                 obs = str(r["obligations"])
@@ -371,6 +592,11 @@ def run_single_benchmark(item: WorkItem):
         # than a genuine model attempt, so a FAIL can be filtered/retried.
         "termination_reason": TerminationReason.OK,
     }
+    if item.max_continuations > 0:
+        # Run-level config, stamped on EVERY result — first-attempt PASSes and
+        # non-genuine early exits included — so the continuation metric can
+        # state its ≤N budget without guessing from the chains that happened to run.
+        result["max_continuations"] = item.max_continuations
 
     if not quota.wait_for_quota(
         item.usage_script, item.quota_5h, item.quota_7d, item.quota_max_waits,
@@ -407,134 +633,21 @@ def run_single_benchmark(item: WorkItem):
         agent_jsonl = os.path.join(agent_dir, "output.jsonl")
         agent_stderr = os.path.join(agent_dir, "stderr.txt")
 
-        # _run_once accumulates only active agent time, so time_secs excludes the
-        # quota retry sleeps (which can be hours) and the infra backoff below.
-        active_secs = 0.0
-
         # Infra retry loop: a run cut short before the model did ANY work
         # (INFRA_ERROR + 0 output tokens) says nothing about the model, so it is
         # retried on a fresh workspace instead of graded. Everything else gets
         # exactly one attempt.
-        quota_exhausted = False
-        infra_retriable = False
-        infra_reasons: list[str] = []
-        for attempt in range(max(item.infra_retries, 0) + 1):
-            # Canonical snapshot for THIS attempt: both the agent self-check and
-            # grader read it, and retries get a fresh copy even in local mode
-            # where the agent can write to the host path.
-            canonical_dir = _make_canonical_dir(name_no_ext, item.benchmark_path, basename, deps)
+        run = _run_agent_with_retries(
+            item, prompt, agent_dir, agent_jsonl, agent_stderr, result, checker_bin, deps, basename, name_no_ext
+        )
+        workspace, canonical_dir = run.workspace, run.canonical_dir
 
-            # Copy benchmark + dependencies into a FRESH isolated workspace per
-            # attempt, so a failed attempt's partial edits can't leak into a retry.
-            workspace = tempfile.mkdtemp(prefix=f"{backend.name}_bench_{name_no_ext}_")
-            shutil.copy2(item.benchmark_path, os.path.join(workspace, basename))
-            for dep in deps:
-                shutil.copy2(dep, os.path.join(workspace, os.path.basename(dep)))
-
-            # Init git repo (baseline for cheating check)
-            subprocess.run(["git", "init"], capture_output=True, cwd=workspace)
-            subprocess.run(["git", "add", "."], capture_output=True, cwd=workspace)
-            subprocess.run(
-                ["git", "commit", "-m", "initial benchmark"],
-                capture_output=True,
-                cwd=workspace,
-                env={
-                    **os.environ,
-                    "GIT_AUTHOR_NAME": "bench",
-                    "GIT_AUTHOR_EMAIL": "bench@bench",
-                    "GIT_COMMITTER_NAME": "bench",
-                    "GIT_COMMITTER_EMAIL": "bench@bench",
-                },
-            )
-
-            wait_for_memory(item.min_free_gb, 120, log_prefix=f"[{name_no_ext}] ")
-
-            # Run the agent, sleeping through any hard provider usage-limit cap that
-            # the proactive gate (above) can't see (see quota.run_with_quota_retry).
-            # Defaults keep the closure bound to this outer infra attempt.
-            def _run_once(workspace=workspace, canonical_dir=canonical_dir):
-                nonlocal active_secs
-                result["error"] = ""
-                with contextlib.suppress(FileNotFoundError):
-                    os.remove(agent_stderr)
-                t0 = time.time()
-                if item.use_container:
-                    _run_agent_container(
-                        item, backend, workspace, agent_dir, agent_jsonl, prompt, result, canonical_dir
-                    )
-                else:
-                    _run_agent_local(
-                        item,
-                        backend,
-                        mode,
-                        workspace,
-                        agent_dir,
-                        agent_jsonl,
-                        prompt,
-                        result,
-                        checker_bin,
-                        canonical_dir,
-                    )
-                active_secs += time.time() - t0
-
-            quota_exhausted = not quota.run_with_quota_retry(
-                _run_once,
-                lambda: backend.detect_quota_block(agent_jsonl),
-                log_prefix=f"[{name_no_ext}] ",
-            )
-            result["time_secs"] = active_secs
-
-            # Parse agent output and save artifacts on every path — including quota
-            # exhaustion — so the result dir keeps a consistent shape and records any
-            # tokens the agent did emit (rather than forcing them to 0).
-            transcript, input_tokens, output_tokens = backend.parse_output(agent_jsonl)
-            result["input_tokens"] = input_tokens
-            result["output_tokens"] = output_tokens
-
-            if quota_exhausted:
-                break  # quota owns its own retry budget — never infra-retried
-
-            # Tag how the run terminated so an INFRA_ERROR (agent cut short by
-            # infrastructure, not a genuine attempt) is distinguishable from a
-            # real FAIL — and, when the model did no work, retried right here.
-            ctx = TerminationContext(
-                backend=backend.name,
-                jsonl_path=agent_jsonl,
-                agent_exit=result.get("agent_exit"),
-                error=result.get("error", ""),
-                stderr_path=agent_stderr,
-            )
-            result["termination_reason"] = classify(ctx)
-
-            # A genuine attempt (any output tokens) is never re-run.
-            infra_retriable = result["termination_reason"] == TerminationReason.INFRA_ERROR and output_tokens == 0
-            if not infra_retriable:
-                break
-            infra_reasons.append(startup_error_snippet(ctx))
-            if attempt >= item.infra_retries:
-                break  # out of retries — recorded below as ERROR, not graded
-
-            _stash_failed_attempt(agent_dir, attempt)
-            shutil.rmtree(workspace, ignore_errors=True)
-            workspace = None
-            shutil.rmtree(canonical_dir, ignore_errors=True)
-            canonical_dir = None
-            base = INFRA_RETRY_BACKOFF[min(attempt, len(INFRA_RETRY_BACKOFF) - 1)]
-            delay = base + random.uniform(0, base / 2)  # jitter: keep --jobs workers out of lockstep
-            print(
-                f"[{name_no_ext}] transient infra failure ({infra_reasons[-1]}) — "
-                f"retrying in {delay:.0f}s (retry {attempt + 1}/{item.infra_retries})",
-                flush=True,
-            )
-            time.sleep(delay)
-
-        elapsed = active_secs
         with open(os.path.join(agent_dir, "transcript.txt"), "w") as f:
             f.write(f"Benchmark: {rel_path}\n")
-            f.write(f"Time: {elapsed:.0f}s\n")
-            f.write(f"Tokens: {input_tokens:,} input / {output_tokens:,} output\n")
+            f.write(f"Time: {result['time_secs']:.0f}s\n")
+            f.write(f"Tokens: {result['input_tokens']:,} input / {result['output_tokens']:,} output\n")
             f.write("=" * 60 + "\n\n")
-            f.write(transcript)
+            f.write(run.transcript)
 
         solution_path = os.path.join(workspace, basename)
         if os.path.isfile(solution_path):
@@ -544,11 +657,7 @@ def run_single_benchmark(item: WorkItem):
         if os.path.isfile(agent_check_file):
             shutil.copy2(agent_check_file, os.path.join(grading_dir, "agent_check.result"))
 
-        if infra_reasons:
-            result["infra_retries"] = attempt  # retries performed (0-based final attempt index)
-            result["infra_retry_reasons"] = infra_reasons
-
-        if quota_exhausted:
+        if run.quota_exhausted:
             # Provider hard-capped us past the retry budget. Mark ERROR (retriable
             # via --resume) and skip grading; the artifacts above keep the result
             # dir consistent with a normal run. Tag QUOTA_EXHAUSTED directly — the
@@ -562,12 +671,12 @@ def run_single_benchmark(item: WorkItem):
                 json.dump(result, f, indent=2)
             return result
 
-        if infra_retriable:
+        if run.infra_retriable:
             # Out of retries with no genuine attempt made: grading the untouched
             # workspace would turn infra noise into a proof verdict (FAIL, or even
             # a bogus PASS). Mark ERROR (retriable via --resume), skip the grader.
             result["check_verdict"] = "ERROR"
-            result["error"] = f"startup/infra failure ({infra_reasons[-1]}); exhausted infra retries"
+            result["error"] = f"startup/infra failure ({run.infra_reasons[-1]}); exhausted infra retries"
             with open(os.path.join(result_dir, "result.json"), "w") as f:
                 json.dump(result, f, indent=2)
             return result
@@ -578,6 +687,12 @@ def run_single_benchmark(item: WorkItem):
             _run_grader_container(item, workspace, basename, grading_dir, check_result_path, result, canonical_dir)
         else:
             _run_grader_local(item, workspace, basename, grading_dir, check_result_path, result, canonical_dir)
+
+        # Opt-in continuation rounds: a genuine non-PASS keeps its workspace and
+        # the agent is asked to build on its own partial proof. The pass@1 fields
+        # above stay untouched; rounds are recorded under result["continuations"].
+        if item.max_continuations > 0 and result["check_verdict"] != "PASS" and not is_non_genuine(result):
+            _run_continuations(item, workspace, result, result_dir, basename, name_no_ext, deps, checker_bin)
 
         # Write per-benchmark result.json
         with open(os.path.join(result_dir, "result.json"), "w") as f:
@@ -601,6 +716,122 @@ def _stash_failed_attempt(agent_dir: str, attempt: int) -> None:
         src = os.path.join(agent_dir, fname)
         if os.path.isfile(src):
             shutil.move(src, os.path.join(dest, fname))
+
+
+def _run_continuations(
+    item: WorkItem,
+    workspace: str,
+    result: dict,
+    result_dir: str,
+    basename: str,
+    name_no_ext: str,
+    deps: list[str],
+    checker_bin: str,
+) -> None:
+    """Continuation rounds (--max-continuations, off by default).
+
+    A genuine non-PASS mixes two outcomes: the agent stopped early (declared
+    itself done with a repairable partial proof still in the file) or it truly
+    cannot solve the task. Each round re-runs the agent in the SAME workspace —
+    the partial proof is still there — with a continuation prompt telling it to
+    build on that prior work, then re-grades; rounds stop at the first PASS, at
+    the --max-continuations budget, or when a round is cut short by infra/quota.
+    A chain cut short is interrupted, not failed: scoring excludes it from the
+    continuation rate (see score.continuation_interrupted) and --resume reruns
+    the benchmark.
+
+    The top-level result keeps the FIRST attempt's verdict, so pass@1 is
+    reported unchanged; each round's verdict/cost is appended to
+    result["continuations"] (the run's ≤N budget is stamped on every result as
+    max_continuations at init) and the round's tokens/time accumulate into the
+    top-level cost fields (the true cost of the whole chain). Artifacts land in
+    <result_dir>/continuations/round-N/, shaped like the agent/ + grading/ dirs.
+    """
+    mode = item.mode
+    prompt = mode.build_continuation_prompt(basename, item.tlapm_path, item.tlapm_lib)
+    agent_check_file = os.path.join(workspace, name_no_ext + ".result")
+    rounds: list[dict] = result.setdefault("continuations", [])
+    for rnd in range(1, item.max_continuations + 1):
+        prev_verdict = rounds[-1]["check_verdict"] if rounds else result["check_verdict"]
+        print(
+            f"[{name_no_ext}] {prev_verdict} — continuing in same workspace "
+            f"(round {rnd}/{item.max_continuations})",
+            flush=True,
+        )
+        round_dir = os.path.join(result_dir, "continuations", f"round-{rnd}")
+        os.makedirs(round_dir, exist_ok=True)
+        with open(os.path.join(round_dir, "prompt.txt"), "w") as f:
+            f.write(prompt)
+        agent_jsonl = os.path.join(round_dir, "output.jsonl")
+        agent_stderr = os.path.join(round_dir, "stderr.txt")
+        round_result = {
+            "round": rnd,
+            "agent_exit": -1,
+            "check_verdict": "ERROR",
+            "time_secs": 0,
+            "error": "",
+            "termination_reason": TerminationReason.OK,
+        }
+        # The in-workspace self-check file survives from the previous round (the
+        # agent may want to read what failed), so note its state to copy it as
+        # this round's evidence only if this round's agent (re)wrote it.
+        check_mtime_before = os.stat(agent_check_file).st_mtime_ns if os.path.isfile(agent_check_file) else None
+
+        run = _run_agent_with_retries(
+            item,
+            prompt,
+            round_dir,
+            agent_jsonl,
+            agent_stderr,
+            round_result,
+            checker_bin,
+            deps,
+            basename,
+            name_no_ext,
+            fixed_workspace=workspace,
+        )
+        try:
+            result["time_secs"] += round_result["time_secs"]
+            result["input_tokens"] += round_result["input_tokens"]
+            result["output_tokens"] += round_result["output_tokens"]
+            if run.quota_exhausted:
+                round_result["agent_exit"] = -3
+                round_result["error"] = "provider usage limit; exhausted quota retries"
+                round_result["termination_reason"] = TerminationReason.QUOTA_EXHAUSTED
+            elif run.infra_retriable:
+                round_result["error"] = f"startup/infra failure ({run.infra_reasons[-1]}); exhausted infra retries"
+
+            with open(os.path.join(round_dir, "transcript.txt"), "w") as f:
+                f.write(run.transcript)
+            solution_path = os.path.join(workspace, basename)
+            if os.path.isfile(solution_path):
+                shutil.copy2(solution_path, os.path.join(round_dir, "solution.tla"))
+            check_mtime_after = os.stat(agent_check_file).st_mtime_ns if os.path.isfile(agent_check_file) else None
+            if check_mtime_after is not None and check_mtime_after != check_mtime_before:
+                shutil.copy2(agent_check_file, os.path.join(round_dir, "agent_check.result"))
+
+            # Same rule as the first attempt: never grade a round the model
+            # never got to work on (quota cap or 0-token startup death).
+            cut_short = run.quota_exhausted or run.infra_retriable
+            if not cut_short:
+                check_result_path = os.path.join(round_dir, "check.result")
+                if item.use_container:
+                    _run_grader_container(
+                        item, workspace, basename, round_dir, check_result_path, round_result, run.canonical_dir
+                    )
+                else:
+                    _run_grader_local(
+                        item, workspace, basename, round_dir, check_result_path, round_result, run.canonical_dir
+                    )
+        finally:
+            shutil.rmtree(run.canonical_dir, ignore_errors=True)
+
+        rounds.append(round_result)
+        if round_result["check_verdict"] == "PASS":
+            print(f"[{name_no_ext}] recovered: PASS on continuation round {rnd}", flush=True)
+            break
+        if cut_short:
+            break
 
 
 def _run_agent_container(
@@ -1009,7 +1240,9 @@ def main():
         help="Override the backend's usage probe with a custom script path",
     )
     parser.add_argument(
-        "--resume", action="store_true", help="Reuse --output-dir: skip benchmarks already PASS there, run the rest"
+        "--resume",
+        action="store_true",
+        help="Reuse --output-dir: skip benchmarks already SKIP or genuinely passed there (first-attempt or continuation), run the rest",
     )
     parser.add_argument(
         "--min-free-gb",
@@ -1025,6 +1258,15 @@ def main():
         help="Extra agent attempts after a transient startup/infrastructure failure "
         "(agent died with 0 output tokens), so 3 = up to 4 attempts total "
         "(default: 3; 0 = no retries, the failure still ends as ERROR)",
+    )
+    parser.add_argument(
+        "--max-continuations",
+        type=int,
+        default=0,
+        help="After a genuine non-PASS verdict, re-run the agent up to N more times in the "
+        "SAME workspace with a continuation prompt (build on its own partial proof), "
+        "stopping at the first PASS. The first attempt's verdict still scores pass@1; "
+        "continuation rounds are recorded and reported separately (default: 0 = off)",
     )
     parser.add_argument(
         "--no-container",
@@ -1148,10 +1390,15 @@ def main():
             # produced by INFRA_ERROR / QUOTA_EXHAUSTED is non-genuine and must
             # be eligible for rerun.
             done_pass = _resume_done_benchmarks(results)
-            n_pass = sum(1 for r in results if is_pass(r) and not is_non_genuine(r))
+            # Count with the same predicate the skip decision uses, so the
+            # message includes benchmarks solved on a continuation round.
+            n_pass = sum(1 for r in results if _resume_should_skip(r) and not is_skipped(r))
             n_skip = n_skipped(results)
             non_genuine = n_non_genuine(results)
-            msg = f"Resume: loaded {len(results)} prior results, skipping {n_pass} genuine PASS + {n_skip} SKIP"
+            msg = (
+                f"Resume: loaded {len(results)} prior results, skipping {n_pass} genuine PASS "
+                f"(first-attempt or continuation) + {n_skip} SKIP"
+            )
             if non_genuine:
                 msg += f"; {non_genuine} infra/quota-cut result(s) eligible for rerun"
             print(msg)
@@ -1180,6 +1427,7 @@ def main():
                 min_free_gb=args.min_free_gb,
                 use_container=use_container,
                 infra_retries=args.infra_retries,
+                max_continuations=args.max_continuations,
             )
         )
 
@@ -1195,8 +1443,10 @@ def main():
             results.append(r)
             icon = VERDICT_ICONS.get(r["check_verdict"], "❓")
             tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
+            cont = _continuation_note(r)
             print(
                 f"[{prior_done + i + 1}/{total_benchmarks}] {icon} {r['benchmark']} ({r['time_secs']:.0f}s, {tokens} tok)"
+                + (f" — {cont}" if cont else "")
             )
             update_summary(results, output_dir, total_benchmarks, backend.name, mode.name)
     else:
@@ -1207,8 +1457,10 @@ def main():
                 results.append(r)
                 icon = VERDICT_ICONS.get(r["check_verdict"], "❓")
                 tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
+                cont = _continuation_note(r)
                 print(
                     f"[{prior_done + done_count}/{total_benchmarks}] {icon} {r['benchmark']} ({r['time_secs']:.0f}s, {tokens} tok)"
+                    + (f" — {cont}" if cont else "")
                 )
                 update_summary(results, output_dir, total_benchmarks, backend.name, mode.name)
 

--- a/src/evaluator/score.py
+++ b/src/evaluator/score.py
@@ -22,6 +22,17 @@ the numerator and denominator — like SKIP — and reported separately as needi
 re-run. TIMEOUT is a limit, not infrastructure: the agent worked and is graded on
 what it left in the workspace, so it stays scored.
 
+Continuations (``tlaps-bench run --max-continuations``) are a separate metric,
+never a replacement: ``check_verdict`` always holds the FIRST attempt's verdict,
+so the pass rate above stays pass@1. When a run recorded continuation rounds
+(``result["continuations"]``), a second, clearly-labeled "with continuations"
+rate is reported (with the run's ≤N budget), counting a task as passed if any
+round reached PASS — the gap between the two is how often a first-attempt
+failure was an early stop rather than an inability. A chain cut short by
+infra/quota before resolving is interrupted, not failed: like a non-genuine
+first attempt it is excluded from the continuation rate and reported separately
+(see ``continuation_interrupted``).
+
 Pluggable scoring: a scorer assigns a non-negative weight to each task; the
 score of a group of tasks is
 
@@ -63,6 +74,60 @@ def is_non_genuine(result: dict) -> bool:
     return result.get("termination_reason") in NON_GENUINE_TERMINATIONS
 
 
+def continuation_passed(result: dict) -> bool:
+    """Whether any continuation round (--max-continuations) reached PASS.
+
+    A round's PASS means the grader verified the proof in the workspace, so it
+    is ground truth regardless of how that round's event stream terminated."""
+    return any(r.get("check_verdict") == PASS_VERDICT for r in result.get("continuations") or [])
+
+
+def is_pass_with_continuations(result: dict) -> bool:
+    """PASS on the first attempt or on any continuation round — the predicate
+    behind the separate "with continuations" rate (pass@1 uses is_pass)."""
+    return is_pass(result) or continuation_passed(result)
+
+
+def continuation_interrupted(result: dict) -> bool:
+    """Whether the continuation chain was cut short by infra/quota before it
+    could resolve: no round passed and the chain-ending round is non-genuine.
+
+    Like a non-genuine first attempt, the outcome is indeterminate — neither a
+    recovery nor an exhausted budget — so the continuation rate excludes it and
+    reports it separately (rerun the benchmark with --resume)."""
+    rounds = result.get("continuations") or []
+    return bool(rounds) and is_non_genuine(rounds[-1]) and not continuation_passed(result)
+
+
+def continuation_budget(results: list[dict]) -> int | None:
+    """The run's --max-continuations budget, when recorded and uniform across
+    results. Mixed budgets (e.g. a run resumed with a different flag) yield
+    None and reports omit the ≤N label."""
+    budgets = {r["max_continuations"] for r in results if r.get("max_continuations")}
+    return budgets.pop() if len(budgets) == 1 else None
+
+
+def continuation_rate_line(results: list[dict], weight: Callable[[dict], float], n_pass: int) -> str | None:
+    """The "with continuations" pass-rate line shared by summary.md and the
+    scorecard, or None when no continuation rounds were recorded. Interrupted
+    chains are excluded from the rate and disclosed; ``n_pass`` is the pass@1
+    count the recovery delta is measured against."""
+    if not any(r.get("continuations") for r in results):
+        return None
+    resolved = [r for r in results if not continuation_interrupted(r)]
+    cpct, cn_pass, cn_total = weighted_score(resolved, weight, passed=is_pass_with_continuations)
+    budget = continuation_budget(results)
+    label = f" (≤{budget})" if budget else ""
+    line = (
+        f"**Pass rate with continuations{label}**: {cn_pass}/{cn_total} ({cpct:.1f}%) — "
+        f"{cn_pass - n_pass} recovered by continuation (pass@1 above is first-attempt only)"
+    )
+    n_cut = sum(1 for r in results if continuation_interrupted(r))
+    if n_cut:
+        line += f" · {n_cut} chain(s) infra/quota-cut (excluded — re-run)"
+    return line
+
+
 def n_skipped(results: list[dict]) -> int:
     """How many tasks were operator-excluded from scoring."""
     return sum(1 for r in results if is_skipped(r))
@@ -81,18 +146,22 @@ SCORERS: dict[str, Callable[[dict], float]] = {
 }
 
 
-def weighted_score(results: list[dict], weight: Callable[[dict], float]) -> tuple[float, int, int]:
+def weighted_score(
+    results: list[dict], weight: Callable[[dict], float], passed: Callable[[dict], bool] = is_pass
+) -> tuple[float, int, int]:
     """Return (score_percent, n_passed, n_total) over the scored tasks.
 
     SKIP and non-genuine tasks are dropped first, so ``n_total`` is the number
     of *scored* tasks (excluded ones count toward neither the pass count nor the
-    denominator).
+    denominator). ``passed`` is the pass predicate: the default scores pass@1;
+    the "with continuations" rate passes ``is_pass_with_continuations`` after
+    also dropping interrupted chains (see continuation_rate_line).
     """
     scored = [r for r in results if not is_skipped(r) and not is_non_genuine(r)]
     n_total = len(scored)
-    n_pass = sum(1 for r in scored if is_pass(r))
+    n_pass = sum(1 for r in scored if passed(r))
     total_w = sum(max(weight(r), 0.0) for r in scored)
-    pass_w = sum(max(weight(r), 0.0) for r in scored if is_pass(r))
+    pass_w = sum(max(weight(r), 0.0) for r in scored if passed(r))
     pct = (100.0 * pass_w / total_w) if total_w > 0 else 0.0
     return pct, n_pass, n_total
 
@@ -144,8 +213,12 @@ def scorecard_md(run: dict, weight: Callable[[dict], float], scoring_name: str) 
         "",
         f"**Source**: {run['path']}",
         pass_line,
-        f"**Cost**: {in_tok:,} in / {out_tok:,} out tokens · {secs:,.0f}s total",
     ]
+    # Separate, clearly-labeled metric — the pass rate above stays pass@1.
+    cont_line = continuation_rate_line(results, weight, n_pass)
+    if cont_line:
+        lines.append(cont_line)
+    lines.append(f"**Cost**: {in_tok:,} in / {out_tok:,} out tokens · {secs:,.0f}s total")
     if scoring_name != "equal":
         lines.append(f"**Scoring**: {scoring_name} (weighted)")
     lines += [
@@ -187,6 +260,18 @@ def comparison_md(runs: list[dict], weight: Callable[[dict], float], scoring_nam
         non_genuine = n_non_genuine(run["results"])
         if non_genuine:
             passed_total += f" (+{non_genuine} infra-cut)"
+        if any(r.get("continuations") for r in run["results"]):
+            _, cn_pass, _ = weighted_score(run["results"], weight, passed=is_pass_with_continuations)
+            # Name the budget: +1 recovery out of ≤1 round and out of ≤10 are
+            # different results, and rows in this table exist to be compared.
+            budget = continuation_budget(run["results"])
+            if budget:
+                passed_total += f" (+{cn_pass - n_pass} via ≤{budget} continuations)"
+            else:
+                passed_total += f" (+{cn_pass - n_pass} via continuation)"
+            n_cut = sum(1 for r in run["results"] if continuation_interrupted(r))
+            if n_cut:
+                passed_total += f" (+{n_cut} chain(s) cut)"
         lines.append(
             f"| {run['id']} | {run['backend']} | {run['mode']} | {pct:.1f}% | "
             f"{passed_total} | {in_tok:,}/{out_tok:,} | {secs:,.0f}s |"

--- a/tests/evaluator/test_continuation.py
+++ b/tests/evaluator/test_continuation.py
@@ -1,0 +1,406 @@
+"""runner continuation rounds (--max-continuations) — repair, don't restart.
+
+A genuine non-PASS may be an early stop rather than an inability: opt-in
+continuation re-runs the agent in the SAME workspace (the partial proof is the
+input) with a continuation prompt, re-grading each round, stopping at the first
+PASS or at the budget. pass@1 must stay untouched: check_verdict keeps the FIRST
+attempt's verdict and rounds are recorded separately under "continuations".
+Fakes stand in for the agent and grader (see test_infra_retry.py).
+
+Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_continuation.py
+"""
+
+import json
+import os
+
+from evaluator import runner
+from evaluator.termination import TerminationReason
+
+BENCH_TEXT = "---- MODULE Bar ----\n====\n"
+
+# One clean copilot terminal event: classifies as a genuine, completed run.
+CLEAN_EVENTS = [{"type": "result", "exitCode": 0}]
+
+# The observed startup shape: nonzero exit, no events, error only on stderr.
+STARTUP = {"exit": 1, "stderr": "Error: Failed to load models\n"}
+# A genuine attempt whose proof simply didn't verify.
+GENUINE = {"exit": 0, "events": CLEAN_EVENTS, "out_tokens": 500}
+
+
+class _ScriptedBackend:
+    """Backend whose per-call behavior is scripted (see _install_agent)."""
+
+    name = "copilot"
+
+    def __init__(self):
+        self.out_tokens = 0  # set by the fake agent for the current call
+
+    def parse_output(self, jsonl_path):
+        return ("", 0, self.out_tokens)
+
+    def detect_quota_block(self, jsonl_path):
+        return None
+
+
+class _FakeMode:
+    name = "proof-completion"
+
+    def __init__(self, bench_dir):
+        self._bench_dir = bench_dir
+
+    def benchmark_dir(self):
+        return self._bench_dir
+
+    def get_dependencies(self, benchmark_path):
+        return []
+
+    def checker_binary_path(self):
+        return "/bin/true"
+
+    def build_prompt(self, basename, tlapm_path, tlapm_lib):
+        return "prove it"
+
+    def build_continuation_prompt(self, basename, tlapm_path, tlapm_lib):
+        return "continue it"
+
+
+def _work_item(tmp_path, backend, max_continuations=0, infra_retries=0):
+    bench_dir = tmp_path / "bench"
+    bench_path = bench_dir / "Foo" / "Bar.tla"
+    os.makedirs(bench_path.parent, exist_ok=True)
+    bench_path.write_text(BENCH_TEXT)
+    return runner.WorkItem(
+        benchmark_path=str(bench_path),
+        output_dir=str(tmp_path / "out"),
+        timeout=10,
+        check_timeout=10,
+        backend=backend,  # ty:ignore[invalid-argument-type]
+        mode=_FakeMode(str(bench_dir)),  # ty:ignore[invalid-argument-type]
+        tlapm_path="/bin/true",
+        tlapm_lib="",
+        infra_retries=infra_retries,
+        max_continuations=max_continuations,
+    )
+
+
+def _install_agent(monkeypatch, backend, calls_spec):
+    """Patch _run_agent_local with a scripted agent: one spec dict per call
+    ({"exit": int, "events": [...], "stderr": str, "out_tokens": int,
+    "mutate": fn(workspace)}), recording workspace/prompt/canonical per call."""
+    calls = {"n": 0, "workspaces": [], "prompts": [], "agent_dirs": [], "canonical_dirs": []}
+
+    def fake_run(
+        item, backend_, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir=None
+    ):
+        spec = calls_spec[calls["n"]]
+        calls["n"] += 1
+        calls["workspaces"].append(workspace)
+        calls["prompts"].append(prompt)
+        calls["agent_dirs"].append(agent_dir)
+        calls["canonical_dirs"].append(canonical_dir)
+        with open(agent_jsonl, "w") as f:
+            for ev in spec.get("events", []):
+                f.write(json.dumps(ev) + "\n")
+        if spec.get("stderr"):
+            with open(os.path.join(agent_dir, "stderr.txt"), "w") as f:
+                f.write(spec["stderr"])
+        result["agent_exit"] = spec.get("exit", 0)
+        backend.out_tokens = spec.get("out_tokens", 0)
+        if "mutate" in spec:
+            spec["mutate"](workspace)
+
+    monkeypatch.setattr(runner, "_run_agent_local", fake_run)
+    return calls
+
+
+def _install_grader(monkeypatch, verdicts):
+    """Patch _run_grader_local with one scripted verdict per grading call."""
+    calls = {"n": 0, "grading_dirs": []}
+
+    def fake_grader(item, workspace, basename, grading_dir, check_result_path, result, canonical_dir=None):
+        result["check_verdict"] = verdicts[calls["n"]]
+        calls["n"] += 1
+        calls["grading_dirs"].append(grading_dir)
+
+    monkeypatch.setattr(runner, "_run_grader_local", fake_grader)
+    return calls
+
+
+def _no_sleep(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(runner.time, "sleep", lambda s: sleeps.append(s))
+    return sleeps
+
+
+def test_continues_in_same_workspace_until_pass(tmp_path, monkeypatch):
+    # FAIL, FAIL, PASS with budget 3: two continuation rounds, then stop early.
+    # The workspace (and the partial proof in it) must persist across rounds,
+    # and check_verdict must keep the FIRST attempt's verdict (pass@1).
+    seen = []
+
+    def scribble(workspace):
+        with open(os.path.join(workspace, "Bar.tla"), "w") as f:
+            f.write("PARTIAL PROOF")
+
+    def check(workspace):
+        with open(os.path.join(workspace, "Bar.tla")) as f:
+            seen.append(f.read())
+
+    backend = _ScriptedBackend()
+    agent = _install_agent(
+        monkeypatch, backend, [dict(GENUINE, mutate=scribble), dict(GENUINE, mutate=check), dict(GENUINE, mutate=check)]
+    )
+    grader = _install_grader(monkeypatch, ["FAIL", "FAIL", "PASS"])
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=3))
+
+    assert agent["n"] == 3 and grader["n"] == 3
+    assert len(set(agent["workspaces"])) == 1  # same workspace every round
+    assert seen == ["PARTIAL PROOF", "PARTIAL PROOF"]
+    assert result["check_verdict"] == "FAIL"  # pass@1 untouched
+    assert [r["check_verdict"] for r in result["continuations"]] == ["FAIL", "PASS"]
+    assert [r["round"] for r in result["continuations"]] == [1, 2]
+    # Round artifacts land under continuations/round-N/, next to agent/ + grading/.
+    out = tmp_path / "out" / "Foo" / "Bar"
+    for rnd in (1, 2):
+        round_dir = out / "continuations" / f"round-{rnd}"
+        assert (round_dir / "prompt.txt").read_text() == "continue it"
+        assert (round_dir / "output.jsonl").is_file()
+        assert (round_dir / "solution.tla").read_text() == "PARTIAL PROOF"
+    assert grader["grading_dirs"] == [
+        str(out / "grading"),
+        str(out / "continuations" / "round-1"),
+        str(out / "continuations" / "round-2"),
+    ]
+    saved = json.loads((out / "result.json").read_text())
+    assert saved["check_verdict"] == "FAIL"
+    assert [r["check_verdict"] for r in saved["continuations"]] == ["FAIL", "PASS"]
+
+
+def test_stops_at_continuation_budget(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [GENUINE] * 3)
+    grader = _install_grader(monkeypatch, ["FAIL"] * 3)
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=2))
+    assert agent["n"] == 3 and grader["n"] == 3
+    assert result["check_verdict"] == "FAIL"
+    assert [r["check_verdict"] for r in result["continuations"]] == ["FAIL", "FAIL"]
+    assert result["max_continuations"] == 2  # the metric must be able to state its budget
+
+
+def test_first_attempt_pass_never_continued(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [GENUINE])
+    _install_grader(monkeypatch, ["PASS"])
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=3))
+    assert agent["n"] == 1
+    assert result["check_verdict"] == "PASS"
+    assert "continuations" not in result
+    assert result["max_continuations"] == 3  # run-level budget stamped even without rounds
+
+
+def test_disabled_by_default(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [GENUINE])
+    _install_grader(monkeypatch, ["FAIL"])
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend))
+    assert agent["n"] == 1
+    assert "continuations" not in result
+    assert "max_continuations" not in result
+
+
+def test_non_genuine_first_attempt_not_continued(tmp_path, monkeypatch):
+    # A first attempt cut short by infra was never a genuine non-PASS: there is
+    # no partial proof to build on, so continuation must not fire (--resume owns
+    # the rerun of non-genuine results).
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [STARTUP])
+    grader = _install_grader(monkeypatch, [])
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=3))
+    assert agent["n"] == 1 and grader["n"] == 0
+    assert result["termination_reason"] == TerminationReason.INFRA_ERROR
+    assert "continuations" not in result
+    assert result["max_continuations"] == 3  # budget still recorded on early exits
+
+
+def test_continuation_rounds_use_continuation_prompt(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [GENUINE] * 2)
+    _install_grader(monkeypatch, ["FAIL", "PASS"])
+    runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=1))
+    assert agent["prompts"] == ["prove it", "continue it"]
+
+
+def test_round_startup_failure_retried_in_place(tmp_path, monkeypatch):
+    # A 0-token startup death in a continuation round leaves the workspace (and
+    # its partial proof) untouched, so the round retries in place — same
+    # workspace, no consumed continuation — and its evidence is stashed.
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [GENUINE, STARTUP, GENUINE])
+    grader = _install_grader(monkeypatch, ["FAIL", "PASS"])
+    sleeps = _no_sleep(monkeypatch)
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=1, infra_retries=1))
+    assert agent["n"] == 3 and grader["n"] == 2
+    assert len(set(agent["workspaces"])) == 1
+    # Same rule as first-attempt retries: each attempt gets a fresh canonical
+    # snapshot (a failed attempt's copy must never reach a retry or the grader).
+    assert agent["canonical_dirs"][1] != agent["canonical_dirs"][2]
+    assert len(sleeps) == 1 and sleeps[0] >= 15
+    rnd = result["continuations"][0]
+    assert rnd["check_verdict"] == "PASS"
+    assert rnd["infra_retries"] == 1
+    assert rnd["infra_retry_reasons"] == ["Error: Failed to load models"]
+    stashed = tmp_path / "out" / "Foo" / "Bar" / "continuations" / "round-1" / "attempts" / "attempt-0"
+    assert "Failed to load models" in (stashed / "stderr.txt").read_text()
+
+
+def test_round_infra_exhaustion_stops_chain_keeps_first_verdict(tmp_path, monkeypatch):
+    # Infra noise must not eat the budget round after round, and must never
+    # touch the genuine first-attempt verdict.
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [GENUINE, STARTUP, STARTUP])
+    grader = _install_grader(monkeypatch, ["FAIL"])
+    _no_sleep(monkeypatch)
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=3, infra_retries=1))
+    assert agent["n"] == 3 and grader["n"] == 1  # never grade an untouched round
+    assert result["check_verdict"] == "FAIL"
+    assert result["termination_reason"] == TerminationReason.OK
+    assert len(result["continuations"]) == 1  # chain stopped, rounds 2-3 not run
+    rnd = result["continuations"][0]
+    assert rnd["check_verdict"] == "ERROR"
+    assert rnd["termination_reason"] == TerminationReason.INFRA_ERROR
+    assert "exhausted infra retries" in rnd["error"]
+
+
+def test_round_quota_exhaustion_stops_chain(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [GENUINE])
+    grader = _install_grader(monkeypatch, ["FAIL"])
+    quota_answers = iter([True, False])  # first attempt runs, round 1 is quota-capped
+    monkeypatch.setattr(
+        runner.quota, "run_with_quota_retry", lambda run, block, **k: next(quota_answers) and (run() or True)
+    )
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=3))
+    assert agent["n"] == 1 and grader["n"] == 1
+    assert result["check_verdict"] == "FAIL"
+    assert result["termination_reason"] == TerminationReason.OK
+    rnd = result["continuations"][0]
+    assert rnd["check_verdict"] == "ERROR"
+    assert rnd["agent_exit"] == -3  # same quota sentinel the first attempt records
+    assert rnd["termination_reason"] == TerminationReason.QUOTA_EXHAUSTED
+    assert len(result["continuations"]) == 1
+
+
+def test_stale_agent_check_not_copied_into_round(tmp_path, monkeypatch):
+    # The in-workspace self-check file survives across rounds (useful context
+    # for the agent), but a round's agent_check.result artifact must only
+    # record a check THAT round actually ran — never round k-1's stale file.
+    def write_check(text, mtime=None):
+        def mutate(workspace):
+            path = os.path.join(workspace, "Bar.result")
+            with open(path, "w") as f:
+                f.write(text)
+            if mtime is not None:
+                os.utime(path, (mtime, mtime))
+
+        return mutate
+
+    backend = _ScriptedBackend()
+    _install_agent(
+        monkeypatch,
+        backend,
+        [
+            dict(GENUINE, mutate=write_check("round0 check", mtime=1_000_000)),
+            GENUINE,  # round 1: agent never re-ran its self-check
+            dict(GENUINE, mutate=write_check("round2 check", mtime=2_000_000)),
+        ],
+    )
+    _install_grader(monkeypatch, ["FAIL", "FAIL", "PASS"])
+    runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=3))
+
+    out = tmp_path / "out" / "Foo" / "Bar"
+    assert (out / "grading" / "agent_check.result").read_text() == "round0 check"
+    assert not (out / "continuations" / "round-1" / "agent_check.result").exists()
+    assert (out / "continuations" / "round-2" / "agent_check.result").read_text() == "round2 check"
+
+
+def test_costs_accumulate_into_top_level(tmp_path, monkeypatch):
+    # Verdict fields stay first-attempt; cost fields cover the whole chain.
+    backend = _ScriptedBackend()
+    _install_agent(monkeypatch, backend, [dict(GENUINE, out_tokens=500), dict(GENUINE, out_tokens=300)])
+    _install_grader(monkeypatch, ["FAIL", "PASS"])
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=1))
+    assert result["output_tokens"] == 800
+    assert result["continuations"][0]["output_tokens"] == 300
+
+
+def test_resume_skips_benchmarks_recovered_by_continuation():
+    def _r(name, verdict, cont_verdicts=None, termination="OK"):
+        out = {"benchmark": name, "check_verdict": verdict, "termination_reason": termination}
+        if cont_verdicts is not None:
+            out["continuations"] = [{"round": i + 1, "check_verdict": v} for i, v in enumerate(cont_verdicts)]
+        return out
+
+    results = [
+        _r("recovered.tla", "FAIL", cont_verdicts=["FAIL", "PASS"]),
+        _r("still-failing.tla", "FAIL", cont_verdicts=["FAIL", "FAIL"]),
+        _r("plain-pass.tla", "PASS"),
+        _r("plain-fail.tla", "FAIL"),
+    ]
+    assert runner._resume_done_benchmarks(results) == {"recovered.tla", "plain-pass.tla"}
+
+
+def _summary_result(name, cont_rounds=None, **kw):
+    out = {
+        "benchmark": name,
+        "check_verdict": "FAIL",
+        "time_secs": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "termination_reason": "OK",
+    }
+    if cont_rounds is not None:
+        out["max_continuations"] = 3
+        out["continuations"] = cont_rounds
+    out.update(kw)
+    return out
+
+
+def test_summary_reports_continuation_metric_separately(tmp_path):
+    results = [
+        _summary_result(
+            "recovered.tla", cont_rounds=[{"round": 1, "check_verdict": "PASS", "termination_reason": "OK"}]
+        ),
+        _summary_result("plain-fail.tla"),
+    ]
+    runner.update_summary(
+        results, str(tmp_path), total_benchmarks=2, backend_name="copilot", mode_name="proof-completion"
+    )
+    summary = (tmp_path / "summary.md").read_text()
+    assert "**Pass rate**: 0/2 (0.0%)" in summary  # pass@1 stays first-attempt only
+    assert "**Pass rate with continuations (≤3)**: 1/2 (50.0%) — 1 recovered by continuation" in summary
+    assert "PASS on continuation 1" in summary
+
+
+def test_summary_excludes_interrupted_chains_from_continuation_rate(tmp_path):
+    # A chain cut by infra/quota is indeterminate: dropped from the continuation
+    # rate (numerator AND denominator) and disclosed — never a silent failure.
+    results = [
+        _summary_result(
+            "recovered.tla", cont_rounds=[{"round": 1, "check_verdict": "PASS", "termination_reason": "OK"}]
+        ),
+        _summary_result(
+            "cut-chain.tla",
+            cont_rounds=[{"round": 1, "check_verdict": "ERROR", "termination_reason": "QUOTA_EXHAUSTED"}],
+        ),
+        _summary_result("plain-fail.tla"),
+    ]
+    runner.update_summary(
+        results, str(tmp_path), total_benchmarks=3, backend_name="copilot", mode_name="proof-completion"
+    )
+    summary = (tmp_path / "summary.md").read_text()
+    assert "**Pass rate**: 0/3 (0.0%)" in summary  # cut-chain's genuine first FAIL stays scored
+    assert (
+        "**Pass rate with continuations (≤3)**: 1/2 (50.0%) — 1 recovered by continuation "
+        "(pass@1 above is first-attempt only) · 1 chain(s) infra/quota-cut (excluded — re-run)"
+    ) in summary
+    assert "continuation chain cut at round 1 (excluded — re-run)" in summary  # per-row note discloses too

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -11,6 +11,8 @@ Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_infra_retry.py
 import json
 import os
 
+import pytest
+
 from evaluator import runner
 from evaluator.termination import TerminationReason
 
@@ -167,6 +169,27 @@ def test_resume_does_not_skip_non_genuine_pass_results():
         _result("failed.tla", "FAIL"),
     ]
     assert runner._resume_done_benchmarks(results) == {"genuine-pass.tla", "legacy-pass.tla", "skipped.tla"}
+
+
+def test_make_workspace_cleans_up_on_setup_failure(tmp_path, monkeypatch):
+    # The temp dir must not leak when workspace setup dies half-way (disk full,
+    # unreadable dep) — same guarantee _make_canonical_dir gives.
+    created = []
+    real_mkdtemp = runner.tempfile.mkdtemp
+
+    def tracking_mkdtemp(**kw):
+        d = real_mkdtemp(**kw)
+        created.append(d)
+        return d
+
+    def broken_copy2(*a, **kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(runner.tempfile, "mkdtemp", tracking_mkdtemp)
+    monkeypatch.setattr(runner.shutil, "copy2", broken_copy2)
+    with pytest.raises(OSError):
+        runner._make_workspace("copilot", "Bar", str(tmp_path / "Bar.tla"), "Bar.tla", [])
+    assert created and not os.path.isdir(created[0])
 
 
 def test_startup_failure_retried_and_final_attempt_graded(tmp_path, monkeypatch):

--- a/tests/evaluator/test_score.py
+++ b/tests/evaluator/test_score.py
@@ -15,7 +15,11 @@ import sys
 from evaluator.score import (
     SCORERS,
     comparison_md,
+    continuation_budget,
+    continuation_interrupted,
+    continuation_passed,
     is_pass,
+    is_pass_with_continuations,
     is_skipped,
     load_run,
     main,
@@ -176,6 +180,125 @@ def test_comparison_discloses_skip_inline():
     md = comparison_md(runs, EQUAL, "equal")
     assert "| r1 | codex | proof-completion | 50.0% | 1/2 (+1 skipped) |" in md
     assert "| r2 | claude_code | proof-completion | 100.0% | 2/2 |" in md  # no note when nothing skipped
+
+
+# --- continuations are a separate metric, never a replacement for pass@1 ---
+
+
+def _cont(*verdicts):
+    return [{"round": i + 1, "check_verdict": v} for i, v in enumerate(verdicts)]
+
+
+# A chain ended by a non-genuine round (the runner stops continuing on these).
+CUT_CHAIN = [{"round": 1, "check_verdict": "ERROR", "termination_reason": "QUOTA_EXHAUSTED"}]
+
+
+def test_continuation_passed_predicates():
+    recovered = _r("FAIL", continuations=_cont("FAIL", "PASS"))
+    still_failing = _r("FAIL", continuations=_cont("FAIL"))
+    assert continuation_passed(recovered) and is_pass_with_continuations(recovered)
+    assert not continuation_passed(still_failing) and not is_pass_with_continuations(still_failing)
+    assert not continuation_passed(_r("FAIL"))  # no rounds recorded
+    assert is_pass_with_continuations(_r("PASS"))  # first-attempt pass counts too
+
+
+def test_weighted_score_with_continuations_same_denominator():
+    # pass@1 and the continuation rate share the scored set (non-genuine excluded).
+    results = [
+        _r("PASS"),
+        _r("FAIL", continuations=_cont("PASS")),
+        _r("FAIL", continuations=_cont("FAIL")),
+        _r("FAIL", termination_reason="INFRA_ERROR"),
+    ]
+    assert weighted_score(results, EQUAL) == (100.0 / 3, 1, 3)
+    assert weighted_score(results, EQUAL, passed=is_pass_with_continuations) == (200.0 / 3, 2, 3)
+
+
+def test_continuation_interrupted_only_for_unresolved_cut_chains():
+    # Interrupted = the chain-ending round was infra/quota-cut with no PASS.
+    assert continuation_interrupted(_r("FAIL", continuations=CUT_CHAIN))
+    # An exhausted budget of genuine rounds is a real continuation failure.
+    assert not continuation_interrupted(_r("FAIL", continuations=_cont("FAIL", "FAIL")))
+    # A recovered chain resolved, however its stream ended.
+    assert not continuation_interrupted(_r("FAIL", continuations=_cont("FAIL", "PASS")))
+    assert not continuation_interrupted(_r("FAIL"))  # no rounds recorded
+
+
+def test_continuation_budget_uniform_or_none():
+    assert continuation_budget([_r("FAIL", max_continuations=3), _r("PASS")]) == 3
+    assert continuation_budget([_r("FAIL", max_continuations=3), _r("FAIL", max_continuations=5)]) is None
+    assert continuation_budget([_r("FAIL")]) is None  # legacy results: no budget recorded
+
+
+def test_scorecard_reports_continuation_rate_separately():
+    results = [_r("FAIL", continuations=_cont("PASS")), _r("FAIL")]
+    run = {"path": "x", "id": "r", "backend": "copilot", "mode": "proof-completion", "results": results}
+    md = scorecard_md(run, EQUAL, "equal")
+    assert "**Pass rate**: 0/2 (0.0%)" in md  # pass@1 stays first-attempt only
+    assert "**Pass rate with continuations**: 1/2 (50.0%) — 1 recovered by continuation" in md
+
+
+def test_scorecard_labels_continuation_budget_and_excludes_cut_chains():
+    # The rate states its budget (≤N), and an interrupted chain is dropped from
+    # numerator AND denominator with a disclosed count — never a silent failure.
+    results = [
+        _r("FAIL", continuations=_cont("PASS"), max_continuations=3),
+        _r("FAIL", continuations=CUT_CHAIN, max_continuations=3),
+        _r("FAIL"),
+    ]
+    run = {"path": "x", "id": "r", "backend": "copilot", "mode": "proof-completion", "results": results}
+    md = scorecard_md(run, EQUAL, "equal")
+    assert "**Pass rate**: 0/3 (0.0%)" in md  # the cut chain's genuine first FAIL stays scored
+    assert (
+        "**Pass rate with continuations (≤3)**: 1/2 (50.0%) — 1 recovered by continuation "
+        "(pass@1 above is first-attempt only) · 1 chain(s) infra/quota-cut (excluded — re-run)"
+    ) in md
+
+
+def test_scorecard_without_continuations_has_no_continuation_line():
+    results = [_r("PASS"), _r("FAIL")]
+    run = {"path": "x", "id": "r", "backend": "copilot", "mode": "proof-completion", "results": results}
+    assert "continuation" not in scorecard_md(run, EQUAL, "equal")
+
+
+def test_comparison_discloses_continuation_recoveries_inline():
+    # The budget is part of the result: +1 recovery out of ≤1 round and out of
+    # ≤10 must not render identically. Legacy results without a recorded budget
+    # fall back to the unlabeled note.
+    runs = [
+        {
+            "id": "r1",
+            "backend": "codex",
+            "mode": "proof-completion",
+            "results": [_r("PASS"), _r("FAIL", continuations=_cont("PASS"), max_continuations=3)],
+        },
+        {
+            "id": "r2",
+            "backend": "copilot",
+            "mode": "proof-completion",
+            "results": [_r("PASS"), _r("FAIL", continuations=_cont("PASS"))],  # legacy: no budget recorded
+        },
+        {"id": "r3", "backend": "claude_code", "mode": "proof-completion", "results": [_r("PASS"), _r("FAIL")]},
+    ]
+    md = comparison_md(runs, EQUAL, "equal")
+    assert "| r1 | codex | proof-completion | 50.0% | 1/2 (+1 via ≤3 continuations) |" in md
+    assert "| r2 | copilot | proof-completion | 50.0% | 1/2 (+1 via continuation) |" in md
+    assert "| r3 | claude_code | proof-completion | 50.0% | 1/2 |" in md  # no note without rounds
+
+
+def test_comparison_discloses_interrupted_chains_inline():
+    # "(+0 via continuation)" alone would hide that the chain was infra/quota-cut
+    # rather than genuinely exhausted — the cut count must appear next to it.
+    runs = [
+        {
+            "id": "r1",
+            "backend": "codex",
+            "mode": "proof-completion",
+            "results": [_r("PASS"), _r("FAIL", continuations=CUT_CHAIN)],
+        },
+    ]
+    md = comparison_md(runs, EQUAL, "equal")
+    assert "| r1 | codex | proof-completion | 50.0% | 1/2 (+0 via continuation) (+1 chain(s) cut) |" in md
 
 
 # --- load_run / main entry point ------------------------------------------


### PR DESCRIPTION
 Added `--max-continuations N` for optional continuation attempts after a genuine non-`PASS` first attempt. ( implements #42 )

The normal first attempt still runs with the same pass@1 semantics. If that attempt does not pass for a genuine proof reason, the runner can start up to `N` more agent runs in the same workspace using a continuation prompt. This lets the agent continue from its existing partial proof instead of starting over. The chain stops as soon as a continuation passes.

  ## Behavior

  - Default behavior is unchanged: `--max-continuations 0`.
  - Pass@1 is unchanged: the top-level `check_verdict` still records only the first attempt’s verdict.
  - Continuation attempts are saved separately under `continuations`.
  - Reports show a separate continuation metric, e.g. `Pass rate with continuations (≤1)`.
  - Token/time totals include continuation rounds when continuations are enabled.
  - Infra/quota-cut continuation chains are excluded from continuation scoring and shown separately.
  - `--resume` skips benchmarks that passed either on the first attempt or through continuation.