### PR TITLE
Add --keep-container and --session-dir for debugging agent runs #44

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -125,7 +125,7 @@ uv run tlaps-bench run [flags]
 | `--force-build` | off | Rebuild the Docker image |
 | `--no-container` | off | Run without Docker (requires native setup) |
 | `--keep-container` | off | Retain each agent container after it exits (drop `--rm`) for debugging (see [Debugging a run](#debugging-a-run-keep-container)) |
-| `--session-dir` | off | Persist each run's agent session state to this persistent host path (survives container removal and reboot; restore with `scripts/restore-session.sh`) |
+| `--session-dir` | off (default `~/.tlaps-bench/sessions` under `--keep-container`) | Persist each run's agent session state to this persistent host path (survives container removal and reboot; restore with `scripts/restore-session.sh`) |
 
 Run `uv run tlaps-bench run --help` for the full flag list.
 
@@ -260,9 +260,9 @@ Each run prints the retained container's name, e.g.:
 [keep-container] retaining container 'tlaps-bench-my_benchmark-1a2b3c4d'. After it exits: `docker exec -it tlaps-bench-my_benchmark-1a2b3c4d bash` to inspect (start it first if stopped: `docker start ...`), `docker commit ... <img>` to snapshot, `docker rm -f ...` to remove.
 ```
 
-The name is unique per attempt, so parallel jobs, infra retries and continuation rounds never collide. Because the agent's state lives in the container's own writable layer (not a bind mount from `/tmp`), it survives a host reboot as long as the container is not removed.
+The name is unique per attempt, so parallel jobs, infra retries and continuation rounds never collide.
 
-Clean up when done — retained containers are **not** auto-removed:
+`--keep-container` also **persists the session state to the host by default** (see below), so a single flag is enough for debugging and the state survives even a host reboot. Clean up when done — retained containers are **not** auto-removed:
 
 ```bash
 docker ps -a --filter name=tlaps-bench- --format '{{.Names}}' | xargs -r docker rm -f
@@ -272,22 +272,22 @@ docker ps -a --filter name=tlaps-bench- --format '{{.Names}}' | xargs -r docker 
 
 ### Persisting session state to the host (`--session-dir`)
 
-`--keep-container` keeps the state inside the container's writable layer, so it is lost if the container is removed (e.g. `docker system prune`) or — for backends that authenticate from a mounted credential file (`codex` / `claude_code` / `pi`) — if a reboot clears the `/tmp` tempdir that the state was mounted from.
+Session state lives inside the container, and for backends that authenticate from a mounted credential file (`codex` / `claude_code` / `pi`) it is written into a `/tmp` tempdir — so a reboot (e.g. after an OOM) clears it even if the container is kept. To avoid that, the agent's session state is bind-mounted straight to a **persistent host directory**.
 
-`--session-dir` avoids both by bind-mounting the agent's session state straight to a **persistent host directory** you choose:
+With `--keep-container` this happens automatically under `~/.tlaps-bench/sessions/`. Pass `--session-dir` to choose the location explicitly (and to persist without keeping the container):
 
 ```bash
 uv run tlaps-bench run --backend copilot --session-dir ./sessions --filter my_benchmark
 ```
 
-Each run writes its state to `./sessions/<backend>/<benchmark>/` on the host (for `codex`/`claude_code`/`pi` the credential files are stored there too, so a single mount holds both auth and session). Because it is a real host path — not `/tmp` and not tied to the container's lifetime — the state survives container removal *and* a host reboot, and can be moved to another machine. `--session-dir` and `--keep-container` are independent and can be combined; `--session-dir` is ignored with `--no-container`.
+Each run writes its state to `<session-dir>/<backend>/<benchmark>/` (or `<...>/<container-name>/` under `--keep-container`, one dir per retained container). For `codex`/`claude_code`/`pi` the credential files are stored there too, so a single mount holds both auth and session. Because it is a real host path — not `/tmp` and not tied to the container's lifetime — the state survives container removal *and* reboot, and can be moved to another machine. A `.gitignore` (`*`) is written at the session root so this credential-bearing data can't be accidentally committed. `--session-dir` is ignored with `--no-container`.
 
 ### Restoring a session into a container
 
 To resume or inspect a persisted session, mount it back into a fresh container:
 
 ```bash
-scripts/restore-session.sh --backend copilot ./sessions/copilot/my_benchmark
+scripts/restore-session.sh --backend copilot ~/.tlaps-bench/sessions/copilot/<container-name>
 ```
 
 This starts an interactive `tlaps-bench-base` shell with the session mounted at the backend's session path (e.g. `/root/.copilot`), so you can read the transcript or run the agent CLI's own resume command (e.g. `copilot --resume`). The container is removed on exit; the host session directory is not. (Network egress is not firewalled in this debug shell, and no benchmark files are mounted — it is for inspecting/continuing the agent session, not for grading.)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -124,6 +124,8 @@ uv run tlaps-bench run [flags]
 | `--max-continuations` | `0` | Run up to N same-workspace continuation attempts after the first attempt completes without PASS (see [Continuation runs](#continuation-runs)) |
 | `--force-build` | off | Rebuild the Docker image |
 | `--no-container` | off | Run without Docker (requires native setup) |
+| `--keep-container` | off | Retain each agent container after it exits (drop `--rm`) for debugging (see [Debugging a run](#debugging-a-run-keep-container)) |
+| `--session-dir` | off | Persist each run's agent session state to this persistent host path (survives container removal and reboot; restore with `scripts/restore-session.sh`) |
 
 Run `uv run tlaps-bench run --help` for the full flag list.
 
@@ -241,6 +243,54 @@ To skip Docker entirely (for debugging, requires native setup):
 ```bash
 uv run tlaps-bench run --backend codex --model gpt-5.5 --no-container
 ```
+
+### Debugging a run (`--keep-container`)
+
+By default each agent container is started with `--rm`, so it (and its writable layer, where the agent's session state such as `.copilot` / `.codex` lives) is deleted the moment the run finishes or is interrupted. That makes it impossible to resume the agent or ask it follow-up questions afterwards.
+
+Pass `--keep-container` to retain the container instead:
+
+```bash
+uv run tlaps-bench run --backend copilot --keep-container --filter my_benchmark
+```
+
+Each run prints the retained container's name, e.g.:
+
+```text
+[keep-container] retaining container 'tlaps-bench-my_benchmark-1a2b3c4d'. After it exits: `docker exec -it tlaps-bench-my_benchmark-1a2b3c4d bash` to inspect (start it first if stopped: `docker start ...`), `docker commit ... <img>` to snapshot, `docker rm -f ...` to remove.
+```
+
+The name is unique per attempt, so parallel jobs, infra retries and continuation rounds never collide. Because the agent's state lives in the container's own writable layer (not a bind mount from `/tmp`), it survives a host reboot as long as the container is not removed.
+
+Clean up when done — retained containers are **not** auto-removed:
+
+```bash
+docker ps -a --filter name=tlaps-bench- --format '{{.Names}}' | xargs -r docker rm -f
+```
+
+`--keep-container` only applies in container mode (it is ignored with `--no-container`).
+
+### Persisting session state to the host (`--session-dir`)
+
+`--keep-container` keeps the state inside the container's writable layer, so it is lost if the container is removed (e.g. `docker system prune`) or — for backends that authenticate from a mounted credential file (`codex` / `claude_code` / `pi`) — if a reboot clears the `/tmp` tempdir that the state was mounted from.
+
+`--session-dir` avoids both by bind-mounting the agent's session state straight to a **persistent host directory** you choose:
+
+```bash
+uv run tlaps-bench run --backend copilot --session-dir ./sessions --filter my_benchmark
+```
+
+Each run writes its state to `./sessions/<backend>/<benchmark>/` on the host (for `codex`/`claude_code`/`pi` the credential files are stored there too, so a single mount holds both auth and session). Because it is a real host path — not `/tmp` and not tied to the container's lifetime — the state survives container removal *and* a host reboot, and can be moved to another machine. `--session-dir` and `--keep-container` are independent and can be combined; `--session-dir` is ignored with `--no-container`.
+
+### Restoring a session into a container
+
+To resume or inspect a persisted session, mount it back into a fresh container:
+
+```bash
+scripts/restore-session.sh --backend copilot ./sessions/copilot/my_benchmark
+```
+
+This starts an interactive `tlaps-bench-base` shell with the session mounted at the backend's session path (e.g. `/root/.copilot`), so you can read the transcript or run the agent CLI's own resume command (e.g. `copilot --resume`). The container is removed on exit; the host session directory is not. (Network egress is not firewalled in this debug shell, and no benchmark files are mounted — it is for inspecting/continuing the agent session, not for grading.)
 
 ---
 

--- a/scripts/restore-session.sh
+++ b/scripts/restore-session.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Restore a persisted agent session into a fresh container for debugging.
+#
+# Pair with `tlaps-bench run --session-dir <DIR>`, which writes each run's agent
+# session state to <DIR>/<backend>/<benchmark>/ on the host. This script mounts
+# one of those directories back into a new tlaps-bench-base container at the
+# backend's session path and drops you into an interactive shell, so you can
+# inspect the state or resume the agent CLI — even after the original container
+# was removed or the host was rebooted.
+#
+# Usage:
+#   scripts/restore-session.sh [--backend NAME] [--image IMG] <host-session-dir>
+#
+#   <host-session-dir>   e.g. <DIR>/copilot/my_benchmark  (the dir holding the
+#                        agent's .copilot/.codex/.claude/.pi contents)
+#   --backend NAME       copilot (default) | codex | claude_code | pi
+#                        selects the in-container mount path
+#   --image IMG          container image (default: tlaps-bench-base:latest)
+#
+# Example:
+#   scripts/restore-session.sh --backend copilot ./sessions/copilot/my_benchmark
+#   # then, inside the container:
+#   copilot --resume        # or inspect ~/.copilot directly
+
+set -euo pipefail
+
+BACKEND="copilot"
+IMAGE="tlaps-bench-base:latest"
+SESSION_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --backend) BACKEND="${2:?--backend needs a value}"; shift 2 ;;
+    --image) IMAGE="${2:?--image needs a value}"; shift 2 ;;
+    -h|--help) sed -n '2,25p' "$0"; exit 0 ;;
+    -*) echo "unknown option: $1" >&2; exit 2 ;;
+    *) SESSION_DIR="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$SESSION_DIR" ]]; then
+  echo "ERROR: missing <host-session-dir>. Run '$0 --help'." >&2
+  exit 2
+fi
+if [[ ! -d "$SESSION_DIR" ]]; then
+  echo "ERROR: not a directory: $SESSION_DIR" >&2
+  exit 2
+fi
+
+# Map backend -> in-container session path (matches session_state_dir in
+# src/evaluator/backends/*.py).
+case "$BACKEND" in
+  copilot) CONTAINER_PATH="/root/.copilot" ;;
+  codex) CONTAINER_PATH="/root/.codex" ;;
+  claude_code|claude) CONTAINER_PATH="/root/.claude" ;;
+  pi) CONTAINER_PATH="/root/.pi" ;;
+  *) echo "ERROR: unknown backend '$BACKEND' (copilot|codex|claude_code|pi)" >&2; exit 2 ;;
+esac
+
+SESSION_DIR="$(cd "$SESSION_DIR" && pwd)"
+echo "Restoring $BACKEND session from $SESSION_DIR -> $CONTAINER_PATH in $IMAGE"
+echo "(interactive shell; the container is removed on exit — the host session dir is not)"
+
+exec docker run --rm -it \
+  --platform linux/amd64 \
+  -v "$SESSION_DIR:$CONTAINER_PATH:rw" \
+  "$IMAGE" bash

