### PR TITLE
Fix duplicate results when resuming runs

### DIFF
--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -476,6 +476,11 @@ def _resume_done_benchmarks(results: list[dict]) -> set[str]:
     return {r["benchmark"] for r in results if _resume_should_skip(r)}
 
 
+def _total_benchmark_count(results: list[dict], selected_benchmarks: set[str]) -> int:
+    """Count unique benchmarks in the cumulative results and current selection."""
+    return len(selected_benchmarks | {result["benchmark"] for result in results})
+
+
 def _continuation_note(result: dict) -> str:
     """One-phrase outcome of a result's continuation rounds ("" without any):
     the round that recovered a PASS, a chain infra/quota-cut before resolving,
@@ -1510,9 +1515,11 @@ def main():
         else:
             print(f"Resume: no prior results.json in {output_dir} — running all")
 
+    selected_benchmarks = set()
     work_items = []
     for bf in benchmark_files:
         rel = os.path.relpath(bf, mode.benchmark_dir())
+        selected_benchmarks.add(rel)
         if rel in done_pass:
             continue
         work_items.append(
@@ -1539,7 +1546,9 @@ def main():
         )
 
     start_time = time.time()
-    total_benchmarks = len(benchmark_files)
+    # A filtered resume keeps results from the rest of the original run, so
+    # the cumulative report's denominator must cover both sets of benchmarks.
+    total_benchmarks = _total_benchmark_count(results, selected_benchmarks)
     prior_done = total_benchmarks - len(work_items)
     if args.resume:
         print(f"Resume: {len(work_items)} benchmarks left to run")

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -461,6 +461,17 @@ def _resume_should_skip(result: dict) -> bool:
     return is_skipped(result) or (is_pass_with_continuations(result) and not is_non_genuine(result))
 
 
+def _record_result(results: list[dict], new_result: dict) -> None:
+    """Record a benchmark's latest result, replacing previous attempts.
+
+    Resume reruns a benchmark in the same output directory. Its new result
+    replaces the previous attempt instead of becoming a second scored task.
+    """
+    benchmark = new_result["benchmark"]
+    results[:] = [result for result in results if result.get("benchmark") != benchmark]
+    results.append(new_result)
+
+
 def _resume_done_benchmarks(results: list[dict]) -> set[str]:
     return {r["benchmark"] for r in results if _resume_should_skip(r)}
 
@@ -1476,7 +1487,9 @@ def main():
         prev_json = os.path.join(output_dir, "results.json")
         if os.path.isfile(prev_json):
             with open(prev_json) as f:
-                results = json.load(f)
+                previous_results = json.load(f)
+            for previous_result in previous_results:
+                _record_result(results, previous_result)
             # Skip genuine PASS (already done) and SKIP (operator-marked
             # frontier benchmarks deliberately excluded from retry). A PASS
             # produced by INFRA_ERROR / QUOTA_EXHAUSTED is non-genuine and must
@@ -1527,14 +1540,14 @@ def main():
 
     start_time = time.time()
     total_benchmarks = len(benchmark_files)
-    prior_done = len(results)
+    prior_done = total_benchmarks - len(work_items)
     if args.resume:
         print(f"Resume: {len(work_items)} benchmarks left to run")
 
     if args.jobs == 1:
         for i, item in enumerate(work_items):
             r = run_single_benchmark(item)
-            results.append(r)
+            _record_result(results, r)
             icon = VERDICT_ICONS.get(r["check_verdict"], "❓")
             tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
             cont = _continuation_note(r)
@@ -1548,7 +1561,7 @@ def main():
             futures = {executor.submit(run_single_benchmark, item): item for item in work_items}
             for done_count, future in enumerate(as_completed(futures), start=1):
                 r = future.result()
-                results.append(r)
+                _record_result(results, r)
                 icon = VERDICT_ICONS.get(r["check_verdict"], "❓")
                 tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
                 cont = _continuation_note(r)

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -173,6 +173,27 @@ def test_resume_does_not_skip_non_genuine_pass_results():
     assert runner._resume_done_benchmarks(results) == {"genuine-pass.tla", "legacy-pass.tla", "skipped.tla"}
 
 
+def test_resumed_result_replaces_non_genuine_attempt(tmp_path):
+    results = [
+        _result("already-passed.tla", "PASS"),
+        _result("retry.tla", "ERROR", termination_reason=TerminationReason.INFRA_ERROR),
+    ]
+
+    runner._record_result(results, _result("retry.tla", "PASS"))
+    runner.update_summary(
+        results, str(tmp_path), total_benchmarks=2, backend_name="copilot", mode_name="proof-completion"
+    )
+
+    assert [(r["benchmark"], r["check_verdict"]) for r in results] == [
+        ("already-passed.tla", "PASS"),
+        ("retry.tla", "PASS"),
+    ]
+    summary = (tmp_path / "summary.md").read_text()
+    assert "**Progress**: 2/2" in summary
+    assert "**Pass rate**: 2/2 (100.0%)" in summary
+    assert json.loads((tmp_path / "results.json").read_text()) == results
+
+
 def test_make_workspace_cleans_up_on_setup_failure(tmp_path, monkeypatch):
     # The temp dir must not leak when workspace setup dies half-way (disk full,
     # unreadable dep) — same guarantee _make_canonical_dir gives.

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -180,8 +180,13 @@ def test_resumed_result_replaces_non_genuine_attempt(tmp_path):
     ]
 
     runner._record_result(results, _result("retry.tla", "PASS"))
+    total_benchmarks = runner._total_benchmark_count(results, {"retry.tla"})
     runner.update_summary(
-        results, str(tmp_path), total_benchmarks=2, backend_name="copilot", mode_name="proof-completion"
+        results,
+        str(tmp_path),
+        total_benchmarks=total_benchmarks,
+        backend_name="copilot",
+        mode_name="proof-completion",
     )
 
     assert [(r["benchmark"], r["check_verdict"]) for r in results] == [
@@ -192,6 +197,60 @@ def test_resumed_result_replaces_non_genuine_attempt(tmp_path):
     assert "**Progress**: 2/2" in summary
     assert "**Pass rate**: 2/2 (100.0%)" in summary
     assert json.loads((tmp_path / "results.json").read_text()) == results
+
+
+def test_total_benchmark_count_includes_new_filtered_benchmark():
+    results = [_result("already-recorded.tla", "PASS")]
+
+    assert runner._total_benchmark_count(results, {"newly-selected.tla"}) == 2
+
+
+def test_filtered_resume_keeps_cumulative_progress_total(tmp_path, monkeypatch):
+    bench_dir = tmp_path / "bench"
+    retry = bench_dir / "Suite" / "retry.tla"
+    retry.parent.mkdir(parents=True)
+    retry.write_text(BENCH_TEXT)
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    previous_results = [
+        _result("Suite/already-passed.tla", "PASS"),
+        _result("Suite/retry.tla", "PASS"),
+    ]
+    (output_dir / "results.json").write_text(json.dumps(previous_results))
+
+    backend = _ScriptedBackend()
+    mode = _FakeMode(str(bench_dir))
+    mode.description = "test mode"
+    mode.get_benchmark_files = lambda filter_pattern: [str(retry)]
+    monkeypatch.setattr(backend, "check_auth", lambda: None, raising=False)
+    monkeypatch.setattr(backend, "default_quota", lambda: (0, 0), raising=False)
+    monkeypatch.setattr(backend, "usage_script", lambda: None, raising=False)
+    monkeypatch.setattr(runner, "get_backend", lambda *args, **kwargs: backend)
+    monkeypatch.setattr(runner, "ensure_tlapm", lambda: None)
+    monkeypatch.setattr(runner, "find_tlapm_lib", lambda tlapm_bin: "/tmp/tlapm-lib")
+    monkeypatch.setattr(runner, "resolve_paths", lambda: (str(tmp_path), "/bin/true"))
+    monkeypatch.setattr(runner, "get_mode", lambda *args: mode)
+    monkeypatch.setattr(
+        runner.sys,
+        "argv",
+        [
+            "tlaps-bench-run",
+            "--no-container",
+            "--resume",
+            "--filter",
+            "retry.tla",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    runner.main()
+
+    summary = (output_dir / "summary.md").read_text()
+    assert "**Progress**: 2/2" in summary
+    assert "**Progress**: 2/1" not in summary
+    assert json.loads((output_dir / "results.json").read_text()) == previous_results
 
 
 def test_make_workspace_cleans_up_on_setup_failure(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fix `--resume` so rerun results replace the previous result for the same benchmark instead of creating duplicate rows. This prevents incorrect scoring and progress from exceeding the total. Existing duplicates are normalized by keeping the latest result.

Resume eligibility remains unchanged.