### PR TITLE
Reuse TLAPM fingerprint cache for proof checks

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -137,6 +137,8 @@ uv run tlaps-bench check path/to/file.tla --mode proof-from-scratch
 uv run tlaps-bench check path/to/file.tla --sany-only
 ```
 
+By default, `check` reuses `<target-dir>/.tlacache`; use `--no-cache` for a cold check, or `--timeout 0` for no checker deadline.
+
 Exit codes: `0` = PASS, `1` = FAIL, `3` = ERROR.
 
 ### `tlaps-bench score`

--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -6,7 +6,12 @@ Designed for AI agents to get quick feedback during proof writing.
 
 Usage:
     python3 check_proof.py benchmark/Euclid/GCD_GCD3.tla \\
-        [--mode {proof-completion,proof-from-scratch}] [--tlapm PATH] [--tlapm-lib PATH] [--timeout SECS]
+        [--mode {proof-completion,proof-from-scratch}] [--tlapm PATH] [--tlapm-lib PATH] \\
+        [--timeout SECS] [--no-cache]
+
+Fingerprint cache:
+    By default the proving run reuses <target-dir>/.tlacache.
+    --no-cache verifies from scratch.
 
 Modes:
     proof-completion (default) — proof completion. The preamble (above PROOF
@@ -456,6 +461,7 @@ def resolve_timeout(explicit):
     agent self-check and the grader can't diverge on the discharge deadline — a
     proof near the boundary must not pass the self-check yet time out at grading.
     A malformed env value falls back to 600 rather than crashing the check.
+    A value of 0 or less means no deadline.
     """
     if explicit is not None:
         return explicit
@@ -463,6 +469,18 @@ def resolve_timeout(explicit):
         return int(os.environ.get("TLAPS_CHECK_TIMEOUT", "600"))
     except ValueError:
         return 600
+
+
+def effective_timeout(timeout):
+    """Return the subprocess deadline; zero or less disables it."""
+    return timeout if timeout > 0 else None
+
+
+def tlapm_cache_args(bench_dir, no_cache):
+    """Return tlapm fingerprint-cache flags for the proving run."""
+    if no_cache:
+        return []
+    return ["--cache-dir", os.path.join(bench_dir, ".tlacache"), "--safefp"]
 
 
 # Machine-readable marker the runner greps for to set the structured
@@ -561,13 +579,17 @@ def _run_in_container(filepath, args):
         cmd += ["--benchmark-dir", os.path.dirname(container_file)]
     if args.sany_only:
         cmd += ["--sany-only"]
+    if args.no_cache:
+        cmd += ["--no-cache"]
 
     config = ContainerConfig(workspace=workspace, result_dir=result_dir)
     config.env["GIT_CONFIG_COUNT"] = "1"
     config.env["GIT_CONFIG_KEY_0"] = "safe.directory"
     config.env["GIT_CONFIG_VALUE_0"] = "/workspace"
+    # Keep --timeout 0 unbounded in the outer Docker call too.
+    container_timeout = args.timeout + 60 if args.timeout > 0 else None
     try:
-        exit_code, stdout, stderr = runner.run_with_output(config, cmd, timeout=args.timeout + 60)
+        exit_code, stdout, stderr = runner.run_with_output(config, cmd, timeout=container_timeout)
         # Print output, filtering container-internal paths
         if stdout:
             for line in stdout.splitlines():
@@ -604,9 +626,14 @@ def main():
         "--timeout",
         type=int,
         default=None,
-        help="Timeout in seconds. If omitted, uses $TLAPS_CHECK_TIMEOUT (set by the "
+        help="Timeout in seconds; 0 means no limit. If omitted, uses $TLAPS_CHECK_TIMEOUT (set by the "
         "runner so the agent's self-check uses the SAME tlapm budget as the grader), "
         "else 600.",
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Verify from scratch: do not reuse or write the target-side .tlacache.",
     )
     parser.add_argument("--output", "-o", default=None, help="Write results to this file (default: <input>.result)")
     parser.add_argument(
@@ -733,12 +760,13 @@ def main():
         # failed obligation, 11 incomplete proof, 12 empty target. This is the
         # authoritative replacement for our hand-rolled incomplete-proof heuristics.
         cmd = [tlapm_path, "--strict", "-I", tlapm_lib]
+        cmd += tlapm_cache_args(bench_dir, args.no_cache)
         community_lib = find_community_lib(filepath)
         if community_lib:
             cmd += ["-I", community_lib]
         cmd.append(tmp_file)
         try:
-            out, err, rc = run_killgroup(cmd, args.timeout, tmp_dir)
+            out, err, rc = run_killgroup(cmd, effective_timeout(args.timeout), tmp_dir)
             tlapm_output = out + err
             tlapm_exit = rc
         except subprocess.TimeoutExpired:

--- a/src/evaluator/modes/base.py
+++ b/src/evaluator/modes/base.py
@@ -191,6 +191,7 @@ class Mode(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; sub
             self._checker_binary,
             os.path.join(workspace, benchmark_basename),
             "--no-container",
+            "--no-cache",
             "--mode",
             self.name,
             "--output",

--- a/tests/common/test_cache_flags.py
+++ b/tests/common/test_cache_flags.py
@@ -1,0 +1,42 @@
+"""Unit coverage for check_proof fingerprint-cache flags."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from common import check_proof
+from evaluator.modes import get_mode, list_modes
+
+NO_CACHE_FLAG = "--no-cache"
+
+
+def test_cache_args_default_reuses_beside_target(tmp_path):
+    args = check_proof.tlapm_cache_args(str(tmp_path), no_cache=False)
+    assert args == ["--cache-dir", str(tmp_path / ".tlacache"), "--safefp"]
+
+
+def test_cache_args_no_cache_gives_nothing(tmp_path):
+    assert check_proof.tlapm_cache_args(str(tmp_path), no_cache=True) == []
+
+
+@pytest.mark.parametrize("mode_name", list_modes())
+def test_grader_command_always_passes_no_cache(mode_name, tmp_path):
+    mode = get_mode(mode_name, str(tmp_path), "/usr/local/bin/check_proof_bin")
+    cmd = mode.checker_command("/ws", "Foo.tla", "/out/check.result", 600)
+    assert NO_CACHE_FLAG in cmd, f"grader command for {mode_name} would reuse the agent's cache"
+
+
+def _src(rel):
+    return (Path(__file__).resolve().parents[2] / "src" / rel).read_text(encoding="utf-8")
+
+
+def test_no_cache_flag_coupled_between_grader_and_checker():
+    assert NO_CACHE_FLAG in _src(os.path.join("evaluator", "modes", "base.py"))
+    assert f'"{NO_CACHE_FLAG}"' in _src(os.path.join("common", "check_proof.py"))
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/common/test_docker_commands.py
+++ b/tests/common/test_docker_commands.py
@@ -61,6 +61,7 @@ class TestCheckDockerDispatch:
             output = None
             benchmark_dir = None
             sany_only = False
+            no_cache = False
 
         with pytest.raises(SystemExit) as exc_info:
             _run_in_container(FIXTURE_TLA, Args())
@@ -87,12 +88,34 @@ class TestCheckDockerDispatch:
             output = None
             benchmark_dir = None
             sany_only = True
+            no_cache = False
 
         with pytest.raises(SystemExit):
             _run_in_container(FIXTURE_TLA, Args())
 
         cmd = mock_run.call_args[0][1]
         assert "--sany-only" in cmd
+
+    @patch("common.container.ContainerRunner.run_with_output")
+    @patch("common.container.ContainerRunner.image_exists", return_value=True)
+    def test_no_cache_flag_passed(self, mock_exists, mock_run):
+        mock_run.return_value = (0, "✅ PASS\n", "")
+
+        from common.check_proof import _run_in_container
+
+        class Args:
+            mode = "proof-completion"
+            timeout = 60
+            output = None
+            benchmark_dir = None
+            sany_only = False
+            no_cache = True
+
+        with pytest.raises(SystemExit):
+            _run_in_container(FIXTURE_TLA, Args())
+
+        cmd = mock_run.call_args[0][1]
+        assert "--no-cache" in cmd
 
     @patch("common.container.ContainerRunner.run_with_output")
     @patch("common.container.ContainerRunner.image_exists", return_value=True)
@@ -107,6 +130,7 @@ class TestCheckDockerDispatch:
             output = None
             benchmark_dir = None
             sany_only = False
+            no_cache = False
 
         with pytest.raises(SystemExit):
             _run_in_container(FIXTURE_TLA, Args())

--- a/tests/common/test_oracle_env_coupling.py
+++ b/tests/common/test_oracle_env_coupling.py
@@ -114,6 +114,17 @@ def test_timeout_malformed_env_falls_back(monkeypatch):
     assert check_proof.resolve_timeout(None) == 600
 
 
+def test_timeout_zero_means_unbounded(monkeypatch):
+    assert check_proof.resolve_timeout(0) == 0
+    monkeypatch.setenv(CHECK_TIMEOUT_ENV, "0")
+    assert check_proof.resolve_timeout(None) == 0
+    assert check_proof.effective_timeout(0) is None
+
+
+def test_effective_timeout_positive_passthrough():
+    assert check_proof.effective_timeout(600) == 600
+
+
 # --- get_baseline_text: canonical first, git fallback -------------------------
 
 

--- a/tests/integration/test_cache_reuse.py
+++ b/tests/integration/test_cache_reuse.py
@@ -1,0 +1,108 @@
+"""End-to-end fingerprint-cache behavior for the real checker."""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+CHECK = os.path.join(REPO, "src", "common", "check_proof.py")
+SRS = os.path.join(REPO, "src", "dataset", "sany-dump", "run.sh")
+
+GOOD_TLA = "---- MODULE Good ----\nEXTENDS Integers, TLAPS\nTHEOREM Target == 1 + 1 = 2\nPROOF OBVIOUS\n====\n"
+
+VERDICT_RE = re.compile(r"^\s*(PASS|FAIL)\b", re.MULTILINE)
+
+
+def _tlapm():
+    for c in ("/opt/tlapm/bin/tlapm", os.path.expanduser("~/.tlapm/bin/tlapm")):
+        if os.path.isfile(c):
+            return c
+    return None
+
+
+def _make_workspace():
+    w = tempfile.mkdtemp(prefix="cachereuse_")
+    with open(os.path.join(w, "Good.tla"), "w") as f:
+        f.write(GOOD_TLA)
+    subprocess.run(["git", "init", "-q"], cwd=w)
+    subprocess.run(["git", "add", "-A"], cwd=w)
+    subprocess.run(
+        ["git", "-c", "user.email=b@b", "-c", "user.name=b", "commit", "-qm", "baseline"],
+        cwd=w, capture_output=True,
+    )
+    return w
+
+
+def _run_check(w, *extra_args):
+    env = {**os.environ, "PYTHONPATH": os.path.join(REPO, "src"), "SANY_RUN_SH": SRS}
+    r = subprocess.run(
+        [sys.executable, CHECK, "Good.tla", "--mode", "proof-from-scratch", "--timeout", "120", *extra_args],
+        cwd=w, capture_output=True, text=True, timeout=300, env=env,
+    )
+    m = VERDICT_RE.search(r.stdout)
+    return (m.group(1) if m else "?"), r.stdout
+
+
+def _fingerprints_path(w):
+    return os.path.join(w, ".tlacache", "Good.tlaps", "fingerprints")
+
+
+def test_default_reuses_cache_beside_target():
+    if _tlapm() is None:
+        print("  SKIP (no tlapm)")
+        return
+    w = _make_workspace()
+    try:
+        verdict1, out1 = _run_check(w)
+        assert verdict1 == "PASS", f"cold run failed:\n{out1[-800:]}"
+        assert os.path.isfile(_fingerprints_path(w)), "no persistent fingerprint cache beside the target"
+
+        verdict2, out2 = _run_check(w)
+        assert verdict2 == "PASS", f"warm run diverged from cold run:\n{out2[-800:]}"
+    finally:
+        shutil.rmtree(w, ignore_errors=True)
+
+
+def test_no_cache_neither_creates_nor_touches_workspace_cache():
+    if _tlapm() is None:
+        print("  SKIP (no tlapm)")
+        return
+    w = _make_workspace()
+    try:
+        verdict, out = _run_check(w, "--no-cache")
+        assert verdict == "PASS", f"--no-cache run failed:\n{out[-800:]}"
+        assert not os.path.exists(os.path.join(w, ".tlacache")), "--no-cache still wrote a workspace cache"
+
+        os.makedirs(os.path.dirname(_fingerprints_path(w)))
+        with open(_fingerprints_path(w), "w") as f:
+            f.write("GARBAGE-NOT-A-FINGERPRINT-FILE\n")
+        verdict, out = _run_check(w, "--no-cache")
+        assert verdict == "PASS", f"--no-cache run failed with workspace cache present:\n{out[-800:]}"
+        with open(_fingerprints_path(w)) as f:
+            assert f.read() == "GARBAGE-NOT-A-FINGERPRINT-FILE\n", "--no-cache touched the workspace cache"
+    finally:
+        shutil.rmtree(w, ignore_errors=True)
+
+
+def test_poisoned_cache_cannot_break_the_check():
+    if _tlapm() is None:
+        print("  SKIP (no tlapm)")
+        return
+    w = _make_workspace()
+    try:
+        os.makedirs(os.path.dirname(_fingerprints_path(w)))
+        with open(_fingerprints_path(w), "w") as f:
+            f.write("GARBAGE-NOT-A-FINGERPRINT-FILE\n")
+        verdict, out = _run_check(w)
+        assert verdict == "PASS", f"corrupt cache broke the default (reusing) run:\n{out[-800:]}"
+    finally:
+        shutil.rmtree(w, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
This PR is the first step toward implementing the features in issue #48.

Features:

1. check_proof now reuses .tlacache, while the grader still runs from scratch with --no-cache.
2. --timeout 0 now disables the checker deadline for long-running proofs.

End-to-end tested with GCD_GCD3: Codex ran the full checker three times; two checks reused the cache, and the final cold grader passed all 38 obligations.