--- a/src/common/container.py
+++ b/src/common/container.py
@@ -96,6 +96,19 @@ class ContainerConfig:
     memory: str = ""
     cpus: float = 0
     credential_mounts: list[str] = field(default_factory=list)  # host credential dirs to copy+mount
+    # Debugging: retain the container after it exits instead of passing --rm, so
+    # its writable layer (where agent session state like .copilot/.codex lives)
+    # survives for inspection or an interactive resume. container_name gives the
+    # retained container a discoverable `docker` name.
+    keep_container: bool = False
+    container_name: str = ""
+    # Debugging: bind-mount a persistent host directory (NOT a /tmp tempdir) at
+    # session_container_path so the agent's session state is written straight to
+    # the host and survives container removal and reboot. When a credential mount
+    # targets the same path, the credentials are copied into this dir too so a
+    # single mount serves both. Empty session_dir disables this.
+    session_dir: str = ""
+    session_container_path: str = ""
 
 
 @dataclass
@@ -215,11 +228,22 @@ class ContainerRunner:
             "run",
             "--platform",
             "linux/amd64",
-            "--rm",
-            "--init",
-            "-i",
-            f"--cidfile={cid_file}",
         ]
+        if config.keep_container:
+            # Retain the container after exit for debugging. A --name makes it
+            # discoverable (docker start/exec/commit); without --rm its writable
+            # layer, holding the agent's session state, persists.
+            if config.container_name:
+                args.extend(["--name", config.container_name])
+        else:
+            args.append("--rm")
+        args.extend(
+            [
+                "--init",
+                "-i",
+                f"--cidfile={cid_file}",
+            ]
+        )
 
         if config.cpus:
             args.append(f"--cpus={config.cpus}")
