### PR TITLE
Update README benchmark task counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ types:
 
 | Source | Proof completion | Proof from scratch | Total |
 |---|--:|--:|--:|
-| tlaplus/Examples | 381 | 126 | 507 |
-| TLAPS distribution examples | 154 | 80 | 234 |
+| tlaplus/Examples | 379 | 126 | 505 |
+| TLAPS distribution examples | 103 | 57 | 160 |
 | ZooKeeper (Remix) | 0 | 18 | 18 |
 | Ivy liveness | 0 | 12 | 12 |
 | etcd (Specula) | 0 | 8 | 8 |
 | AbstractRaft | 0 | 4 | 4 |
 | OpenAddressing (lemmy/Examples) | 1 | 5 | 6 |
 | Anvil | 0 | 1 | 1 |
-| **Total** | **536** | **254** | **790** |
+| **Total** | **483** | **231** | **714** |
 
 ## Running
 


### PR DESCRIPTION
| Source | Proof completion | Proof from scratch | Total |
|---|--:|--:|--:|
| tlaplus/Examples | 381 → 379 | 126 | 507 → 505 |
| TLAPS distribution examples | 154 → 103 | 80 → 57 | 234 → 160 |
| ZooKeeper (Remix) | 0 | 18 | 18 |
| Ivy liveness | 0 | 12 | 12 |
| etcd (Specula) | 0 | 8 | 8 |
| AbstractRaft | 0 | 4 | 4 |
| OpenAddressing (lemmy/Examples) | 1 | 5 | 6 |
| Anvil | 0 | 1 | 1 |
| **Total** | **536 → 483** | **254 → 231** | **790 → 714** |

Following the task removals in #41 and #46, fix the stale counts in the README.
