### PR TITLE
Rename mutex example and link results website

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -60,9 +60,11 @@ Ivy liveness examples  —  benchmark groups prefixed `ivy_examples_`
     (https://github.com/kenmcmil/ivy, examples/liveness/, MIT).
     Copyright (c) Microsoft Corporation.
 
-Anvil  —  MIT  —  benchmark group AnvilLock
-    TLA+ model of the lock demo (src/tla_demo.rs) from the Anvil framework for
-    building formally verified Kubernetes controllers.
+two_thread_mutex  —  MIT  —  benchmark group two_thread_mutex
+    TLA+ model of src/tla_demo.rs from the Anvil repository
+    (https://github.com/anvil-verifier/anvil), a standalone two-thread
+    mutual-exclusion example included there to illustrate TLA+ usage. It is not
+    part of Anvil's verified Kubernetes-controller proofs.
     Copyright 2022 VMware, Inc.
 
 etcd / Specula  —  benchmark group etcd_raft

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 A benchmark for evaluating AI's ability to write [TLAPS](https://proofs.tlaplus.net/doc/) (TLA+ Proof System) proofs.
 
+Benchmark results are available on the [TLAPS-Bench website](https://specula-org.github.io/tlaps-bench-website/).
+
 ## Overview
 
 TLAPS proofs are checked mechanically by `tlapm`: a proof is either accepted or
@@ -48,7 +50,7 @@ can be derived.
 | [etcd (Specula)](https://github.com/specula-org) | 1 | – | 8 | 8 |
 | [OpenAddressing](https://github.com/lemmy/Examples) | 1 | 1 | 5 | 6 |
 | AbstractRaft | 1 | – | 4 | 4 |
-| [Anvil](https://github.com/anvil-verifier/anvil) | 1 | – | 1 | 1 |
+| [two_thread_mutex (Anvil)](https://github.com/anvil-verifier/anvil/blob/main/src/tla_demo.rs) | 1 | – | 1 | 1 |
 | **Subtotal** | **12** | **1** | **48** | **49** |
 
 **71 examples, 714 tasks in total.** A per-example breakdown is in

--- a/benchmark/proof-from-scratch/two_thread_mutex/two_thread_mutex_Liveness.tla
+++ b/benchmark/proof-from-scratch/two_thread_mutex/two_thread_mutex_Liveness.tla
@@ -1,4 +1,4 @@
------------------------------ MODULE AnvilLock_Liveness -----------------------------
+-------------------------- MODULE two_thread_mutex_Liveness -------------------------
 EXTENDS TLAPS
 
 VARIABLES lock, threads

--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -20,7 +20,6 @@ This file is generated; regenerate it with `python3 scripts/dataset_table.py`.
 | Example | Source | Proof completion | Proof from scratch | Total |
 |---|---|--:|--:|--:|
 | AbstractRaft | AbstractRaft | – | 4 | 4 |
-| [AnvilLock](https://github.com/anvil-verifier/anvil/blob/main/src/tla_demo.rs) | Anvil | – | 1 | 1 |
 | [hybrid_reliable_broadcast_cisa](https://github.com/kenmcmil/ivy/blob/master/examples/liveness/hybrid_reliable_broadcast_cisa.ivy) | Ivy liveness | – | 3 | 3 |
 | [alternating_bit_protocol](https://github.com/kenmcmil/ivy/blob/master/examples/liveness/alternating_bit_protocol.ivy) | Ivy liveness | – | 2 | 2 |
 | [ticket](https://github.com/kenmcmil/ivy/blob/master/examples/liveness/ticket.ivy) | Ivy liveness | – | 2 | 2 |
@@ -90,5 +89,6 @@ This file is generated; regenerate it with `python3 scripts/dataset_table.py`.
 | [byihive](https://github.com/tlaplus/Examples/tree/master/specifications/byihive) | tlaplus/Examples | 1 | 1 | 2 |
 | GermanProtocol | tlaplus/Examples | – | 1 | 1 |
 | [SpecifyingSystems_HourClock](https://github.com/tlaplus/Examples/tree/master/specifications/SpecifyingSystems/HourClock) | tlaplus/Examples | 1 | – | 1 |
+| [two_thread_mutex](https://github.com/anvil-verifier/anvil/blob/main/src/tla_demo.rs) | two_thread_mutex (Anvil) | – | 1 | 1 |
 
 **Total: 71 examples — 483 proof-completion + 231 proof-from-scratch = 714 tasks.**

--- a/scripts/dataset_table.py
+++ b/scripts/dataset_table.py
@@ -48,8 +48,8 @@ def source_label(group):
         return "AbstractRaft"
     if group == "OpenAddressing":
         return "OpenAddressing"
-    if group == "AnvilLock":
-        return "Anvil"
+    if group == "two_thread_mutex":
+        return "two_thread_mutex (Anvil)"
     return "TLAPS distribution examples"
 
 
@@ -62,7 +62,7 @@ SOURCE_URL = {
     "Ivy liveness": "https://github.com/kenmcmil/ivy",
     "etcd (Specula)": "https://github.com/specula-org",
     "OpenAddressing": "https://github.com/lemmy/Examples",
-    "Anvil": "https://github.com/anvil-verifier/anvil",
+    "two_thread_mutex (Anvil)": "https://github.com/anvil-verifier/anvil/blob/main/src/tla_demo.rs",
 }
 
 
@@ -97,7 +97,7 @@ _GROUP_URL = {
     "ZooKeeper": "https://github.com/Disalg-ICS-NJU/zookeeper-tla-spec/blob/main/high-level-spec/Zab.tla",
     "ZooKeeper_LowLevel": "https://github.com/Disalg-ICS-NJU/zookeeper-tla-spec/tree/main/low-level-spec/zk-3.7",
     "tlaplus_examples_BlockingQueue": "https://github.com/lemmy/BlockingQueue",
-    "AnvilLock": "https://github.com/anvil-verifier/anvil/blob/main/src/tla_demo.rs",
+    "two_thread_mutex": "https://github.com/anvil-verifier/anvil/blob/main/src/tla_demo.rs",
     # AbstractRaft was contributed directly; the upstream location of
     # tlaplus_examples_GermanProtocol could not be found.
 }

--- a/source/two_thread_mutex/two_thread_mutex.tla
+++ b/source/two_thread_mutex/two_thread_mutex.tla
@@ -1,8 +1,8 @@
------------------------------ MODULE AnvilLock -----------------------------
+-------------------------- MODULE two_thread_mutex -------------------------
 EXTENDS TLAPS
 
 (***************************************************************************)
-(* TLA+ model corresponding to anvil's src/tla_demo.rs.                    *)
+(* TLA+ model corresponding to anvil-verifier/anvil's src/tla_demo.rs.     *)
 (*                                                                         *)
 (* The Rust model has two thread identifiers, A and B.  Each thread starts *)
 (* in Waiting, can acquire the lock and move to Holding, then can release  *)


### PR DESCRIPTION
- Rename the Anvil example to `two_thread_mutex`.
- Add the results website to the README.