@@ -242,16 +266,36 @@ class ContainerRunner:
         # Credential directory mounts. Copy to throwaway tempdirs so agent
         # cannot modify host credentials. Cleaned up after run.
         self._credential_tmps: list[str] = []
+        session_mounted = False
 
         for name in config.credential_mounts:
             mount = self._CREDENTIAL_MOUNTS.get(name)
             if mount is None:
                 raise ValueError(f"unknown credential mount: {name}")
             src = Path.home() / f".{name}"
-            if src.is_dir():
+            if not src.is_dir():
+                continue
+            # When a persistent session dir targets this same path, copy the
+            # credentials INTO it (instead of a throwaway tempdir) so auth and
+            # session state live together on the host and survive a reboot.
+            if config.session_dir and mount.mount_path == config.session_container_path:
+                os.makedirs(config.session_dir, exist_ok=True)
+                with contextlib.suppress(Exception):
+                    mount.copy(src, Path(config.session_dir))
+                args.extend(["-v", f"{config.session_dir}:{mount.mount_path}:rw"])
+                session_mounted = True
+            else:
                 tmp = self._copy_credential_dir(name, src, mount)
                 if tmp:
                     args.extend(["-v", f"{tmp}:{mount.mount_path}:rw"])
+
+        # Persist agent session state to a host dir when no credential mount
+        # already claimed that path (e.g. copilot, or claude/codex on env auth):
+        # survives container removal and host reboot, and can be restored into
+        # another container later.
+        if config.session_dir and config.session_container_path and not session_mounted:
+            os.makedirs(config.session_dir, exist_ok=True)
+            args.extend(["-v", f"{config.session_dir}:{config.session_container_path}:rw"])
 
         # Env vars
         for key, value in config.env.items():

--- a/src/common/container.py
+++ b/src/common/container.py
@@ -96,17 +96,12 @@ class ContainerConfig:
     memory: str = ""
     cpus: float = 0
     credential_mounts: list[str] = field(default_factory=list)  # host credential dirs to copy+mount
-    # Debugging: retain the container after it exits instead of passing --rm, so
-    # its writable layer (where agent session state like .copilot/.codex lives)
-    # survives for inspection or an interactive resume. container_name gives the
-    # retained container a discoverable `docker` name.
+    # Debugging: skip --rm so the container (and the agent session state in its
+    # writable layer) survives exit; container_name makes it discoverable.
     keep_container: bool = False
     container_name: str = ""
-    # Debugging: bind-mount a persistent host directory (NOT a /tmp tempdir) at
-    # session_container_path so the agent's session state is written straight to
-    # the host and survives container removal and reboot. When a credential mount
-    # targets the same path, the credentials are copied into this dir too so a
-    # single mount serves both. Empty session_dir disables this.
+    # Debugging: bind-mount this persistent host dir at session_container_path
+    # so agent session state survives container removal and host reboot.
     session_dir: str = ""
     session_container_path: str = ""
 
@@ -230,9 +225,6 @@ class ContainerRunner:
             "linux/amd64",
         ]
         if config.keep_container:
-            # Retain the container after exit for debugging. A --name makes it
-            # discoverable (docker start/exec/commit); without --rm its writable
-            # layer, holding the agent's session state, persists.
             if config.container_name:
                 args.extend(["--name", config.container_name])
         else:
@@ -275,9 +267,8 @@ class ContainerRunner:
             src = Path.home() / f".{name}"
             if not src.is_dir():
                 continue
-            # When a persistent session dir targets this same path, copy the
-            # credentials INTO it (instead of a throwaway tempdir) so auth and
-            # session state live together on the host and survive a reboot.
+            # Session dir targets this path: copy credentials into it (not a
+            # throwaway tempdir) so auth and session state persist together.
             if config.session_dir and mount.mount_path == config.session_container_path:
                 os.makedirs(config.session_dir, exist_ok=True)
                 with contextlib.suppress(Exception):
@@ -289,10 +280,7 @@ class ContainerRunner:
                 if tmp:
                     args.extend(["-v", f"{tmp}:{mount.mount_path}:rw"])
 
-        # Persist agent session state to a host dir when no credential mount
-        # already claimed that path (e.g. copilot, or claude/codex on env auth):
-        # survives container removal and host reboot, and can be restored into
-        # another container later.
+        # Mount the session dir when no credential mount already claimed its path.
         if config.session_dir and config.session_container_path and not session_mounted:
             os.makedirs(config.session_dir, exist_ok=True)
             args.extend(["-v", f"{config.session_dir}:{config.session_container_path}:rw"])

--- a/src/evaluator/backends/base.py
+++ b/src/evaluator/backends/base.py
@@ -131,10 +131,8 @@ class AgentBackend(ABC):
     install_script: str | None = None  # run at container start (e.g. "install-codex.sh")
     env_keys: list[str] = []  # host env vars to forward into container
     credential_mounts: list[str] = []  # host credential dirs to copy into agent containers
-    # Container path holding this backend's agent session state (conversation /
-    # resumable session files). --session-dir bind-mounts a persistent host
-    # directory here so the state survives container removal and host reboot.
-    # None means the backend keeps no separate session dir (e.g. litellm).
+    # Container path holding this backend's session state; --session-dir mounts
+    # a persistent host dir here. None = no session dir (e.g. litellm).
     session_state_dir: str | None = None
 
     def get_credential_mounts(self) -> list[str]:

--- a/src/evaluator/backends/base.py
+++ b/src/evaluator/backends/base.py
@@ -131,6 +131,11 @@ class AgentBackend(ABC):
     install_script: str | None = None  # run at container start (e.g. "install-codex.sh")
     env_keys: list[str] = []  # host env vars to forward into container
     credential_mounts: list[str] = []  # host credential dirs to copy into agent containers
+    # Container path holding this backend's agent session state (conversation /
+    # resumable session files). --session-dir bind-mounts a persistent host
+    # directory here so the state survives container removal and host reboot.
+    # None means the backend keeps no separate session dir (e.g. litellm).
+    session_state_dir: str | None = None
 
     def get_credential_mounts(self) -> list[str]:
         """Credential directories this backend needs mounted for the current run."""

--- a/src/evaluator/backends/claude_code.py
+++ b/src/evaluator/backends/claude_code.py
@@ -22,6 +22,7 @@ DEFAULT_MODEL = "claude-opus-4-8"
 class ClaudeCodeBackend(AgentBackend):
     name = "claude_code"
     install_script = "install-claudecode.sh"
+    session_state_dir = "/root/.claude"
     env_keys = [
         "ANTHROPIC_API_KEY",
         "CLAUDE_CODE_USE_BEDROCK",

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -37,6 +37,7 @@ _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..",
 class CodexBackend(AgentBackend):
     name = "codex"
     install_script = "install-codex.sh"
+    session_state_dir = "/root/.codex"
     env_keys = [
         "OPENAI_API_KEY",
         "AZURE_OPENAI_API_KEY",

--- a/src/evaluator/backends/copilot.py
+++ b/src/evaluator/backends/copilot.py
@@ -14,6 +14,7 @@ DEFAULT_MODEL = "claude-opus-4.8"
 class CopilotBackend(AgentBackend):
     name = "copilot"
     install_script = "install-copilot.sh"
+    session_state_dir = "/root/.copilot"
     env_keys = [
         "COPILOT_GITHUB_TOKEN",
         "GH_TOKEN",

--- a/src/evaluator/backends/pi.py
+++ b/src/evaluator/backends/pi.py
@@ -21,6 +21,7 @@ DEFAULT_MODEL = "openai/gpt-5.5"
 class PiBackend(AgentBackend):
     name = "pi"
     install_script = "install-pi.sh"
+    session_state_dir = "/root/.pi"
     env_keys = [
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_OAUTH_TOKEN",

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -839,6 +839,28 @@ def _run_continuations(
             break
 
 
+def _resolve_session_dir(session_dir_arg: str | None, keep_container: bool, use_container: bool) -> str:
+    """Root dir for persisted agent session state: explicit --session-dir, or a
+    default under --keep-container so debugging needs a single flag. "" = off."""
+    if not use_container:
+        return ""
+    if session_dir_arg:
+        return os.path.abspath(session_dir_arg)
+    if keep_container:
+        return os.path.expanduser(os.path.join("~", ".tlaps-bench", "sessions"))
+    return ""
+
+
+def _prepare_session_dir(session_dir: str) -> None:
+    """Create the session root and, since session data can hold credentials,
+    guard the tree with a .gitignore in case it lands inside a git repo."""
+    os.makedirs(session_dir, exist_ok=True)
+    gitignore = os.path.join(session_dir, ".gitignore")
+    if not os.path.exists(gitignore):
+        with open(gitignore, "w") as f:
+            f.write("# tlaps-bench session data (may contain credentials) — do not commit\n*\n")
+
+
 def _run_agent_container(
     item: WorkItem,
     backend,
@@ -871,8 +893,10 @@ def _run_agent_container(
         # uuid suffix keeps retained containers unique across retries and jobs
         config.container_name = f"tlaps-bench-{safe}-{uuid.uuid4().hex[:8]}"
     if item.session_dir and backend.session_state_dir:
-        # Stable path (no uuid) so retries/continuations resume the same session.
-        host_session = os.path.join(item.session_dir, backend.name, safe)
+        # A retained container keys its session by container name (each kept
+        # container ↔ its own dir); otherwise by benchmark, so retries and
+        # continuations resume the same session.
+        host_session = os.path.join(item.session_dir, backend.name, config.container_name or safe)
         config.session_dir = host_session
         config.session_container_path = backend.session_state_dir
         print(
@@ -1311,16 +1335,19 @@ def main():
         action="store_true",
         help="Retain each agent's Docker container after it exits (drop --rm) so its "
         "writable layer — where the agent's session state lives — survives for "
-        "inspection or an interactive resume. Prints the container name to reattach "
-        "with. Container mode only; remember to `docker rm` the containers when done.",
+        "inspection or an interactive resume. Also persists session state to "
+        "~/.tlaps-bench/sessions by default (override with --session-dir). Prints the "
+        "container name to reattach with. Container mode only; remember to "
+        "`docker rm` the containers when done.",
     )
     parser.add_argument(
         "--session-dir",
         default=None,
-        help="Persist each run's agent session state to a subdirectory of this "
-        "PERSISTENT host path (instead of a /tmp tempdir that a reboot clears), so "
-        "it survives container removal and reboot and can be restored into another "
-        "container with scripts/restore-session.sh. Container mode only.",
+        help="Persist each run's agent session state under this PERSISTENT host path "
+        "(default ~/.tlaps-bench/sessions when --keep-container is set) instead of a "
+        "/tmp tempdir that a reboot clears, so it survives container removal and reboot "
+        "and can be restored into another container with scripts/restore-session.sh. "
+        "Container mode only.",
     )
     parser.add_argument(
         "--force-build",
@@ -1350,9 +1377,9 @@ def main():
     if args.session_dir and not use_container:
         print("WARNING: --session-dir has no effect with --no-container (no container to mount into)")
 
-    session_dir = os.path.abspath(args.session_dir) if (args.session_dir and use_container) else ""
+    session_dir = _resolve_session_dir(args.session_dir, args.keep_container, use_container)
     if session_dir:
-        os.makedirs(session_dir, exist_ok=True)
+        _prepare_session_dir(session_dir)
 
     if use_container:
         # In container mode, tlapm and checker are inside the image.

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -253,13 +253,9 @@ class WorkItem:
     # workspace so it builds on its own partial proof (see _run_continuations).
     # 0 disables. pass@1 (check_verdict) is unaffected either way.
     max_continuations: int = 0
-    # Debugging: retain each agent container (drop --rm) so its writable layer,
-    # holding the agent's session state, survives for inspection/resume.
+    # Debugging: retain each agent container (drop --rm) for inspection/resume.
     keep_container: bool = False
-    # Debugging: persistent host directory under which each run's agent session
-    # state is bind-mounted (instead of a /tmp tempdir), so it survives container
-    # removal and host reboot and can be restored into another container. Empty
-    # disables it. Only used in container mode.
+    # Debugging: persistent host dir for agent session state ("" = off).
     session_dir: str = ""
 
 
@@ -872,15 +868,10 @@ def _run_agent_container(
     name_no_ext = os.path.splitext(os.path.basename(item.benchmark_path))[0]
     safe = re.sub(r"[^A-Za-z0-9_.-]", "_", name_no_ext)
     if item.keep_container:
-        # uuid suffix keeps the name unique across retries, continuations and
-        # parallel jobs, so a retained container never collides with a new run.
+        # uuid suffix keeps retained containers unique across retries and jobs
         config.container_name = f"tlaps-bench-{safe}-{uuid.uuid4().hex[:8]}"
     if item.session_dir and backend.session_state_dir:
-        # Persist this benchmark's agent session state to a stable host path
-        # (per backend + benchmark) so it survives container removal / reboot
-        # and can be restored into another container. Stable (no uuid) so an
-        # infra retry or continuation round resumes the same session.
-        # build_docker_args creates the directory.
+        # Stable path (no uuid) so retries/continuations resume the same session.
         host_session = os.path.join(item.session_dir, backend.name, safe)
         config.session_dir = host_session
         config.session_container_path = backend.session_state_dir
@@ -972,9 +963,8 @@ def _run_agent_container(
         if container_run:
             runner.kill(container_run)
     finally:
-        # Keep the credential bind-mount sources when retaining the container so
-        # a `docker start` can still authenticate; otherwise remove the throwaway
-        # copies as usual.
+        # A retained container keeps its credential mount sources so a
+        # `docker start` can still authenticate.
         if not item.keep_container:
             runner.cleanup_credential_tmps()
 

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -29,6 +29,7 @@ import sys
 import tempfile
 import threading
 import time
+import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 
@@ -252,6 +253,14 @@ class WorkItem:
     # workspace so it builds on its own partial proof (see _run_continuations).
     # 0 disables. pass@1 (check_verdict) is unaffected either way.
     max_continuations: int = 0
+    # Debugging: retain each agent container (drop --rm) so its writable layer,
+    # holding the agent's session state, survives for inspection/resume.
+    keep_container: bool = False
+    # Debugging: persistent host directory under which each run's agent session
+    # state is bind-mounted (instead of a /tmp tempdir), so it survives container
+    # removal and host reboot and can be restored into another container. Empty
+    # disables it. Only used in container mode.
+    session_dir: str = ""
 
 
 def _make_canonical_dir(name_no_ext: str, benchmark_path: str, basename: str, deps: list[str]) -> str:
@@ -858,7 +867,28 @@ def _run_agent_container(
         firewall_hosts=backend.firewall_hosts(),
         install_script=backend.install_script,
         credential_mounts=backend.get_credential_mounts(),
+        keep_container=item.keep_container,
     )
+    name_no_ext = os.path.splitext(os.path.basename(item.benchmark_path))[0]
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", name_no_ext)
+    if item.keep_container:
+        # uuid suffix keeps the name unique across retries, continuations and
+        # parallel jobs, so a retained container never collides with a new run.
+        config.container_name = f"tlaps-bench-{safe}-{uuid.uuid4().hex[:8]}"
+    if item.session_dir and backend.session_state_dir:
+        # Persist this benchmark's agent session state to a stable host path
+        # (per backend + benchmark) so it survives container removal / reboot
+        # and can be restored into another container. Stable (no uuid) so an
+        # infra retry or continuation round resumes the same session.
+        # build_docker_args creates the directory.
+        host_session = os.path.join(item.session_dir, backend.name, safe)
+        config.session_dir = host_session
+        config.session_container_path = backend.session_state_dir
+        print(
+            f"[session-dir] persisting {backend.name} session state for '{name_no_ext}' "
+            f"to {host_session} (restore with scripts/restore-session.sh)",
+            flush=True,
+        )
     if canonical_dir:
         config.env["TLAPS_BENCHMARK_DIR"] = "/benchmark"
     # Self-check uses the SAME tlapm budget as the grader (item.check_timeout),
@@ -870,6 +900,15 @@ def _run_agent_container(
     container_run = None
     try:
         container_run = runner.run(config, cmd, stdin_data=prompt)
+        if item.keep_container:
+            name = config.container_name
+            print(
+                f"[keep-container] retaining container '{name}'. After it exits: "
+                f"`docker exec -it {name} bash` to inspect (start it first if stopped: "
+                f"`docker start {name}`), `docker commit {name} <img>` to snapshot, "
+                f"`docker rm -f {name}` to remove.",
+                flush=True,
+            )
         proc = container_run.proc
         assert proc.stdout is not None  # Popen created with stdout=PIPE
 
@@ -933,7 +972,11 @@ def _run_agent_container(
         if container_run:
             runner.kill(container_run)
     finally:
-        runner.cleanup_credential_tmps()
+        # Keep the credential bind-mount sources when retaining the container so
+        # a `docker start` can still authenticate; otherwise remove the throwaway
+        # copies as usual.
+        if not item.keep_container:
+            runner.cleanup_credential_tmps()
 
 
 def _run_agent_local(
@@ -1274,6 +1317,22 @@ def main():
         help="Run agent locally instead of inside a Docker container",
     )
     parser.add_argument(
+        "--keep-container",
+        action="store_true",
+        help="Retain each agent's Docker container after it exits (drop --rm) so its "
+        "writable layer — where the agent's session state lives — survives for "
+        "inspection or an interactive resume. Prints the container name to reattach "
+        "with. Container mode only; remember to `docker rm` the containers when done.",
+    )
+    parser.add_argument(
+        "--session-dir",
+        default=None,
+        help="Persist each run's agent session state to a subdirectory of this "
+        "PERSISTENT host path (instead of a /tmp tempdir that a reboot clears), so "
+        "it survives container removal and reboot and can be restored into another "
+        "container with scripts/restore-session.sh. Container mode only.",
+    )
+    parser.add_argument(
         "--force-build",
         action="store_true",
         help="Force rebuild the Docker base image before running",
@@ -1295,6 +1354,15 @@ def main():
 
     # Container mode is default; --no-container disables it
     use_container = not args.no_container
+
+    if args.keep_container and not use_container:
+        print("WARNING: --keep-container has no effect with --no-container (no container to retain)")
+    if args.session_dir and not use_container:
+        print("WARNING: --session-dir has no effect with --no-container (no container to mount into)")
+
+    session_dir = os.path.abspath(args.session_dir) if (args.session_dir and use_container) else ""
+    if session_dir:
+        os.makedirs(session_dir, exist_ok=True)
 
     if use_container:
         # In container mode, tlapm and checker are inside the image.
@@ -1428,6 +1496,8 @@ def main():
                 use_container=use_container,
                 infra_retries=args.infra_retries,
                 max_continuations=args.max_continuations,
+                keep_container=use_container and args.keep_container,
+                session_dir=session_dir,
             )
         )
 

--- a/tests/evaluator/test_container.py
+++ b/tests/evaluator/test_container.py
@@ -29,6 +29,80 @@ class TestBuildDockerArgs:
         assert not any(a.startswith("--memory=") for a in args)
         assert not any(a.startswith("--cpus=") for a in args)
 
+    def test_keep_container_drops_rm_and_names_container(self):
+        runner = ContainerRunner()
+        config = ContainerConfig(keep_container=True, container_name="tlaps-bench-foo-abc123")
+        args, _ = runner.build_docker_args(config)
+
+        # --rm removed so the container survives exit; --name makes it discoverable.
+        assert "--rm" not in args
+        assert "--name" in args
+        assert args[args.index("--name") + 1] == "tlaps-bench-foo-abc123"
+
+    def test_keep_container_without_name_omits_name_flag(self):
+        runner = ContainerRunner()
+        config = ContainerConfig(keep_container=True)
+        args, _ = runner.build_docker_args(config)
+
+        assert "--rm" not in args
+        assert "--name" not in args
+
+    def test_name_not_set_by_default(self):
+        runner = ContainerRunner()
+        config = ContainerConfig()
+        args, _ = runner.build_docker_args(config)
+
+        assert "--rm" in args
+        assert "--name" not in args
+
+    def test_session_dir_mounts_for_backend_without_credential_mount(self, tmp_path):
+        # copilot-style: no credential mount, so the persistent session dir is
+        # bind-mounted directly at the backend's session path (and created).
+        session_dir = tmp_path / "sessions" / "copilot" / "bench1"
+        runner = ContainerRunner()
+        config = ContainerConfig(session_dir=str(session_dir), session_container_path="/root/.copilot")
+        args, _ = runner.build_docker_args(config)
+
+        mount_args = [args[i + 1] for i, a in enumerate(args) if a == "-v"]
+        assert f"{session_dir}:/root/.copilot:rw" in mount_args
+        assert session_dir.is_dir()
+
+    def test_session_dir_merges_credentials_into_single_persistent_mount(self, tmp_path):
+        # claude-style: session path == credential mount path. Credentials must be
+        # copied INTO the persistent session dir (not a throwaway tempdir) and the
+        # path mounted exactly once, so auth + session state persist together.
+        claude_home = tmp_path / ".claude"
+        claude_home.mkdir()
+        (claude_home / ".credentials.json").write_text('{"claudeAiOauth": {"accessToken": "secret"}}\n')
+        session_dir = tmp_path / "sessions" / "claude_code" / "bench1"
+
+        runner = ContainerRunner()
+        config = ContainerConfig(
+            credential_mounts=["claude"],
+            session_dir=str(session_dir),
+            session_container_path="/root/.claude",
+        )
+        try:
+            with patch("common.container.Path.home", return_value=tmp_path):
+                args, _ = runner.build_docker_args(config)
+
+            mount_args = [args[i + 1] for i, a in enumerate(args) if a == "-v"]
+            claude_mounts = [m for m in mount_args if m.endswith(":/root/.claude:rw")]
+            assert claude_mounts == [f"{session_dir}:/root/.claude:rw"]
+            assert (session_dir / ".credentials.json").exists()
+            # persistent, so it is never queued for cleanup
+            assert runner._credential_tmps == []
+        finally:
+            runner.cleanup_credential_tmps()
+
+    def test_no_session_mount_by_default(self):
+        runner = ContainerRunner()
+        config = ContainerConfig(workspace="/tmp/ws")
+        args, _ = runner.build_docker_args(config)
+
+        mount_args = [args[i + 1] for i, a in enumerate(args) if a == "-v"]
+        assert not any(m.endswith(":/root/.copilot:rw") for m in mount_args)
+
     def test_workspace_mount(self):
         runner = ContainerRunner()
         config = ContainerConfig(workspace="/tmp/ws")
@@ -414,3 +488,56 @@ class TestRunPreflight:
         config = ContainerConfig(firewall_hosts=["api.githubcopilot.com"])
         with pytest.raises(RuntimeError, match="preflight failed"):
             runner.run_preflight(config, ["copilot"], "say ok")
+
+
+class TestRunAgentContainerSessionWiring:
+    """_run_agent_container composes keep_container / session_dir onto the config."""
+
+    def _capture_config(self, tmp_path, *, keep_container=False, session_dir=""):
+        from evaluator import runner as runner_mod
+
+        backend = CopilotBackend()
+        item = MagicMock(
+            benchmark_path=str(tmp_path / "My-Bench.tla"),
+            timeout=0,
+            check_timeout=600,
+            keep_container=keep_container,
+            session_dir=session_dir,
+        )
+        captured = {}
+
+        class _FakeRunner:
+            def run(self, config, cmd, stdin_data=None):
+                captured["config"] = config
+                raise RuntimeError("stop after capture")  # short-circuit the stream loop
+
+            def kill(self, run):
+                pass
+
+            def cleanup_credential_tmps(self):
+                pass
+
+        result: dict = {}
+        with patch.object(runner_mod, "ContainerRunner", _FakeRunner):
+            runner_mod._run_agent_container(
+                item, backend, str(tmp_path / "ws"), str(tmp_path / "agent"),
+                str(tmp_path / "agent.jsonl"), "prompt", result,
+            )
+        return captured["config"]
+
+    def test_session_dir_sets_per_benchmark_path_and_container_path(self, tmp_path):
+        session_root = tmp_path / "sessions"
+        config = self._capture_config(tmp_path, session_dir=str(session_root))
+        # <root>/<backend>/<sanitized-benchmark>; build_docker_args creates it
+        assert config.session_dir == str(session_root / "copilot" / "My-Bench")
+        assert config.session_container_path == "/root/.copilot"
+
+    def test_no_session_dir_leaves_config_empty(self, tmp_path):
+        config = self._capture_config(tmp_path, session_dir="")
+        assert config.session_dir == ""
+        assert config.session_container_path == ""
+
+    def test_keep_container_names_container(self, tmp_path):
+        config = self._capture_config(tmp_path, keep_container=True)
+        assert config.keep_container is True
+        assert config.container_name.startswith("tlaps-bench-My-Bench-")

--- a/tests/evaluator/test_container.py
+++ b/tests/evaluator/test_container.py
@@ -525,12 +525,19 @@ class TestRunAgentContainerSessionWiring:
             )
         return captured["config"]
 
-    def test_session_dir_sets_per_benchmark_path_and_container_path(self, tmp_path):
+    def test_session_dir_keyed_by_benchmark_without_keep_container(self, tmp_path):
         session_root = tmp_path / "sessions"
         config = self._capture_config(tmp_path, session_dir=str(session_root))
         # <root>/<backend>/<sanitized-benchmark>; build_docker_args creates it
         assert config.session_dir == str(session_root / "copilot" / "My-Bench")
         assert config.session_container_path == "/root/.copilot"
+
+    def test_session_dir_keyed_by_container_name_with_keep_container(self, tmp_path):
+        session_root = tmp_path / "sessions"
+        config = self._capture_config(tmp_path, session_dir=str(session_root), keep_container=True)
+        # Each retained container gets its own session dir, keyed by its name.
+        assert config.session_dir == str(session_root / "copilot" / config.container_name)
+        assert config.container_name.startswith("tlaps-bench-My-Bench-")
 
     def test_no_session_dir_leaves_config_empty(self, tmp_path):
         config = self._capture_config(tmp_path, session_dir="")
@@ -541,3 +548,49 @@ class TestRunAgentContainerSessionWiring:
         config = self._capture_config(tmp_path, keep_container=True)
         assert config.keep_container is True
         assert config.container_name.startswith("tlaps-bench-My-Bench-")
+
+
+class TestResolveSessionDir:
+    def test_explicit_session_dir_wins(self, tmp_path):
+        from evaluator.runner import _resolve_session_dir
+
+        got = _resolve_session_dir(str(tmp_path / "s"), keep_container=False, use_container=True)
+        assert got == str(tmp_path / "s")
+
+    def test_keep_container_defaults_to_home_dir(self):
+        from evaluator.runner import _resolve_session_dir
+
+        got = _resolve_session_dir(None, keep_container=True, use_container=True)
+        assert got == os.path.expanduser("~/.tlaps-bench/sessions")
+
+    def test_off_without_keep_or_explicit(self):
+        from evaluator.runner import _resolve_session_dir
+
+        assert _resolve_session_dir(None, keep_container=False, use_container=True) == ""
+
+    def test_off_without_container(self, tmp_path):
+        from evaluator.runner import _resolve_session_dir
+
+        assert _resolve_session_dir(str(tmp_path), keep_container=True, use_container=False) == ""
+
+
+class TestPrepareSessionDir:
+    def test_creates_dir_and_gitignore_star(self, tmp_path):
+        from evaluator.runner import _prepare_session_dir
+
+        session = tmp_path / "sessions"
+        _prepare_session_dir(str(session))
+        gitignore = session / ".gitignore"
+        assert session.is_dir()
+        # `*` ignores the whole tree so credential-bearing session data can't be
+        # accidentally committed.
+        assert "*" in gitignore.read_text().splitlines()
+
+    def test_does_not_overwrite_existing_gitignore(self, tmp_path):
+        from evaluator.runner import _prepare_session_dir
+
+        session = tmp_path / "sessions"
+        session.mkdir()
+        (session / ".gitignore").write_text("custom\n")
+        _prepare_session_dir(str(session))
+        assert (session / ".gitignore").read_text() == "custom\n"


### PR DESCRIPTION
Closes #44

What this does:

Right now every agent container runs with a hardcoded `--rm`, so the moment a benchmark finishes or crashes, or gets interrupted, the container is gone and the agent's session state goes with it.

This PR adds two flags to fix that:

**`--keep-container`**: keeps the container around after the run instead of deleting it. Each container gets a unique, readable name like `tlaps-bench-<benchmark>-<uuid8>`, and the runner prints exactly how to get back in (`docker start` + `docker exec`). Credential mounts are kept too, so a restarted container can still authenticate.

**`--session-dir <path>`**: saves the agent's session state to a normal folder on the host (`<path>/<backend>/<benchmark>/`). This covers the reboot case from the issue too. Previously the session state for codex/claude/pi sat in a `/tmp` tempdir, which a reboot wipes. Now it's written to a persistent host folder, so it survives reboots, container removal, and `docker system prune`.

There's also a small helper, `scripts/restore-session.sh`, that mounts a saved session back into a fresh container so we can inspect it or resume the agent (e.g. `copilot --resume`).

Note:
Nothing changes for normal runs, without these flags the docker args are exactly the same as before.