### PR TITLE
Add strict one-shot evaluation backends

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -90,8 +90,9 @@ ENV SANY_RUN_SH=/opt/sany/src/dataset/sany-dump/run.sh \
     COMMUNITY_LIB=/opt/community \
     TLAPS_IN_CONTAINER=1
 
-# Layer 8: LiteLLM agent script
+# Layer 8: Provider runners
 COPY src/evaluator/backends/litellm_agent.py /opt/litellm_agent.py
+COPY src/evaluator/backends/oneshot_runner.py /opt/oneshot_runner.py
 
 # Lock down checker + SANY
 RUN chmod 0755 /usr/local/bin/check_proof_bin \

--- a/docker/install-scripts/install-copilot-sdk.sh
+++ b/docker/install-scripts/install-copilot-sdk.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+pip install --no-cache-dir --break-system-packages github-copilot-sdk==1.0.7
+python3 -m copilot download-runtime

--- a/docker/install-scripts/install-litellm-oneshot.sh
+++ b/docker/install-scripts/install-litellm-oneshot.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+pip install --no-cache-dir --break-system-packages litellm==1.89.3

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -84,7 +84,7 @@ For the `pi` backend, the model format is `provider/model` (e.g. `openai/gpt-5.5
 
 ### Strict one-shot backends
 
-`litellm_oneshot` and `copilot_oneshot` use the same provider-neutral one-shot contract. The target module and its dependencies are embedded in one user prompt, only one provider invocation is permitted, and the response must be either one complete TLA+ module or exactly one `tla` code fence containing that module. The runner materializes that response as `solution.tla`; there is no agent tool loop or opportunity to inspect and edit the workspace.
+`litellm_oneshot` and `copilot_oneshot` use the same provider-neutral one-shot contract. The target module and its dependencies are embedded in one user prompt, only one provider invocation is permitted, and the requested response is either one complete TLA+ module or exactly one `tla` code fence containing that module. The runner materializes the sole non-empty response as `solution.tla` and leaves syntax and proof validity to the normal grader; there is no agent tool loop or opportunity to inspect and edit the workspace.
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
@@ -95,6 +95,8 @@ uv run tlaps-bench run --backend copilot_oneshot --model claude-opus-4.8 --filte
 ```
 
 The LiteLLM backend makes one non-streaming `litellm.completion` invocation with the prompt as its sole user message and no tools or system message. LiteLLM-level retries are disabled, but provider transport behavior below that adapter boundary is not wire-audited. Its normalized `model_requests: 1` therefore means one logical completion invocation, not an observed wire-request count. The Copilot backend uses the official Python Copilot SDK. Its request handler rebuilds the SDK's outbound inference request from endpoint-specific control-field allowlists before forwarding it: system and developer messages, tool definitions and tool choice, and SDK-added current date/time context are removed. The handler blocks unknown model-layer endpoints and any second inference attempt. This is an auditable exactly-one-request guarantee at the SDK-to-Copilot-API boundary; it does not claim control over prompts or processing that GitHub's gateway may apply after receiving the request.
+
+Copilot receives the benchmark's absolute deadline, so SDK and session startup count against the same wall-clock budget as inference. At the deadline an independent watchdog freezes the wire guard, cancels in-flight forwarding, emits and flushes usage plus request-audit evidence, and only then attempts the SDK's abort/teardown; the host allows a bounded 10-second drain window before a hard kill. The frozen guard rejects any late SDK inference attempt, so that window is cleanup time only: the verdict is already `TIMEOUT`, and recorded model runtime is capped at the benchmark timeout.
 
 Strict one-shot runs automatically skip the model preflight because it would consume another inference. Their inline infrastructure retry count is fixed at `0`, and `--max-continuations` must also remain `0`. `copilot_oneshot` accepts only an explicit `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`; it does not probe a Copilot CLI login, mount stored session credentials, or accept the agentic backend's BYOK settings.
 
@@ -126,7 +128,7 @@ Benchmark files live in `benchmark/proof-completion/` and `benchmark/proof-from-
 
 ### `tlaps-bench run`
 
-Run one or more benchmarks with an agent backend.
+Run one or more benchmarks with an evaluator backend.
 
 ```bash
 uv run tlaps-bench run [flags]
@@ -134,12 +136,12 @@ uv run tlaps-bench run [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--backend` | `codex` | Agent backend to use |
+| `--backend` | `codex` | Evaluator backend to use |
 | `--mode` | `proof-completion` | Benchmark mode |
 | `--model` | (backend default) | Override the model |
 | `--filter` | (all benchmarks) | Substring match on path, comma-separated |
-| `--jobs` | `1` | Number of parallel agent runs |
-| `--timeout` | `28800` | Per-benchmark agent timeout in seconds |
+| `--jobs` | `1` | Number of parallel backend runs |
+| `--timeout` | `28800` | Per-benchmark backend timeout in seconds |
 | `--check-timeout` | `600` | Per-benchmark checker (tlapm) timeout in seconds |
 | `--output-dir` | auto-generated | Output directory |
 | `--resume` | off | Skip benchmarks already marked `SKIP` or genuine `PASS` (first-attempt or continuation) |
@@ -337,9 +339,13 @@ This installs the Python environment, downloads tlapm 1.6, compiles the checker 
 
 ---
 
-## Adding a New Agent Backend
+## Backend Architecture
 
-To add support for a new coding agent, create a Python file in `src/evaluator/backends/` that subclasses `AgentBackend`.
+All entries in the backend registry share the neutral `Backend` lifecycle. Tool-using workspace editors inherit `AgenticBackend`; strict single-request implementations inherit the sibling `OneShotBackend`. Prompt construction, command/deadline propagation, option validation, result metadata, request-audit validation, and submission preparation are polymorphic backend hooks, so the common runner and termination classifier do not special-case one-shot names or provider names. Runtime one-shot providers implement the `OneShotProvider` protocol and are selected through a registry; each one-shot backend cross-checks the common request contract against its provider's raw audit evidence.
+
+## Adding a New Agentic Backend
+
+To add support for a new coding agent, create a Python file in `src/evaluator/backends/` that subclasses `AgenticBackend`.
 
 ### 1. Create the backend file
 
@@ -353,10 +359,11 @@ from __future__ import annotations
 import json
 import os
 
-from .base import AgentBackend, detect_firewall_hosts
+from .agentic import AgenticBackend
+from .base import detect_firewall_hosts
 
 
-class MyAgentBackend(AgentBackend):
+class MyAgentBackend(AgenticBackend):
     name = "my_agent"
     install_script = "install-my-agent.sh"
     env_keys = ["MY_AGENT_API_KEY"]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -38,14 +38,16 @@ uv run tlaps-bench run --backend codex --model gpt-5.5 --mode proof-from-scratch
 
 ## Backends
 
-A backend is the AI agent that attempts the proof. Five are included:
+A backend is the model integration that attempts the proof. Seven are included:
 
 | Backend | CLI Name | Default Model |
 |---------|----------|---------------|
 | OpenAI Codex | `codex` | `gpt-5.5` |
 | Claude Code | `claude_code` | `claude-opus-4-8` |
 | GitHub Copilot | `copilot` | `claude-opus-4.8` |
+| GitHub Copilot SDK (one-shot) | `copilot_oneshot` | `claude-opus-4.8` |
 | LiteLLM | `litellm` | `claude-sonnet-4-6` |
+| LiteLLM (one-shot) | `litellm_oneshot` | `claude-sonnet-4-6` |
 | Pi | `pi` | `openai/gpt-5.5` |
 
 Select a backend with `--backend`:
@@ -54,6 +56,7 @@ Select a backend with `--backend`:
 uv run tlaps-bench run --backend claude_code --model claude-opus-4-8
 uv run tlaps-bench run --backend pi --model anthropic/claude-sonnet-4-6
 uv run tlaps-bench run --backend litellm --model claude-sonnet-4-6
+uv run tlaps-bench run --backend litellm_oneshot --model claude-sonnet-4-6
 ```
 
 ### Authentication
@@ -72,10 +75,30 @@ If you are already logged in to an agent on your host machine (e.g. `codex login
 | `codex` | `OPENAI_API_KEY` or `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_HOST` | `~/.codex/` (logged-in session) |
 | `claude_code` | `ANTHROPIC_API_KEY` | `~/.claude/` |
 | `copilot` | `COPILOT_GITHUB_TOKEN` or `GH_TOKEN`. BYOK: `COPILOT_PROVIDER_BASE_URL` + `COPILOT_PROVIDER_API_KEY` + `COPILOT_PROVIDER_TYPE` | |
+| `copilot_oneshot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` | |
 | `litellm` | Model-dependent: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `DEEPSEEK_API_KEY` | `~/.aws/` (for Bedrock models) |
+| `litellm_oneshot` | Model-dependent: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `DEEPSEEK_API_KEY` | `~/.aws/` (for Bedrock models) |
 | `pi` | Provider-dependent: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc. | `~/.pi/` (auth.json), `~/.aws/` (for Bedrock) |
 
 For the `pi` backend, the model format is `provider/model` (e.g. `openai/gpt-5.5`, `anthropic/claude-sonnet-4-6`). The provider prefix determines which credentials are used.
+
+### Strict one-shot backends
+
+`litellm_oneshot` and `copilot_oneshot` use the same provider-neutral one-shot contract. The target module and its dependencies are embedded in one user prompt, only one provider invocation is permitted, and the response must be either one complete TLA+ module or exactly one `tla` code fence containing that module. The runner materializes that response as `solution.tla`; there is no agent tool loop or opportunity to inspect and edit the workspace.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+uv run tlaps-bench run --backend litellm_oneshot --model claude-sonnet-4-6 --filter GCD_GCD3
+
+export COPILOT_GITHUB_TOKEN=github_pat_...
+uv run tlaps-bench run --backend copilot_oneshot --model claude-opus-4.8 --filter GCD_GCD3
+```
+
+The LiteLLM backend makes one non-streaming `litellm.completion` invocation with the prompt as its sole user message and no tools or system message. LiteLLM-level retries are disabled, but provider transport behavior below that adapter boundary is not wire-audited. Its normalized `model_requests: 1` therefore means one logical completion invocation, not an observed wire-request count. The Copilot backend uses the official Python Copilot SDK. Its request handler rebuilds the SDK's outbound inference request from endpoint-specific control-field allowlists before forwarding it: system and developer messages, tool definitions and tool choice, and SDK-added current date/time context are removed. The handler blocks unknown model-layer endpoints and any second inference attempt. This is an auditable exactly-one-request guarantee at the SDK-to-Copilot-API boundary; it does not claim control over prompts or processing that GitHub's gateway may apply after receiving the request.
+
+Strict one-shot runs automatically skip the model preflight because it would consume another inference. Their inline infrastructure retry count is fixed at `0`, and `--max-continuations` must also remain `0`. `copilot_oneshot` accepts only an explicit `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`; it does not probe a Copilot CLI login, mount stored session credentials, or accept the agentic backend's BYOK settings.
+
+With `--no-container`, the runner uses its source-tree path instead of `/opt`. LiteLLM is already a project dependency; native Copilot runs additionally require `github-copilot-sdk==1.0.7` and its runtime (`python3 -m copilot download-runtime`) in the active environment.
 
 ---
 
@@ -120,8 +143,8 @@ uv run tlaps-bench run [flags]
 | `--check-timeout` | `600` | Per-benchmark checker (tlapm) timeout in seconds |
 | `--output-dir` | auto-generated | Output directory |
 | `--resume` | off | Skip benchmarks already marked `SKIP` or genuine `PASS` (first-attempt or continuation) |
-| `--infra-retries` | `3` | Extra attempts after a transient agent startup/infra failure (0 output tokens); `0` = no inline retries |
-| `--max-continuations` | `0` | Run up to N same-workspace continuation attempts after the first attempt completes without PASS (see [Continuation runs](#continuation-runs)) |
+| `--infra-retries` | `3` agentic; `0` one-shot | Extra attempts after a transient agent startup/infra failure (0 output tokens); strict one-shot backends require `0` |
+| `--max-continuations` | `0` | Run up to N same-workspace continuation attempts after the first attempt completes without PASS; strict one-shot backends require `0` (see [Continuation runs](#continuation-runs)) |
 | `--force-build` | off | Rebuild the Docker image |
 | `--no-container` | off | Run without Docker (requires native setup) |
 | `--keep-container` | off | Retain each agent container after it exits (drop `--rm`) for debugging (see [Debugging a run](#debugging-a-run-keep-container)) |

--- a/src/common/container.py
+++ b/src/common/container.py
@@ -1,4 +1,4 @@
-"""Programmatic Docker container interface for running agent backends."""
+"""Programmatic Docker container interface for running evaluator backends."""
 
 from __future__ import annotations
 
@@ -214,7 +214,7 @@ def _copy_codex_bedrock_config(src: Path, dst: Path) -> bool:
 
 
 class ContainerRunner:
-    """Programmatic interface to Docker for running agent backends in isolation."""
+    """Programmatic interface to Docker for running evaluator backends in isolation."""
 
     _CREDENTIAL_MOUNTS = {
         "aws": CredentialMount("/root/.aws", _copy_all_credentials),

--- a/src/evaluator/backends/__init__.py
+++ b/src/evaluator/backends/__init__.py
@@ -4,14 +4,18 @@ from .base import AgentBackend
 from .claude_code import ClaudeCodeBackend
 from .codex import CodexBackend
 from .copilot import CopilotBackend
+from .copilot_oneshot import CopilotOneShotBackend
 from .litellm import LiteLLMBackend
+from .litellm_oneshot import LiteLLMOneShotBackend
 from .pi import PiBackend
 
 _REGISTRY = {
     CodexBackend.name: CodexBackend,
     ClaudeCodeBackend.name: ClaudeCodeBackend,
     CopilotBackend.name: CopilotBackend,
+    CopilotOneShotBackend.name: CopilotOneShotBackend,
     LiteLLMBackend.name: LiteLLMBackend,
+    LiteLLMOneShotBackend.name: LiteLLMOneShotBackend,
     PiBackend.name: PiBackend,
 }
 

--- a/src/evaluator/backends/__init__.py
+++ b/src/evaluator/backends/__init__.py
@@ -1,12 +1,15 @@
-"""Agent backend registry."""
+"""Evaluator backend registry and public approach contracts."""
 
-from .base import AgentBackend
+from .agentic import AgenticBackend as AgenticBackend
+from .base import AgentBackend as AgentBackend
+from .base import Backend
 from .claude_code import ClaudeCodeBackend
 from .codex import CodexBackend
 from .copilot import CopilotBackend
 from .copilot_oneshot import CopilotOneShotBackend
 from .litellm import LiteLLMBackend
 from .litellm_oneshot import LiteLLMOneShotBackend
+from .oneshot import OneShotBackend as OneShotBackend
 from .pi import PiBackend
 
 _REGISTRY = {
@@ -20,7 +23,7 @@ _REGISTRY = {
 }
 
 
-def get_backend(name: str, model: str | None = None) -> AgentBackend:
+def get_backend(name: str, model: str | None = None) -> Backend:
     if name not in _REGISTRY:
         raise ValueError(f"unknown backend {name!r}; available: {sorted(_REGISTRY)}")
     return _REGISTRY[name](model=model)

--- a/src/evaluator/backends/agentic.py
+++ b/src/evaluator/backends/agentic.py
@@ -1,0 +1,11 @@
+"""Base class for tool-using, workspace-editing evaluator backends."""
+
+from __future__ import annotations
+
+from .base import Backend
+
+
+class AgenticBackend(Backend):
+    """An evaluator backend that edits its workspace through an agent loop."""
+
+    approach = "agentic"

--- a/src/evaluator/backends/base.py
+++ b/src/evaluator/backends/base.py
@@ -1,10 +1,12 @@
-"""Abstract base class for agent CLI backends."""
+"""Shared contracts for evaluator backends."""
 
 from __future__ import annotations
 
 import os
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 BEDROCK_HOSTS = [
@@ -126,20 +128,56 @@ def has_aws_shared_credentials() -> bool:
     return (Path.home() / ".aws").is_dir()
 
 
-class AgentBackend(ABC):
+@dataclass(frozen=True)
+class BackendCapabilities:
+    """Execution features supported by a backend approach.
+
+    ``max_*`` is ``None`` when the capability is unbounded.  A cooperative
+    deadline lets the backend emit its final audit at the logical benchmark
+    deadline; ``timeout_drain_grace`` is only a bounded flush/cleanup window
+    before the host hard-kills it, never additional model time.
+    """
+
+    model_preflight: bool = True
+    default_infra_retries: int = 3
+    max_infra_retries: int | None = None
+    max_continuations: int | None = None
+    cooperative_deadline: bool = False
+    timeout_drain_grace: float = 0.0
+
+
+class SubmissionDisposition:
+    """What the common runner should do with a backend submission."""
+
+    GRADE = "GRADE"
+    FAIL = "FAIL"
+    ERROR = "ERROR"
+    TIMEOUT = "TIMEOUT"
+
+
+@dataclass(frozen=True)
+class SubmissionPlan:
+    """Backend-owned preparation result consumed by the common runner."""
+
+    disposition: str = SubmissionDisposition.GRADE
+    copy_solution: bool = True
+    error: str | None = None
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+class Backend(ABC):
+    """A first-class evaluator backend, independent of interaction approach."""
+
     name: str = ""
+    approach: str = "agentic"
+    provider: str | None = None
     install_script: str | None = None  # run at container start (e.g. "install-codex.sh")
     env_keys: list[str] = []  # host env vars to forward into container
     credential_mounts: list[str] = []  # host credential dirs to copy into agent containers
     # Container path holding this backend's session state; --session-dir mounts
     # a persistent host dir here. None = no session dir (e.g. litellm).
     session_state_dir: str | None = None
-    # Capability flags used by the runner. Agentic backends keep the historical
-    # behavior; strict one-shot backends override these defaults.
-    is_one_shot: bool = False
-    supports_model_preflight: bool = True
-    supports_continuations: bool = True
-    default_infra_retries: int = 3
+    capabilities = BackendCapabilities()
 
     def get_credential_mounts(self) -> list[str]:
         """Credential directories this backend needs mounted for the current run."""
@@ -147,7 +185,7 @@ class AgentBackend(ABC):
 
     @abstractmethod
     def build_command(self, workspace: str, result_dir: str) -> list[str]:
-        """Build the agent CLI command. Prompt is fed via stdin.
+        """Build the backend command. Prompt is fed via stdin.
 
         Args:
             workspace: agent's working directory (will be the CLI's cwd).
@@ -157,6 +195,85 @@ class AgentBackend(ABC):
     @abstractmethod
     def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         """Parse the backend's stdout dump into (transcript, input_tokens, output_tokens)."""
+
+    def build_run_command(self, workspace: str, result_dir: str, deadline: float | None) -> list[str]:
+        """Build one execution command.
+
+        Agentic backends retain their existing command unchanged. Approaches
+        with a cooperative logical deadline override this hook and propagate
+        the absolute epoch deadline to their child runner.
+        """
+
+        return self.build_command(workspace, result_dir)
+
+    def build_prompt(
+        self,
+        mode: Any,
+        benchmark_path: str,
+        dependencies: list[str],
+        benchmark_basename: str,
+        tlapm_path: str,
+        tlapm_lib: str,
+    ) -> str:
+        """Build the prompt for this backend's interaction approach."""
+
+        return mode.build_prompt(benchmark_basename, tlapm_path, tlapm_lib)
+
+    def initial_result_metadata(self) -> dict[str, object]:
+        """Stable metadata stamped on every result before execution."""
+
+        metadata: dict[str, object] = {"approach": self.approach}
+        if self.provider is not None:
+            metadata["provider"] = self.provider
+        return metadata
+
+    def prepare_submission(
+        self,
+        jsonl_path: str,
+        destination: str,
+        termination_reason: str,
+        error: str,
+        *,
+        allow_materialization: bool,
+    ) -> SubmissionPlan:
+        """Prepare the workspace submission and decide whether to grade it.
+
+        Agentic backends already edit the workspace, so their default plan is
+        immediately gradeable. Other approaches own their materialization and
+        early-verdict policy in their sibling backend base class.
+        """
+
+        return SubmissionPlan()
+
+    def resolve_infra_retries(self, configured: int | None) -> int:
+        """Resolve and validate a retry count for CLI and direct Python calls."""
+
+        retries = self.capabilities.default_infra_retries if configured is None else configured
+        if not isinstance(retries, int) or isinstance(retries, bool):
+            raise ValueError("--infra-retries must be an integer")
+        if retries < 0:
+            raise ValueError("--infra-retries must be >= 0")
+        maximum = self.capabilities.max_infra_retries
+        if maximum is not None and retries > maximum:
+            if maximum == 0 and self.approach == "one_shot":
+                raise ValueError("strict one-shot backends require --infra-retries 0")
+            raise ValueError(f"backend {self.name!r} supports at most {maximum} infrastructure retries")
+        return retries
+
+    def validate_options(self, infra_retries: int | None, max_continuations: int) -> int:
+        """Validate execution policy and return the resolved retry count."""
+
+        retries = self.resolve_infra_retries(infra_retries)
+        if not isinstance(max_continuations, int) or isinstance(max_continuations, bool):
+            raise ValueError("--max-continuations must be an integer")
+        if max_continuations < 0:
+            raise ValueError("--max-continuations must be >= 0")
+        maximum = self.capabilities.max_continuations
+        if maximum is not None and max_continuations > maximum:
+            if maximum == 0:
+                raise ValueError(f"backend {self.name!r} does not support --max-continuations")
+            raise ValueError(f"backend {self.name!r} supports at most {maximum} continuations")
+        return retries
 
     def check_auth(self) -> str | None:
         """Host-side fast auth check. Returns None if OK, error string otherwise."""
@@ -206,3 +323,13 @@ class AgentBackend(ABC):
     def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
         """Return backend-specific, JSON-serializable result metadata."""
         return {}
+
+    def validate_request_audit(self, audit: dict[str, object], request_count: int) -> bool:
+        """Validate approach-specific model-request evidence, failing closed by default."""
+
+        return False
+
+
+# Compatibility for external backends written against the historical name.
+# New in-tree backends inherit Backend through AgenticBackend or OneShotBackend.
+AgentBackend = Backend

--- a/src/evaluator/backends/base.py
+++ b/src/evaluator/backends/base.py
@@ -134,6 +134,12 @@ class AgentBackend(ABC):
     # Container path holding this backend's session state; --session-dir mounts
     # a persistent host dir here. None = no session dir (e.g. litellm).
     session_state_dir: str | None = None
+    # Capability flags used by the runner. Agentic backends keep the historical
+    # behavior; strict one-shot backends override these defaults.
+    is_one_shot: bool = False
+    supports_model_preflight: bool = True
+    supports_continuations: bool = True
+    default_infra_retries: int = 3
 
     def get_credential_mounts(self) -> list[str]:
         """Credential directories this backend needs mounted for the current run."""
@@ -187,3 +193,16 @@ class AgentBackend(ABC):
         with a usage_script overrides this with its subscription's sensible caps.
         """
         return (0.0, 0.0)
+
+    def materialize_solution(self, jsonl_path: str, destination: str) -> bool:
+        """Materialize a model response at ``destination`` when needed.
+
+        Agentic backends edit the workspace themselves, so the default is a
+        no-op. One-shot backends override this hook because their sole model
+        response must be converted into the target module before grading.
+        """
+        return False
+
+    def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
+        """Return backend-specific, JSON-serializable result metadata."""
+        return {}

--- a/src/evaluator/backends/claude_code.py
+++ b/src/evaluator/backends/claude_code.py
@@ -6,8 +6,8 @@ import json
 import os
 import subprocess
 
+from .agentic import AgenticBackend
 from .base import (
-    AgentBackend,
     detect_firewall_hosts,
     has_aws_bedrock_bearer_token,
     has_aws_env_credentials,
@@ -19,7 +19,7 @@ from .base import (
 DEFAULT_MODEL = "claude-opus-4-8"
 
 
-class ClaudeCodeBackend(AgentBackend):
+class ClaudeCodeBackend(AgenticBackend):
     name = "claude_code"
     install_script = "install-claudecode.sh"
     session_state_dir = "/root/.claude"

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -12,8 +12,8 @@ from pathlib import Path
 
 from evaluator import quota
 
+from .agentic import AgenticBackend
 from .base import (
-    AgentBackend,
     detect_firewall_hosts,
     has_aws_bedrock_bearer_token,
     has_aws_env_credentials,
@@ -34,7 +34,7 @@ _RETRY_AT_RE = re.compile(r"try again at\s+(\d{1,2}):(\d{2})\s*([AaPp][Mm])")
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 
-class CodexBackend(AgentBackend):
+class CodexBackend(AgenticBackend):
     name = "codex"
     install_script = "install-codex.sh"
     session_state_dir = "/root/.codex"

--- a/src/evaluator/backends/copilot.py
+++ b/src/evaluator/backends/copilot.py
@@ -6,12 +6,13 @@ import json
 import os
 import subprocess
 
-from .base import AgentBackend, detect_firewall_hosts
+from .agentic import AgenticBackend
+from .base import detect_firewall_hosts
 
 DEFAULT_MODEL = "claude-opus-4.8"
 
 
-class CopilotBackend(AgentBackend):
+class CopilotBackend(AgenticBackend):
     name = "copilot"
     install_script = "install-copilot.sh"
     session_state_dir = "/root/.copilot"

--- a/src/evaluator/backends/copilot_oneshot.py
+++ b/src/evaluator/backends/copilot_oneshot.py
@@ -1,0 +1,28 @@
+"""Strict one-shot backend using the official GitHub Copilot SDK."""
+
+from __future__ import annotations
+
+import os
+
+from .base import detect_firewall_hosts
+from .copilot import DEFAULT_MODEL, CopilotBackend
+from .oneshot import OneShotBackend
+
+
+class CopilotOneShotBackend(OneShotBackend, CopilotBackend):
+    name = "copilot_oneshot"
+    provider = "copilot"
+    install_script = "install-copilot-sdk.sh"
+    session_state_dir = None
+    env_keys = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
+
+    def __init__(self, model: str | None = None):
+        self.model = model or DEFAULT_MODEL
+
+    def check_auth(self) -> str | None:
+        if any(os.environ.get(key) for key in self.env_keys):
+            return None
+        return "copilot_oneshot: COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN not set"
+
+    def firewall_hosts(self) -> list[str]:
+        return detect_firewall_hosts(self.model) + ["api.github.com"]

--- a/src/evaluator/backends/copilot_oneshot.py
+++ b/src/evaluator/backends/copilot_oneshot.py
@@ -3,18 +3,24 @@
 from __future__ import annotations
 
 import os
+from dataclasses import replace
 
 from .base import detect_firewall_hosts
-from .copilot import DEFAULT_MODEL, CopilotBackend
+from .copilot import DEFAULT_MODEL
 from .oneshot import OneShotBackend
 
 
-class CopilotOneShotBackend(OneShotBackend, CopilotBackend):
+class CopilotOneShotBackend(OneShotBackend):
     name = "copilot_oneshot"
     provider = "copilot"
     install_script = "install-copilot-sdk.sh"
     session_state_dir = None
     env_keys = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
+    capabilities = replace(
+        OneShotBackend.capabilities,
+        cooperative_deadline=True,
+        timeout_drain_grace=10.0,
+    )
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL
@@ -26,3 +32,17 @@ class CopilotOneShotBackend(OneShotBackend, CopilotBackend):
 
     def firewall_hosts(self) -> list[str]:
         return detect_firewall_hosts(self.model) + ["api.github.com"]
+
+    def validate_request_audit(self, audit: dict[str, object], request_count: int) -> bool:
+        """Cross-check Copilot's wire evidence against the common audit."""
+
+        return (
+            super().validate_request_audit(audit, request_count)
+            and audit.get("audit_scope") == "wire"
+            and audit.get("wire_audited") is True
+            and self._is_exact_count(audit.get("inference_requests"), request_count)
+            and self._is_exact_count(audit.get("inference_attempts"), request_count)
+            and self._is_exact_count(audit.get("unknown_requests"), 0)
+            and self._is_exact_bool(audit.get("system_removed"), request_count == 1)
+            and self._is_exact_bool(audit.get("tools_removed"), request_count == 1)
+        )

--- a/src/evaluator/backends/litellm.py
+++ b/src/evaluator/backends/litellm.py
@@ -3,49 +3,25 @@
 from __future__ import annotations
 
 import json
-import os
 
-from .base import (
-    AgentBackend,
-    detect_firewall_hosts,
-    has_aws_bedrock_bearer_token,
-    has_aws_env_credentials,
-    has_aws_shared_credentials,
-    needs_aws_shared_credentials,
-)
-
-DEFAULT_MODEL = "claude-sonnet-4-6"
+from .agentic import AgenticBackend
+from .base import detect_firewall_hosts
+from .litellm_common import DEFAULT_MODEL, ENV_KEYS, check_auth, credential_mounts, uses_bedrock
 
 
-class LiteLLMBackend(AgentBackend):
+class LiteLLMBackend(AgenticBackend):
     name = "litellm"
     install_script = "install-litellm.sh"
-    env_keys = [
-        "OPENAI_API_KEY",
-        "ANTHROPIC_API_KEY",
-        "GOOGLE_API_KEY",
-        "GEMINI_API_KEY",
-        "AZURE_OPENAI_API_KEY",
-        "AZURE_API_BASE",
-        "AZURE_API_VERSION",
-        "DEEPSEEK_API_KEY",
-        "AWS_ACCESS_KEY_ID",
-        "AWS_SECRET_ACCESS_KEY",
-        "AWS_REGION",
-        "AWS_DEFAULT_REGION",
-        "AWS_REGION_NAME",
-    ]
+    env_keys = ENV_KEYS
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL
 
     def get_credential_mounts(self) -> list[str]:
-        if self._uses_bedrock() and needs_aws_shared_credentials():
-            return ["aws"]
-        return []
+        return credential_mounts(self.model)
 
     def _uses_bedrock(self) -> bool:
-        return "bedrock" in self.model.lower()
+        return uses_bedrock(self.model)
 
     def build_command(self, workspace: str, result_dir: str) -> list[str]:
         return [
@@ -61,34 +37,7 @@ class LiteLLMBackend(AgentBackend):
         return detect_firewall_hosts(self.model)
 
     def check_auth(self) -> str | None:
-        m = self.model.lower()
-        if "bedrock" in m:
-            if has_aws_bedrock_bearer_token():
-                if not (os.environ.get("AWS_REGION_NAME") or os.environ.get("AWS_REGION")):
-                    return "litellm: AWS_REGION_NAME or AWS_REGION required for bedrock bearer-token auth"
-                return None
-            if has_aws_env_credentials():
-                if not (os.environ.get("AWS_REGION_NAME") or os.environ.get("AWS_REGION")):
-                    return "litellm: AWS_REGION_NAME or AWS_REGION required for bedrock model"
-                return None
-            if has_aws_shared_credentials():
-                return None
-            return "litellm: AWS credentials not found for bedrock model"
-        if "anthropic" in m or "claude" in m:
-            if os.environ.get("ANTHROPIC_API_KEY"):
-                return None
-            return "litellm: ANTHROPIC_API_KEY not set for anthropic model"
-        if "gemini" in m or "google" in m:
-            if os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY"):
-                return None
-            return "litellm: GOOGLE_API_KEY or GEMINI_API_KEY not set for google model"
-        if "deepseek" in m:
-            if os.environ.get("DEEPSEEK_API_KEY"):
-                return None
-            return "litellm: DEEPSEEK_API_KEY not set for deepseek model"
-        if os.environ.get("OPENAI_API_KEY") or os.environ.get("AZURE_OPENAI_API_KEY"):
-            return None
-        return "litellm: OPENAI_API_KEY not set"
+        return check_auth(self.model, self.name)
 
     def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         lines: list[str] = []

--- a/src/evaluator/backends/litellm_common.py
+++ b/src/evaluator/backends/litellm_common.py
@@ -1,0 +1,73 @@
+"""Provider configuration shared by agentic and one-shot LiteLLM backends."""
+
+from __future__ import annotations
+
+import os
+
+from .base import (
+    has_aws_bedrock_bearer_token,
+    has_aws_env_credentials,
+    has_aws_shared_credentials,
+    needs_aws_shared_credentials,
+)
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+
+ENV_KEYS = [
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_API_BASE",
+    "AZURE_API_VERSION",
+    "DEEPSEEK_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
+    "AWS_REGION_NAME",
+]
+
+
+def uses_bedrock(model: str) -> bool:
+    return "bedrock" in model.lower()
+
+
+def credential_mounts(model: str) -> list[str]:
+    if uses_bedrock(model) and needs_aws_shared_credentials():
+        return ["aws"]
+    return []
+
+
+def check_auth(model: str, backend_name: str) -> str | None:
+    """Validate provider-specific credentials without coupling approaches."""
+
+    normalized = model.lower()
+    if "bedrock" in normalized:
+        if has_aws_bedrock_bearer_token():
+            if not (os.environ.get("AWS_REGION_NAME") or os.environ.get("AWS_REGION")):
+                return f"{backend_name}: AWS_REGION_NAME or AWS_REGION required for bedrock bearer-token auth"
+            return None
+        if has_aws_env_credentials():
+            if not (os.environ.get("AWS_REGION_NAME") or os.environ.get("AWS_REGION")):
+                return f"{backend_name}: AWS_REGION_NAME or AWS_REGION required for bedrock model"
+            return None
+        if has_aws_shared_credentials():
+            return None
+        return f"{backend_name}: AWS credentials not found for bedrock model"
+    if "anthropic" in normalized or "claude" in normalized:
+        if os.environ.get("ANTHROPIC_API_KEY"):
+            return None
+        return f"{backend_name}: ANTHROPIC_API_KEY not set for anthropic model"
+    if "gemini" in normalized or "google" in normalized:
+        if os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY"):
+            return None
+        return f"{backend_name}: GOOGLE_API_KEY or GEMINI_API_KEY not set for google model"
+    if "deepseek" in normalized:
+        if os.environ.get("DEEPSEEK_API_KEY"):
+            return None
+        return f"{backend_name}: DEEPSEEK_API_KEY not set for deepseek model"
+    if os.environ.get("OPENAI_API_KEY") or os.environ.get("AZURE_OPENAI_API_KEY"):
+        return None
+    return f"{backend_name}: OPENAI_API_KEY not set"

--- a/src/evaluator/backends/litellm_oneshot.py
+++ b/src/evaluator/backends/litellm_oneshot.py
@@ -2,11 +2,38 @@
 
 from __future__ import annotations
 
-from .litellm import LiteLLMBackend
+from .base import detect_firewall_hosts
+from .litellm_common import DEFAULT_MODEL, ENV_KEYS, check_auth, credential_mounts
 from .oneshot import OneShotBackend
 
 
-class LiteLLMOneShotBackend(OneShotBackend, LiteLLMBackend):
+class LiteLLMOneShotBackend(OneShotBackend):
     name = "litellm_oneshot"
     provider = "litellm"
     install_script = "install-litellm-oneshot.sh"
+    env_keys = ENV_KEYS
+
+    def __init__(self, model: str | None = None):
+        self.model = model or DEFAULT_MODEL
+
+    def get_credential_mounts(self) -> list[str]:
+        return credential_mounts(self.model)
+
+    def check_auth(self) -> str | None:
+        return check_auth(self.model, self.name)
+
+    def firewall_hosts(self) -> list[str]:
+        return detect_firewall_hosts(self.model)
+
+    def validate_request_audit(self, audit: dict[str, object], request_count: int) -> bool:
+        """Cross-check LiteLLM's adapter evidence against the common audit."""
+
+        return (
+            super().validate_request_audit(audit, request_count)
+            and audit.get("audit_scope") == "adapter"
+            and audit.get("wire_audited") is False
+            and self._is_exact_count(audit.get("litellm_completion_invocations"), request_count)
+            and audit.get("litellm_retries_disabled") is True
+            and audit.get("system_supplied") is False
+            and audit.get("tools_supplied") is False
+        )

--- a/src/evaluator/backends/litellm_oneshot.py
+++ b/src/evaluator/backends/litellm_oneshot.py
@@ -1,0 +1,12 @@
+"""Strict one-shot backend using LiteLLM's provider adapters."""
+
+from __future__ import annotations
+
+from .litellm import LiteLLMBackend
+from .oneshot import OneShotBackend
+
+
+class LiteLLMOneShotBackend(OneShotBackend, LiteLLMBackend):
+    name = "litellm_oneshot"
+    provider = "litellm"
+    install_script = "install-litellm-oneshot.sh"

--- a/src/evaluator/backends/oneshot.py
+++ b/src/evaluator/backends/oneshot.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 import tempfile
 from collections.abc import Iterator
 from contextlib import suppress
@@ -13,8 +14,6 @@ from typing import Any
 
 from .base import AgentBackend
 
-_MODULE_HEADER = re.compile(r"^-{4,}\s*MODULE\s+[A-Za-z_][A-Za-z0-9_]*\s*-{4,}\s*$")
-_MODULE_END = re.compile(r"^={4,}\s*$")
 _FENCED_BLOCK = re.compile(r"```(?P<language>[^\n`]*)\r?\n(?P<body>.*?)```", re.DOTALL)
 _REQUEST_COUNT_KEYS = (
     "model_requests",
@@ -60,53 +59,17 @@ def _event_payload(event: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
-def _complete_module(text: str) -> str | None:
-    """Normalize ``text`` iff it is exactly one complete TLA+ module."""
-    candidate = text.strip()
-    if not candidate:
-        return None
-
-    lines = candidate.splitlines()
-    if not _MODULE_HEADER.fullmatch(lines[0].strip()) or not _MODULE_END.fullmatch(lines[-1].strip()):
-        return None
-
-    # Reject a second top-level module and content after the outer terminator.
-    # Nested modules remain valid: each nested header increments the depth.
-    depth = 0
-    for index, line in enumerate(lines):
-        stripped = line.strip()
-        if _MODULE_HEADER.fullmatch(stripped):
-            if depth == 0 and index != 0:
-                return None
-            depth += 1
-        elif _MODULE_END.fullmatch(stripped):
-            if depth == 0:
-                return None
-            depth -= 1
-            if depth == 0 and index != len(lines) - 1:
-                return None
-    if depth != 0:
-        return None
-    return candidate + "\n"
-
-
-def _extract_complete_module(response: str) -> str | None:
-    """Accept a raw module or the sole ``tla`` Markdown code block."""
-    raw_module = _complete_module(response)
-    if raw_module is not None:
-        return raw_module
-    if "```" not in response:
-        return None
-
+def _unwrap_tla_fence(response: str) -> str:
+    """Unwrap a sole ``tla`` Markdown fence, leaving all other text unchanged."""
     matches = list(_FENCED_BLOCK.finditer(response))
     if len(matches) != 1 or response.count("```") != 2:
-        return None
+        return response
     match = matches[0]
     if response[: match.start()].strip() or response[match.end() :].strip():
-        return None
+        return response
     if match.group("language").strip().lower() != "tla":
-        return None
-    return _complete_module(match.group("body"))
+        return response
+    return match.group("body")
 
 
 class OneShotBackend(AgentBackend):
@@ -120,14 +83,13 @@ class OneShotBackend(AgentBackend):
     default_infra_retries = 0
 
     def build_command(self, workspace: str, result_dir: str) -> list[str]:
-        runner_path = (
-            "/opt/oneshot_runner.py"
+        runner = (
+            ["python3", "/opt/oneshot_runner.py"]
             if workspace == "/workspace"
-            else str(Path(__file__).with_name("oneshot_runner.py"))
+            else [sys.executable, "-m", "evaluator.backends.oneshot_runner"]
         )
         return [
-            "python3",
-            runner_path,
+            *runner,
             "--provider",
             self.provider,
             "--workspace",
@@ -160,21 +122,16 @@ class OneShotBackend(AgentBackend):
         return "\n".join(lines), input_tokens, output_tokens
 
     def materialize_solution(self, jsonl_path: str, destination: str) -> bool:
-        """Write the unique complete-module response without mutating on failure."""
-        responses: list[str] = []
+        """Atomically write the sole non-empty response for grader validation."""
+        responses: list[object] = []
         for event in _iter_events(jsonl_path):
             if event.get("type") != "response":
                 continue
-            response = _event_payload(event).get("text")
-            if not isinstance(response, str) or not response.strip():
-                continue
-            responses.append(response)
+            responses.append(_event_payload(event).get("text"))
 
-        if len(responses) != 1:
+        if len(responses) != 1 or not isinstance(responses[0], str) or not responses[0].strip():
             return False
-        module = _extract_complete_module(responses[0])
-        if module is None:
-            return False
+        solution = _unwrap_tla_fence(responses[0])
 
         target = Path(destination)
         temporary: str | None = None
@@ -188,7 +145,7 @@ class OneShotBackend(AgentBackend):
                 delete=False,
             ) as stream:
                 temporary = stream.name
-                stream.write(module)
+                stream.write(solution)
             os.replace(temporary, target)
         except OSError:
             if temporary is not None:
@@ -208,6 +165,11 @@ class OneShotBackend(AgentBackend):
             payload = _event_payload(event)
             if event_type in {"response", "usage"}:
                 saw_model_output = True
+
+            if event_type == "error":
+                message = payload.get("message")
+                if isinstance(message, str) and message:
+                    metadata["error"] = message
 
             if event_type in {"metadata", "request_audit", "result"}:
                 metadata.update(payload)

--- a/src/evaluator/backends/oneshot.py
+++ b/src/evaluator/backends/oneshot.py
@@ -12,7 +12,14 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
-from .base import AgentBackend
+from evaluator.termination import TerminationReason
+
+from .base import (
+    Backend,
+    BackendCapabilities,
+    SubmissionDisposition,
+    SubmissionPlan,
+)
 
 _FENCED_BLOCK = re.compile(r"```(?P<language>[^\n`]*)\r?\n(?P<body>.*?)```", re.DOTALL)
 _REQUEST_COUNT_KEYS = (
@@ -72,15 +79,26 @@ def _unwrap_tla_fence(response: str) -> str:
     return match.group("body")
 
 
-class OneShotBackend(AgentBackend):
-    """Common command, output, and materialization behavior for one-shot runs."""
+class OneShotBackend(Backend):
+    """Sibling backend approach for one audited, tool-free model request."""
 
     provider: str = ""
     model: str
-    is_one_shot = True
-    supports_model_preflight = False
-    supports_continuations = False
-    default_infra_retries = 0
+    approach = "one_shot"
+    capabilities = BackendCapabilities(
+        model_preflight=False,
+        default_infra_retries=0,
+        max_infra_retries=0,
+        max_continuations=0,
+    )
+
+    @staticmethod
+    def _is_exact_count(value: object, expected: int) -> bool:
+        return isinstance(value, int) and not isinstance(value, bool) and value == expected
+
+    @staticmethod
+    def _is_exact_bool(value: object, expected: bool) -> bool:
+        return value is expected
 
     def build_command(self, workspace: str, result_dir: str) -> list[str]:
         runner = (
@@ -99,6 +117,72 @@ class OneShotBackend(AgentBackend):
             "--model",
             self.model,
         ]
+
+    def build_run_command(self, workspace: str, result_dir: str, deadline: float | None) -> list[str]:
+        command = self.build_command(workspace, result_dir)
+        command.extend(("--deadline", f"{deadline:.6f}" if deadline is not None else "0"))
+        return command
+
+    def build_prompt(
+        self,
+        mode: Any,
+        benchmark_path: str,
+        dependencies: list[str],
+        benchmark_basename: str,
+        tlapm_path: str,
+        tlapm_lib: str,
+    ) -> str:
+        return mode.build_one_shot_prompt(benchmark_path, dependencies)
+
+    def initial_result_metadata(self) -> dict[str, object]:
+        return {
+            **super().initial_result_metadata(),
+            "one_shot": True,
+            "model_requests": 0,
+        }
+
+    def prepare_submission(
+        self,
+        jsonl_path: str,
+        destination: str,
+        termination_reason: str,
+        error: str,
+        *,
+        allow_materialization: bool,
+    ) -> SubmissionPlan:
+        if not allow_materialization:
+            return SubmissionPlan(copy_solution=False)
+        if termination_reason == TerminationReason.INFRA_ERROR:
+            return SubmissionPlan(
+                disposition=SubmissionDisposition.ERROR,
+                copy_solution=False,
+                error=error or "one-shot request contract violation",
+            )
+        if termination_reason == TerminationReason.TIMEOUT:
+            return SubmissionPlan(
+                disposition=SubmissionDisposition.TIMEOUT,
+                copy_solution=False,
+                error=error or None,
+            )
+        if termination_reason != TerminationReason.OK:
+            return SubmissionPlan(
+                disposition=SubmissionDisposition.ERROR,
+                copy_solution=False,
+                error=error or f"one-shot run ended with {termination_reason}",
+            )
+
+        materialized = self.materialize_solution(jsonl_path, destination)
+        metadata: dict[str, object] = {"materialized": materialized}
+        if not materialized:
+            message = "one-shot response could not be uniquely materialized"
+            metadata["materialization_error"] = message
+            return SubmissionPlan(
+                disposition=SubmissionDisposition.FAIL,
+                copy_solution=False,
+                error=message,
+                metadata=metadata,
+            )
+        return SubmissionPlan(copy_solution=True, metadata=metadata)
 
     def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         lines: list[str] = []
@@ -186,3 +270,18 @@ class OneShotBackend(AgentBackend):
         metadata["one_shot"] = True
         metadata["model_requests"] = max(request_counts) if request_counts else int(saw_model_output)
         return metadata
+
+    def validate_request_audit(self, audit: dict[str, object], request_count: int) -> bool:
+        """Validate the provider-neutral strict request contract."""
+
+        return (
+            audit.get("provider") == self.provider
+            and self._is_exact_count(audit.get("model_requests"), request_count)
+            and audit.get("audit_scope") in {"adapter", "wire"}
+            and audit.get("contract_ok") is True
+            and self._is_exact_count(audit.get("request_attempts"), request_count)
+            and self._is_exact_count(audit.get("blocked_requests"), 0)
+            and audit.get("system_prompt_present") is False
+            and audit.get("tools_present") is False
+            and audit.get("retries_enabled") is False
+        )

--- a/src/evaluator/backends/oneshot.py
+++ b/src/evaluator/backends/oneshot.py
@@ -1,0 +1,226 @@
+"""Shared host-side contract for single-request model backends."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from collections.abc import Iterator
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from .base import AgentBackend
+
+_MODULE_HEADER = re.compile(r"^-{4,}\s*MODULE\s+[A-Za-z_][A-Za-z0-9_]*\s*-{4,}\s*$")
+_MODULE_END = re.compile(r"^={4,}\s*$")
+_FENCED_BLOCK = re.compile(r"```(?P<language>[^\n`]*)\r?\n(?P<body>.*?)```", re.DOTALL)
+_REQUEST_COUNT_KEYS = (
+    "model_requests",
+    "litellm_completion_invocations",
+    "inference_requests",
+    "request_count",
+)
+
+
+def _as_nonnegative_int(value: object) -> int:
+    """Return a safe token/request count for loosely typed JSON events."""
+    if isinstance(value, bool):
+        return 0
+    try:
+        return max(int(value), 0)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _iter_events(jsonl_path: str) -> Iterator[dict[str, Any]]:
+    try:
+        with open(jsonl_path, encoding="utf-8", errors="replace") as stream:
+            for raw in stream:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    event = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(event, dict):
+                    yield event
+    except OSError:
+        return
+
+
+def _event_payload(event: dict[str, Any]) -> dict[str, Any]:
+    """Flatten the common top-level event shape while tolerating ``data``."""
+    payload = {key: value for key, value in event.items() if key != "type"}
+    data = payload.pop("data", None)
+    if isinstance(data, dict):
+        payload.update(data)
+    return payload
+
+
+def _complete_module(text: str) -> str | None:
+    """Normalize ``text`` iff it is exactly one complete TLA+ module."""
+    candidate = text.strip()
+    if not candidate:
+        return None
+
+    lines = candidate.splitlines()
+    if not _MODULE_HEADER.fullmatch(lines[0].strip()) or not _MODULE_END.fullmatch(lines[-1].strip()):
+        return None
+
+    # Reject a second top-level module and content after the outer terminator.
+    # Nested modules remain valid: each nested header increments the depth.
+    depth = 0
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if _MODULE_HEADER.fullmatch(stripped):
+            if depth == 0 and index != 0:
+                return None
+            depth += 1
+        elif _MODULE_END.fullmatch(stripped):
+            if depth == 0:
+                return None
+            depth -= 1
+            if depth == 0 and index != len(lines) - 1:
+                return None
+    if depth != 0:
+        return None
+    return candidate + "\n"
+
+
+def _extract_complete_module(response: str) -> str | None:
+    """Accept a raw module or the sole ``tla`` Markdown code block."""
+    raw_module = _complete_module(response)
+    if raw_module is not None:
+        return raw_module
+    if "```" not in response:
+        return None
+
+    matches = list(_FENCED_BLOCK.finditer(response))
+    if len(matches) != 1 or response.count("```") != 2:
+        return None
+    match = matches[0]
+    if response[: match.start()].strip() or response[match.end() :].strip():
+        return None
+    if match.group("language").strip().lower() != "tla":
+        return None
+    return _complete_module(match.group("body"))
+
+
+class OneShotBackend(AgentBackend):
+    """Common command, output, and materialization behavior for one-shot runs."""
+
+    provider: str = ""
+    model: str
+    is_one_shot = True
+    supports_model_preflight = False
+    supports_continuations = False
+    default_infra_retries = 0
+
+    def build_command(self, workspace: str, result_dir: str) -> list[str]:
+        runner_path = (
+            "/opt/oneshot_runner.py"
+            if workspace == "/workspace"
+            else str(Path(__file__).with_name("oneshot_runner.py"))
+        )
+        return [
+            "python3",
+            runner_path,
+            "--provider",
+            self.provider,
+            "--workspace",
+            workspace,
+            "--result-dir",
+            result_dir,
+            "--model",
+            self.model,
+        ]
+
+    def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
+        lines: list[str] = []
+        input_tokens = 0
+        output_tokens = 0
+
+        for event in _iter_events(jsonl_path):
+            event_type = event.get("type")
+            payload = _event_payload(event)
+            if event_type == "response":
+                response = payload.get("text", "")
+                if isinstance(response, str) and response:
+                    lines.extend((f"[AGENT] {response}", ""))
+            elif event_type == "usage":
+                input_tokens += _as_nonnegative_int(payload.get("input_tokens"))
+                output_tokens += _as_nonnegative_int(payload.get("output_tokens"))
+            elif event_type == "error":
+                message = payload.get("message", "")
+                lines.extend((f"[ERROR] {message}", ""))
+
+        return "\n".join(lines), input_tokens, output_tokens
+
+    def materialize_solution(self, jsonl_path: str, destination: str) -> bool:
+        """Write the unique complete-module response without mutating on failure."""
+        responses: list[str] = []
+        for event in _iter_events(jsonl_path):
+            if event.get("type") != "response":
+                continue
+            response = _event_payload(event).get("text")
+            if not isinstance(response, str) or not response.strip():
+                continue
+            responses.append(response)
+
+        if len(responses) != 1:
+            return False
+        module = _extract_complete_module(responses[0])
+        if module is None:
+            return False
+
+        target = Path(destination)
+        temporary: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=target.parent,
+                prefix=f".{target.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as stream:
+                temporary = stream.name
+                stream.write(module)
+            os.replace(temporary, target)
+        except OSError:
+            if temporary is not None:
+                with suppress(OSError):
+                    os.unlink(temporary)
+            return False
+        return True
+
+    def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
+        """Return normalized, result-safe audit metadata from runner events."""
+        metadata: dict[str, object] = {"one_shot": True}
+        request_counts: list[int] = []
+        saw_model_output = False
+
+        for event in _iter_events(jsonl_path):
+            event_type = event.get("type")
+            payload = _event_payload(event)
+            if event_type in {"response", "usage"}:
+                saw_model_output = True
+
+            if event_type in {"metadata", "request_audit", "result"}:
+                metadata.update(payload)
+
+            for key in _REQUEST_COUNT_KEYS:
+                if key in payload:
+                    request_counts.append(_as_nonnegative_int(payload[key]))
+            requests = payload.get("requests")
+            if isinstance(requests, list):
+                request_counts.append(len(requests))
+
+        for key in (*_REQUEST_COUNT_KEYS, "requests"):
+            metadata.pop(key, None)
+        metadata["one_shot"] = True
+        metadata["model_requests"] = max(request_counts) if request_counts else int(saw_model_output)
+        return metadata

--- a/src/evaluator/backends/oneshot_runner.py
+++ b/src/evaluator/backends/oneshot_runner.py
@@ -1,0 +1,611 @@
+"""Provider-neutral strict one-shot model runner.
+
+The process reads one prompt from stdin and writes JSONL events to stdout.  The
+LiteLLM path makes one completion call with retries disabled.  The Copilot path
+uses the official SDK's request-handler seam to remove SDK-added context at the
+wire boundary and fail closed before a second inference request is forwarded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+try:
+    from copilot import CopilotRequestHandler as _CopilotRequestHandler
+except ImportError:  # The LiteLLM-only installation intentionally omits this dependency.
+
+    class _CopilotRequestHandler:  # type: ignore[no-redef]
+        async def send_request(self, _request: httpx.Request, _ctx: object) -> httpx.Response:
+            raise RuntimeError("github-copilot-sdk is not installed")
+
+
+_INFERENCE_ENDPOINTS = (
+    "/chat/completions",
+    "/responses",
+    "/v1/messages",
+    "/messages",
+)
+_AUXILIARY_ENDPOINTS = (
+    "/models/session",
+    "/models",
+    "/policy",
+)
+_CONTEXT_AND_TOOL_KEYS = frozenset(
+    {
+        "context",
+        "conversation",
+        "developer",
+        "developer_message",
+        "function_call",
+        "functions",
+        "history",
+        "input",
+        "instructions",
+        "messages",
+        "parallel_tool_calls",
+        "previous_response_id",
+        "prompt",
+        "system",
+        "tool_choice",
+        "tools",
+    }
+)
+_SAFE_INFERENCE_CONTROL_KEYS = {
+    "/responses": frozenset(
+        {
+            "include",
+            "max_output_tokens",
+            "model",
+            "reasoning",
+            "service_tier",
+            "store",
+            "stream",
+            "temperature",
+            "top_p",
+            "truncation",
+        }
+    ),
+    "/chat/completions": frozenset(
+        {
+            "frequency_penalty",
+            "logit_bias",
+            "logprobs",
+            "max_completion_tokens",
+            "max_tokens",
+            "model",
+            "n",
+            "presence_penalty",
+            "reasoning_effort",
+            "seed",
+            "service_tier",
+            "stop",
+            "stream",
+            "stream_options",
+            "temperature",
+            "top_logprobs",
+            "top_p",
+            "verbosity",
+        }
+    ),
+    "/v1/messages": frozenset(
+        {
+            "max_tokens",
+            "model",
+            "service_tier",
+            "stop_sequences",
+            "stream",
+            "temperature",
+            "thinking",
+            "top_k",
+            "top_p",
+        }
+    ),
+    "/messages": frozenset(
+        {
+            "max_tokens",
+            "model",
+            "service_tier",
+            "stop_sequences",
+            "stream",
+            "temperature",
+            "thinking",
+            "top_k",
+            "top_p",
+        }
+    ),
+}
+_FORBIDDEN_FORWARD_HEADERS = {
+    "connection",
+    "content-encoding",
+    "content-length",
+    "host",
+    "keep-alive",
+    "proxy-connection",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+_COPILOT_TOKEN_KEYS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+
+
+def _emit(event_type: str, **payload: object) -> None:
+    print(json.dumps({"type": event_type, **payload}, ensure_ascii=False), flush=True)
+
+
+def _nonnegative_int(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        return max(int(value), 0)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _get(value: object, name: str, default: object = None) -> object:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _inference_endpoint(url: str) -> str | None:
+    path = urlsplit(url).path.lower().rstrip("/")
+    for endpoint in _INFERENCE_ENDPOINTS:
+        if path.endswith(endpoint):
+            return endpoint
+    return None
+
+
+def _auxiliary_endpoint(url: str) -> str | None:
+    path = urlsplit(url).path.lower().rstrip("/")
+    for endpoint in _AUXILIARY_ENDPOINTS:
+        if path.endswith(endpoint):
+            return endpoint
+    return None
+
+
+def _assert_no_hidden_context(value: object) -> None:
+    """Fail closed if a retained control field embeds another prompt schema."""
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            normalized = str(key).lower()
+            if normalized in _CONTEXT_AND_TOOL_KEYS:
+                raise RuntimeError(f"strict one-shot: retained hidden context field {key}")
+            if normalized == "role" and str(nested).lower() in {
+                "assistant",
+                "developer",
+                "system",
+                "tool",
+            }:
+                raise RuntimeError(f"strict one-shot: retained hidden {nested} role")
+            _assert_no_hidden_context(nested)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _assert_no_hidden_context(item)
+
+
+def _rewrite_inference_payload(endpoint: str, payload: object, prompt: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise RuntimeError("strict one-shot: inference body must be a JSON object")
+    if endpoint not in _SAFE_INFERENCE_CONTROL_KEYS:
+        raise RuntimeError(f"strict one-shot: unsupported inference endpoint {endpoint}")
+
+    rewritten = {
+        key: value for key, value in payload.items() if str(key).lower() in _SAFE_INFERENCE_CONTROL_KEYS[endpoint]
+    }
+    if endpoint == "/responses":
+        canonical = [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": prompt}],
+                "type": "message",
+            }
+        ]
+        rewritten["input"] = canonical
+    elif endpoint in {"/chat/completions", "/v1/messages", "/messages"}:
+        canonical = [{"role": "user", "content": prompt}]
+        rewritten["messages"] = canonical
+    else:  # The endpoint membership check above makes this unreachable.
+        raise AssertionError(endpoint)
+
+    for key, value in rewritten.items():
+        if key not in {"input", "messages"}:
+            _assert_no_hidden_context(value)
+    canonical_key = "input" if endpoint == "/responses" else "messages"
+    if rewritten.get(canonical_key) != canonical:
+        raise RuntimeError("strict one-shot: failed to install the canonical user prompt")
+    return rewritten
+
+
+class StrictCopilotRequestHandler(_CopilotRequestHandler):
+    """Rewrite the sole Copilot inference request and block every later attempt."""
+
+    def __init__(self, prompt: str, model: str | None = None) -> None:
+        self._prompt = prompt
+        self.model = model
+        self._expected_session_id: str | None = None
+        self.inference_attempts = 0
+        self.forwarded_inference_requests = 0
+        self.blocked_requests = 0
+        self.unknown_requests = 0
+        self.endpoint: str | None = None
+        self.request_sha256: str | None = None
+        self.system_removed = False
+        self.tools_removed = False
+
+    def bind_session(self, session_id: str) -> None:
+        if not session_id:
+            raise RuntimeError("strict one-shot: Copilot session has no id")
+        if self._expected_session_id is not None and self._expected_session_id != session_id:
+            raise RuntimeError("strict one-shot: handler cannot be rebound to another session")
+        self._expected_session_id = session_id
+
+    async def _forward(self, request: httpx.Request, ctx: object) -> httpx.Response:
+        return await super().send_request(request, ctx)
+
+    async def send_request(self, request: httpx.Request, ctx: object) -> httpx.Response:
+        endpoint = _inference_endpoint(str(request.url))
+        if endpoint is None:
+            if _auxiliary_endpoint(str(request.url)) is not None:
+                return await self._forward(request, ctx)
+            self.blocked_requests += 1
+            self.unknown_requests += 1
+            raise RuntimeError("strict one-shot: blocked unknown model-layer endpoint")
+
+        self.inference_attempts += 1
+        self.endpoint = endpoint
+        session_id = getattr(ctx, "session_id", None)
+        if self._expected_session_id is None or session_id != self._expected_session_id:
+            self.blocked_requests += 1
+            raise RuntimeError("strict one-shot: inference request has an unexpected session id")
+        if self.forwarded_inference_requests != 0:
+            self.blocked_requests += 1
+            raise RuntimeError("strict one-shot: blocked inference request after the first")
+        if request.method.upper() != "POST":
+            self.blocked_requests += 1
+            raise RuntimeError("strict one-shot: inference request must use POST")
+
+        try:
+            payload = json.loads(request.content)
+            rewritten_payload = _rewrite_inference_payload(endpoint, payload, self._prompt)
+            body = json.dumps(
+                rewritten_payload,
+                ensure_ascii=False,
+                allow_nan=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except RuntimeError:
+            self.blocked_requests += 1
+            raise
+        except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            self.blocked_requests += 1
+            raise RuntimeError("strict one-shot: invalid inference request body") from exc
+
+        headers = [
+            (name, value)
+            for name, value in request.headers.multi_items()
+            if name.lower() not in _FORBIDDEN_FORWARD_HEADERS
+        ]
+        rewritten = httpx.Request(request.method, request.url, headers=headers, content=body)
+
+        # Reserve the only forwarding slot before the await.  A runtime retry or
+        # concurrent attempt therefore observes the slot as consumed even when
+        # the first upstream request fails after being sent.
+        self.forwarded_inference_requests = 1
+        self.request_sha256 = hashlib.sha256(body).hexdigest()
+        self.system_removed = True
+        self.tools_removed = True
+        return await self._forward(rewritten, ctx)
+
+    async def open_websocket(self, _ctx: object) -> object:
+        self.inference_attempts += 1
+        self.blocked_requests += 1
+        raise RuntimeError("strict one-shot: WebSocket inference is disabled")
+
+    def assert_complete(self) -> None:
+        if self.inference_attempts != 1 or self.forwarded_inference_requests != 1 or self.blocked_requests != 0:
+            raise RuntimeError("strict one-shot: expected exactly one inference attempt and one forwarded request")
+
+    def audit(self) -> dict[str, object]:
+        audit: dict[str, object] = {
+            "provider": "copilot",
+            "wire_audited": True,
+            "inference_requests": self.forwarded_inference_requests,
+            "inference_attempts": self.inference_attempts,
+            "blocked_requests": self.blocked_requests,
+            "unknown_requests": self.unknown_requests,
+            "system_removed": self.system_removed,
+            "tools_removed": self.tools_removed,
+        }
+        if self.model is not None:
+            audit["model"] = self.model
+        if self.endpoint is not None:
+            audit["endpoint"] = self.endpoint
+        if self.request_sha256 is not None:
+            audit["request_sha256"] = self.request_sha256
+        return audit
+
+
+@dataclass(frozen=True)
+class ProviderResult:
+    text: str
+    input_tokens: int
+    output_tokens: int
+    audit: dict[str, object]
+
+
+class ProviderRunError(RuntimeError):
+    """Provider failure carrying the request audit accumulated before it failed."""
+
+    def __init__(self, message: str, audit: dict[str, object]) -> None:
+        super().__init__(message)
+        self.audit = audit
+
+
+def _response_text(response: object) -> str:
+    choices = _get(response, "choices", [])
+    if not isinstance(choices, (list, tuple)) or len(choices) != 1:
+        raise RuntimeError("one-shot provider returned an invalid choice count")
+    message = _get(choices[0], "message")
+    content = _get(message, "content")
+    if not isinstance(content, str) or not content.strip():
+        raise RuntimeError("one-shot provider returned no text response")
+    return content
+
+
+def _response_finish_reason(response: object) -> str | None:
+    choices = _get(response, "choices", [])
+    if not isinstance(choices, (list, tuple)) or len(choices) != 1:
+        return None
+    finish_reason = _get(choices[0], "finish_reason")
+    return finish_reason if isinstance(finish_reason, str) and finish_reason else None
+
+
+def _litellm_max_tokens(litellm: object, model: str) -> int:
+    """Use pinned LiteLLM metadata without a provider lookup or network preflight."""
+    model_cost = getattr(litellm, "model_cost", {})
+    if not isinstance(model_cost, dict):
+        return 32_768
+    candidates = (model, model.split("/", 1)[-1])
+    for candidate in candidates:
+        metadata = model_cost.get(candidate)
+        if not isinstance(metadata, dict):
+            continue
+        for key in ("max_output_tokens", "max_tokens"):
+            limit = metadata.get(key)
+            if isinstance(limit, int) and not isinstance(limit, bool) and limit > 0:
+                return min(32_768, limit)
+    return 32_768
+
+
+def run_litellm(prompt: str, model: str) -> ProviderResult:
+    request = {"model": model, "messages": [{"role": "user", "content": prompt}]}
+    request_sha256 = hashlib.sha256(
+        json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    audit: dict[str, object] = {
+        "provider": "litellm",
+        "model": model,
+        "litellm_completion_invocations": 0,
+        "wire_audited": False,
+        "litellm_retries_disabled": True,
+        "request_sha256": request_sha256,
+        "system_supplied": False,
+        "tools_supplied": False,
+        "max_tokens": 32_768,
+    }
+    try:
+        import litellm
+    except ImportError as exc:
+        raise ProviderRunError("litellm is not installed", audit) from exc
+
+    max_tokens = _litellm_max_tokens(litellm, model)
+    audit["max_tokens"] = max_tokens
+
+    # This disables LiteLLM's own retry orchestration. Provider transports may
+    # have behavior below this adapter boundary, so this is intentionally not
+    # described as a wire-level request count.
+    try:
+        audit["litellm_completion_invocations"] = 1
+        response = litellm.completion(
+            model=model,
+            messages=request["messages"],
+            stream=False,
+            temperature=0.0,
+            max_tokens=max_tokens,
+            num_retries=0,
+        )
+        usage = _get(response, "usage", {})
+        input_tokens = _nonnegative_int(_get(usage, "prompt_tokens", _get(usage, "input_tokens", 0)))
+        output_tokens = _nonnegative_int(_get(usage, "completion_tokens", _get(usage, "output_tokens", 0)))
+        text = _response_text(response)
+        finish_reason = _response_finish_reason(response)
+        if finish_reason is not None:
+            audit["finish_reason"] = finish_reason
+    except Exception as exc:
+        raise ProviderRunError(str(exc), audit) from exc
+    return ProviderResult(
+        text=text,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        audit=audit,
+    )
+
+
+def _load_copilot_sdk() -> tuple[type, type, type]:
+    try:
+        from copilot import CopilotClient
+        from copilot.session_events import AssistantMessageData, AssistantUsageData
+    except ImportError as exc:
+        raise RuntimeError("github-copilot-sdk is not installed") from exc
+    return CopilotClient, AssistantMessageData, AssistantUsageData
+
+
+def _copilot_token() -> str:
+    for key in _COPILOT_TOKEN_KEYS:
+        token = os.environ.get(key)
+        if token:
+            return token
+    raise RuntimeError("COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN is required")
+
+
+async def run_copilot(
+    prompt: str,
+    model: str,
+    workspace: str,
+    timeout: float,
+    handler: StrictCopilotRequestHandler | None = None,
+) -> ProviderResult:
+    CopilotClient, AssistantMessageData, AssistantUsageData = _load_copilot_sdk()
+    token = _copilot_token()
+    guard = handler or StrictCopilotRequestHandler(prompt)
+    guard.model = model
+    events: list[object] = []
+
+    with tempfile.TemporaryDirectory(prefix="tlaps-bench-copilot-") as base_directory:
+        async with CopilotClient(
+            github_token=token,
+            use_logged_in_user=False,
+            base_directory=base_directory,
+            working_directory=workspace,
+            mode="empty",
+            request_handler=guard,
+            log_level="none",
+        ) as client:
+            session = await client.create_session(
+                model=model,
+                tools=[],
+                available_tools=[],
+                system_message={"mode": "replace", "content": ""},
+                tool_search={"enabled": False},
+                capi={"enable_web_socket_responses": False},
+                enable_session_telemetry=False,
+                skip_custom_instructions=True,
+                streaming=True,
+                include_sub_agent_streaming_events=False,
+                mcp_servers={},
+                custom_agents=[],
+                enable_config_discovery=False,
+                skip_embedding_retrieval=True,
+                enable_on_demand_instruction_discovery=False,
+                enable_file_hooks=False,
+                enable_host_git_operations=False,
+                enable_session_store=False,
+                enable_skills=False,
+                plugin_directories=[],
+                instruction_directories=[],
+                infinite_sessions={"enabled": False},
+                memory={"enabled": False},
+                on_event=events.append,
+            )
+            guard.bind_session(session.session_id)
+            async with session:
+                final_event = await session.send_and_wait(
+                    prompt,
+                    agent_mode="interactive",
+                    timeout=timeout,
+                )
+
+    guard.assert_complete()
+    if final_event is None or not isinstance(final_event.data, AssistantMessageData):
+        raise RuntimeError("Copilot returned no final assistant message")
+    text = final_event.data.content
+    if not isinstance(text, str) or not text.strip():
+        raise RuntimeError("Copilot returned an empty assistant message")
+    if getattr(final_event.data, "tool_requests", None):
+        raise RuntimeError("Copilot returned tool requests in strict one-shot mode")
+
+    input_tokens = 0
+    output_tokens = 0
+    finish_reason: str | None = None
+    for event in events:
+        data = getattr(event, "data", None)
+        if isinstance(data, AssistantUsageData):
+            input_tokens += _nonnegative_int(data.input_tokens)
+            output_tokens += _nonnegative_int(data.output_tokens)
+            event_finish_reason = getattr(data, "finish_reason", None)
+            if isinstance(event_finish_reason, str) and event_finish_reason:
+                finish_reason = event_finish_reason
+    audit = guard.audit()
+    if finish_reason is not None:
+        audit["finish_reason"] = finish_reason
+    return ProviderResult(text, input_tokens, output_tokens, audit)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one strict one-shot model request")
+    parser.add_argument("--provider", required=True, choices=("litellm", "copilot"))
+    parser.add_argument("--workspace", required=True)
+    parser.add_argument("--result-dir", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--timeout", type=float, default=28_800.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    prompt = sys.stdin.read()
+    if not prompt.strip():
+        _emit("error", message="empty prompt on stdin")
+        _emit("result", status="error", model_requests=0)
+        return 1
+    if args.timeout <= 0:
+        _emit("error", message="timeout must be positive")
+        _emit("result", status="error", model_requests=0)
+        return 1
+
+    guard = StrictCopilotRequestHandler(prompt, args.model) if args.provider == "copilot" else None
+    if args.provider == "litellm":
+        audit: dict[str, object] = {
+            "provider": "litellm",
+            "model": args.model,
+            "litellm_completion_invocations": 0,
+            "wire_audited": False,
+            "litellm_retries_disabled": True,
+        }
+    else:
+        audit = guard.audit() if guard is not None else {"provider": "copilot", "model": args.model}
+    try:
+        if args.provider == "litellm":
+            result = run_litellm(prompt, args.model)
+        else:
+            result = asyncio.run(run_copilot(prompt, args.model, args.workspace, args.timeout, handler=guard))
+        audit = result.audit
+        _emit("response", text=result.text)
+        _emit(
+            "usage",
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+            model_requests=1,
+        )
+        _emit("request_audit", **audit)
+        _emit("result", status="success", model_requests=1)
+        return 0
+    except Exception as exc:
+        if guard is not None:
+            audit = guard.audit()
+        elif isinstance(exc, ProviderRunError):
+            audit = exc.audit
+        _emit("request_audit", **audit)
+        _emit("error", message=str(exc))
+        request_count = audit.get(
+            "litellm_completion_invocations",
+            audit.get("inference_requests", 0),
+        )
+        _emit("result", status="error", model_requests=_nonnegative_int(request_count))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/evaluator/backends/oneshot_runner.py
+++ b/src/evaluator/backends/oneshot_runner.py
@@ -15,9 +15,10 @@ import json
 import os
 import sys
 import tempfile
-from contextlib import suppress
+import time
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 from urllib.parse import urlsplit
 
 import httpx
@@ -236,6 +237,9 @@ class StrictCopilotRequestHandler(_CopilotRequestHandler):
         self._prompt = prompt
         self.model = model
         self._expected_session_id: str | None = None
+        self._deadline: float | None = None
+        self._frozen = False
+        self._forward_tasks: set[asyncio.Task[httpx.Response]] = set()
         self.inference_attempts = 0
         self.forwarded_inference_requests = 0
         self.blocked_requests = 0
@@ -252,6 +256,30 @@ class StrictCopilotRequestHandler(_CopilotRequestHandler):
             raise RuntimeError("strict one-shot: handler cannot be rebound to another session")
         self._expected_session_id = session_id
 
+    def set_deadline(self, deadline: float | None) -> None:
+        """Bind the benchmark deadline before the SDK can start inference."""
+
+        if self._deadline is not None and deadline != self._deadline:
+            raise RuntimeError("strict one-shot: handler deadline cannot be rebound")
+        self._deadline = deadline
+        if deadline is not None and time.time() >= deadline:
+            self.freeze()
+
+    def freeze(self) -> None:
+        """Atomically close inference and cancel any forwarding work in flight."""
+
+        self._frozen = True
+        for task in tuple(self._forward_tasks):
+            task.cancel()
+
+    def _inference_closed(self) -> bool:
+        if self._frozen:
+            return True
+        if self._deadline is not None and time.time() >= self._deadline:
+            self.freeze()
+            return True
+        return False
+
     async def _forward(self, request: httpx.Request, ctx: object) -> httpx.Response:
         return await super().send_request(request, ctx)
 
@@ -263,6 +291,11 @@ class StrictCopilotRequestHandler(_CopilotRequestHandler):
             self.blocked_requests += 1
             self.unknown_requests += 1
             raise RuntimeError("strict one-shot: blocked unknown model-layer endpoint")
+
+        if self._inference_closed():
+            self.inference_attempts += 1
+            self.blocked_requests += 1
+            raise RuntimeError("strict one-shot: blocked inference request after benchmark deadline")
 
         self.inference_attempts += 1
         self.endpoint = endpoint
@@ -303,11 +336,19 @@ class StrictCopilotRequestHandler(_CopilotRequestHandler):
         # Reserve the only forwarding slot before the await.  A runtime retry or
         # concurrent attempt therefore observes the slot as consumed even when
         # the first upstream request fails after being sent.
+        if self._inference_closed():
+            self.blocked_requests += 1
+            raise RuntimeError("strict one-shot: blocked inference request after benchmark deadline")
         self.forwarded_inference_requests = 1
         self.request_sha256 = hashlib.sha256(body).hexdigest()
         self.system_removed = True
         self.tools_removed = True
-        return await self._forward(rewritten, ctx)
+        forward_task = asyncio.create_task(self._forward(rewritten, ctx))
+        self._forward_tasks.add(forward_task)
+        try:
+            return await forward_task
+        finally:
+            self._forward_tasks.discard(forward_task)
 
     async def open_websocket(self, _ctx: object) -> object:
         self.inference_attempts += 1
@@ -319,8 +360,21 @@ class StrictCopilotRequestHandler(_CopilotRequestHandler):
             raise RuntimeError("strict one-shot: expected exactly one inference attempt and one forwarded request")
 
     def audit(self) -> dict[str, object]:
+        contract_ok = (
+            self.blocked_requests == 0
+            and self.inference_attempts == self.forwarded_inference_requests
+            and self.forwarded_inference_requests <= 1
+            and (self.forwarded_inference_requests == 0 or (self.system_removed is True and self.tools_removed is True))
+        )
         audit: dict[str, object] = {
             "provider": "copilot",
+            "model_requests": self.forwarded_inference_requests,
+            "request_attempts": self.inference_attempts,
+            "system_prompt_present": self.forwarded_inference_requests > 0 and self.system_removed is not True,
+            "tools_present": self.forwarded_inference_requests > 0 and self.tools_removed is not True,
+            "retries_enabled": False,
+            "audit_scope": "wire",
+            "contract_ok": contract_ok,
             "wire_audited": True,
             "inference_requests": self.forwarded_inference_requests,
             "inference_attempts": self.inference_attempts,
@@ -328,6 +382,7 @@ class StrictCopilotRequestHandler(_CopilotRequestHandler):
             "unknown_requests": self.unknown_requests,
             "system_removed": self.system_removed,
             "tools_removed": self.tools_removed,
+            "deadline_closed": self._frozen,
         }
         if self.model is not None:
             audit["model"] = self.model
@@ -406,22 +461,34 @@ def _litellm_max_tokens(litellm: object, model: str) -> int:
     return 32_768
 
 
-def run_litellm(prompt: str, model: str) -> ProviderResult:
+def _litellm_audit(prompt: str, model: str, max_tokens: int = 32_768) -> dict[str, object]:
     request = {"model": model, "messages": [{"role": "user", "content": prompt}]}
-    request_sha256 = hashlib.sha256(
-        json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
-    audit: dict[str, object] = {
+    return {
         "provider": "litellm",
         "model": model,
+        "model_requests": 0,
+        "request_attempts": 0,
+        "blocked_requests": 0,
+        "system_prompt_present": False,
+        "tools_present": False,
+        "retries_enabled": False,
+        "audit_scope": "adapter",
+        "contract_ok": True,
         "litellm_completion_invocations": 0,
         "wire_audited": False,
         "litellm_retries_disabled": True,
-        "request_sha256": request_sha256,
+        "request_sha256": hashlib.sha256(
+            json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        ).hexdigest(),
         "system_supplied": False,
         "tools_supplied": False,
-        "max_tokens": 32_768,
+        "max_tokens": max_tokens,
     }
+
+
+def run_litellm(prompt: str, model: str) -> ProviderResult:
+    request = {"model": model, "messages": [{"role": "user", "content": prompt}]}
+    audit = _litellm_audit(prompt, model)
     try:
         import litellm
     except ImportError as exc:
@@ -437,6 +504,8 @@ def run_litellm(prompt: str, model: str) -> ProviderResult:
     output_tokens = 0
     try:
         audit["litellm_completion_invocations"] = 1
+        audit["model_requests"] = 1
+        audit["request_attempts"] = 1
         response = litellm.completion(
             model=model,
             messages=request["messages"],
@@ -496,7 +565,12 @@ def _copilot_usage(events: list[object], usage_data_type: type | None) -> tuple[
     return input_tokens, output_tokens, finish_reason
 
 
-async def _send_copilot_and_wait(session: object, prompt: str, timeout: float | None) -> object:
+async def _send_copilot_and_wait(
+    session: object,
+    prompt: str,
+    deadline: float | None,
+    on_deadline: Callable[[], None] | None = None,
+) -> object:
     """Wait for Copilot with a distinguishable runner-owned deadline."""
 
     async def send() -> object:
@@ -506,19 +580,32 @@ async def _send_copilot_and_wait(session: object, prompt: str, timeout: float | 
             timeout=None,
         )
 
-    if timeout is None:
+    if deadline is None:
         return await send()
 
+    remaining = deadline - time.time()
+    if remaining <= 0:
+        if on_deadline is not None:
+            on_deadline()
+        raise _CopilotDeadlineExceeded
+
     task = asyncio.create_task(send())
-    done, _pending = await asyncio.wait({task}, timeout=timeout)
+    try:
+        done, _pending = await asyncio.wait({task}, timeout=remaining)
+    except asyncio.CancelledError:
+        task.cancel()
+        raise
     if task in done:
         # A provider/network TimeoutError raised by the task remains a normal
         # provider failure; only our own elapsed deadline gets the marker below.
         return task.result()
 
     task.cancel()
-    with suppress(asyncio.CancelledError):
-        await task
+    # Emit the terminal timeout evidence before any cancellation wait or SDK
+    # context teardown can hang. The host gives this flush a bounded grace and
+    # hard-kills only after that grace expires.
+    if on_deadline is not None:
+        on_deadline()
     raise _CopilotDeadlineExceeded
 
 
@@ -526,13 +613,75 @@ async def run_copilot(
     prompt: str,
     model: str,
     workspace: str,
-    timeout: float | None,
+    deadline: float | None,
     handler: StrictCopilotRequestHandler | None = None,
+    on_timeout: Callable[[ProviderTimeoutError], None] | None = None,
 ) -> ProviderResult:
     guard = handler or StrictCopilotRequestHandler(prompt)
     guard.model = model
+    guard.set_deadline(deadline)
     events: list[object] = []
     usage_data_type: type | None = None
+    session: object | None = None
+    deadline_reported = False
+    owner_task = asyncio.current_task()
+    abort_tasks: set[asyncio.Task[None]] = set()
+
+    def timeout_error() -> ProviderTimeoutError:
+        input_tokens, output_tokens, finish_reason = _copilot_usage(events, usage_data_type)
+        audit = guard.audit()
+        if finish_reason is not None:
+            audit["finish_reason"] = finish_reason
+        return ProviderTimeoutError(
+            "Copilot request reached benchmark deadline",
+            audit,
+            input_tokens,
+            output_tokens,
+        )
+
+    async def abort_session(target: object) -> None:
+        try:
+            await target.abort()  # type: ignore[attr-defined]
+        except Exception:
+            # The guard is already frozen. Abort is only a best-effort signal to
+            # stop provider work and must never delay or replace durable evidence.
+            return
+
+    def schedule_abort() -> None:
+        if session is None:
+            return
+        task = asyncio.create_task(abort_session(session))
+        abort_tasks.add(task)
+        task.add_done_callback(abort_tasks.discard)
+
+    def report_deadline() -> None:
+        nonlocal deadline_reported
+        if deadline_reported:
+            return
+        deadline_reported = True
+        # Freeze first so the bounded drain window cannot start another model
+        # request. Persist the stable audit before any SDK abort/teardown await.
+        guard.freeze()
+        error = timeout_error()
+        try:
+            if on_timeout is not None:
+                on_timeout(error)
+        finally:
+            schedule_abort()
+
+    async def deadline_watchdog() -> None:
+        assert deadline is not None
+        remaining = deadline - time.time()
+        if remaining > 0:
+            await asyncio.sleep(remaining)
+        report_deadline()
+        if owner_task is not None and not owner_task.done():
+            owner_task.cancel()
+
+    if deadline is not None and deadline <= time.time():
+        report_deadline()
+        raise timeout_error()
+    watchdog_task = asyncio.create_task(deadline_watchdog()) if deadline is not None else None
 
     try:
         CopilotClient, AssistantMessageData, AssistantUsageData = _load_copilot_sdk()
@@ -575,9 +724,12 @@ async def run_copilot(
                     memory={"enabled": False},
                     on_event=events.append,
                 )
+                if deadline_reported:
+                    schedule_abort()
+                    raise _CopilotDeadlineExceeded
                 guard.bind_session(session.session_id)
                 async with session:
-                    final_event = await _send_copilot_and_wait(session, prompt, timeout)
+                    final_event = await _send_copilot_and_wait(session, prompt, deadline, report_deadline)
 
         guard.assert_complete()
         if final_event is None or not isinstance(final_event.data, AssistantMessageData):
@@ -587,19 +739,21 @@ async def run_copilot(
             raise RuntimeError("Copilot returned an empty assistant message")
         if getattr(final_event.data, "tool_requests", None):
             raise RuntimeError("Copilot returned tool requests in strict one-shot mode")
+    except asyncio.CancelledError as exc:
+        if deadline_reported:
+            raise timeout_error() from exc
+        raise
     except Exception as exc:
         input_tokens, output_tokens, finish_reason = _copilot_usage(events, usage_data_type)
         audit = guard.audit()
         if finish_reason is not None:
             audit["finish_reason"] = finish_reason
-        if timeout is not None and isinstance(exc, _CopilotDeadlineExceeded):
-            raise ProviderTimeoutError(
-                f"Copilot request timed out after {timeout:g}s",
-                audit,
-                input_tokens,
-                output_tokens,
-            ) from exc
+        if deadline_reported or (deadline is not None and isinstance(exc, _CopilotDeadlineExceeded)):
+            raise timeout_error() from exc
         raise ProviderRunError(str(exc), audit, input_tokens, output_tokens) from exc
+    finally:
+        if watchdog_task is not None:
+            watchdog_task.cancel()
 
     input_tokens, output_tokens, finish_reason = _copilot_usage(events, usage_data_type)
     audit = guard.audit()
@@ -608,13 +762,77 @@ async def run_copilot(
     return ProviderResult(text, input_tokens, output_tokens, audit)
 
 
+class OneShotProvider(Protocol):
+    """Runtime adapter used by the provider-neutral one-shot process."""
+
+    @property
+    def audit(self) -> dict[str, object]: ...
+
+    def invoke(self, on_timeout: Callable[[ProviderTimeoutError], None]) -> ProviderResult: ...
+
+
+ProviderFactory = Callable[[str, str, str, float | None], OneShotProvider]
+
+
+class _LiteLLMProvider:
+    def __init__(self, prompt: str, model: str, _workspace: str, _deadline: float | None) -> None:
+        self.prompt = prompt
+        self.model = model
+
+    @property
+    def audit(self) -> dict[str, object]:
+        return _litellm_audit(self.prompt, self.model)
+
+    def invoke(self, _on_timeout: Callable[[ProviderTimeoutError], None]) -> ProviderResult:
+        return run_litellm(self.prompt, self.model)
+
+
+class _CopilotProvider:
+    def __init__(self, prompt: str, model: str, workspace: str, deadline: float | None) -> None:
+        self.prompt = prompt
+        self.model = model
+        self.workspace = workspace
+        self.deadline = deadline
+        self.guard = StrictCopilotRequestHandler(prompt, model)
+
+    @property
+    def audit(self) -> dict[str, object]:
+        return self.guard.audit()
+
+    def invoke(self, on_timeout: Callable[[ProviderTimeoutError], None]) -> ProviderResult:
+        return asyncio.run(
+            run_copilot(
+                self.prompt,
+                self.model,
+                self.workspace,
+                self.deadline,
+                handler=self.guard,
+                on_timeout=on_timeout,
+            )
+        )
+
+
+_PROVIDER_REGISTRY: dict[str, ProviderFactory] = {
+    "litellm": _LiteLLMProvider,
+    "copilot": _CopilotProvider,
+}
+
+
+def register_provider(name: str, factory: ProviderFactory) -> None:
+    """Register a one-shot provider without changing the runner lifecycle."""
+
+    if not name or name in _PROVIDER_REGISTRY:
+        raise ValueError(f"one-shot provider already registered or invalid: {name!r}")
+    _PROVIDER_REGISTRY[name] = factory
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run one strict one-shot model request")
-    parser.add_argument("--provider", required=True, choices=("litellm", "copilot"))
+    parser.add_argument("--provider", required=True, choices=sorted(_PROVIDER_REGISTRY))
     parser.add_argument("--workspace", required=True)
     parser.add_argument("--result-dir", required=True)
     parser.add_argument("--model", required=True)
-    parser.add_argument("--timeout", type=float, default=28_800.0)
+    parser.add_argument("--deadline", type=float, default=0.0)
     return parser.parse_args(argv)
 
 
@@ -625,46 +843,25 @@ def main(argv: list[str] | None = None) -> int:
         _emit("error", message="empty prompt on stdin")
         _emit("result", status="error", model_requests=0)
         return 1
-    guard = StrictCopilotRequestHandler(prompt, args.model) if args.provider == "copilot" else None
-    if args.provider == "litellm":
-        audit: dict[str, object] = {
-            "provider": "litellm",
-            "model": args.model,
-            "litellm_completion_invocations": 0,
-            "wire_audited": False,
-            "litellm_retries_disabled": True,
-        }
-    else:
-        audit = guard.audit() if guard is not None else {"provider": "copilot", "model": args.model}
-    try:
-        if args.provider == "litellm":
-            result = run_litellm(prompt, args.model)
-        else:
-            timeout = args.timeout if args.timeout > 0 else None
-            result = asyncio.run(run_copilot(prompt, args.model, args.workspace, timeout, handler=guard))
-        audit = result.audit
-        _emit("response", text=result.text)
-        _emit(
-            "usage",
-            input_tokens=result.input_tokens,
-            output_tokens=result.output_tokens,
-            model_requests=1,
-        )
-        _emit("request_audit", **audit)
-        _emit("result", status="success", model_requests=1)
-        return 0
-    except Exception as exc:
+    deadline = args.deadline if args.deadline > 0 else None
+    provider = _PROVIDER_REGISTRY[args.provider](prompt, args.model, args.workspace, deadline)
+    terminal_emitted = False
+
+    def emit_failure(exc: Exception) -> None:
+        nonlocal terminal_emitted
+        if terminal_emitted:
+            return
+        terminal_emitted = True
+        audit = provider.audit
         input_tokens = 0
         output_tokens = 0
         if isinstance(exc, ProviderRunError):
             audit = exc.audit
             input_tokens = exc.input_tokens
             output_tokens = exc.output_tokens
-        elif guard is not None:
-            audit = guard.audit()
         request_count = audit.get(
-            "litellm_completion_invocations",
-            audit.get("inference_requests", 0),
+            "model_requests",
+            audit.get("litellm_completion_invocations", audit.get("inference_requests", 0)),
         )
         model_requests = _nonnegative_int(request_count)
         if model_requests > 0:
@@ -678,6 +875,23 @@ def main(argv: list[str] | None = None) -> int:
         _emit("error", message=str(exc))
         status = "timeout" if isinstance(exc, ProviderTimeoutError) else "error"
         _emit("result", status=status, model_requests=model_requests)
+
+    try:
+        result = provider.invoke(emit_failure)
+        if terminal_emitted:
+            return 1
+        _emit("response", text=result.text)
+        _emit(
+            "usage",
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+            model_requests=1,
+        )
+        _emit("request_audit", **result.audit)
+        _emit("result", status="success", model_requests=1)
+        return 0
+    except Exception as exc:
+        emit_failure(exc)
         return 1
 
 

--- a/src/evaluator/backends/oneshot_runner.py
+++ b/src/evaluator/backends/oneshot_runner.py
@@ -15,6 +15,7 @@ import json
 import os
 import sys
 import tempfile
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlsplit
@@ -346,11 +347,27 @@ class ProviderResult:
 
 
 class ProviderRunError(RuntimeError):
-    """Provider failure carrying the request audit accumulated before it failed."""
+    """Provider failure carrying the audit and usage accumulated before it failed."""
 
-    def __init__(self, message: str, audit: dict[str, object]) -> None:
+    def __init__(
+        self,
+        message: str,
+        audit: dict[str, object],
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+    ) -> None:
         super().__init__(message)
         self.audit = audit
+        self.input_tokens = _nonnegative_int(input_tokens)
+        self.output_tokens = _nonnegative_int(output_tokens)
+
+
+class ProviderTimeoutError(ProviderRunError):
+    """The provider-side wait reached the benchmark's propagated deadline."""
+
+
+class _CopilotDeadlineExceeded(RuntimeError):
+    """Internal marker for the deadline owned by this runner."""
 
 
 def _response_text(response: object) -> str:
@@ -416,13 +433,14 @@ def run_litellm(prompt: str, model: str) -> ProviderResult:
     # This disables LiteLLM's own retry orchestration. Provider transports may
     # have behavior below this adapter boundary, so this is intentionally not
     # described as a wire-level request count.
+    input_tokens = 0
+    output_tokens = 0
     try:
         audit["litellm_completion_invocations"] = 1
         response = litellm.completion(
             model=model,
             messages=request["messages"],
             stream=False,
-            temperature=0.0,
             max_tokens=max_tokens,
             num_retries=0,
         )
@@ -434,7 +452,7 @@ def run_litellm(prompt: str, model: str) -> ProviderResult:
         if finish_reason is not None:
             audit["finish_reason"] = finish_reason
     except Exception as exc:
-        raise ProviderRunError(str(exc), audit) from exc
+        raise ProviderRunError(str(exc), audit, input_tokens, output_tokens) from exc
     return ProviderResult(
         text=text,
         input_tokens=input_tokens,
@@ -460,83 +478,130 @@ def _copilot_token() -> str:
     raise RuntimeError("COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN is required")
 
 
-async def run_copilot(
-    prompt: str,
-    model: str,
-    workspace: str,
-    timeout: float,
-    handler: StrictCopilotRequestHandler | None = None,
-) -> ProviderResult:
-    CopilotClient, AssistantMessageData, AssistantUsageData = _load_copilot_sdk()
-    token = _copilot_token()
-    guard = handler or StrictCopilotRequestHandler(prompt)
-    guard.model = model
-    events: list[object] = []
-
-    with tempfile.TemporaryDirectory(prefix="tlaps-bench-copilot-") as base_directory:
-        async with CopilotClient(
-            github_token=token,
-            use_logged_in_user=False,
-            base_directory=base_directory,
-            working_directory=workspace,
-            mode="empty",
-            request_handler=guard,
-            log_level="none",
-        ) as client:
-            session = await client.create_session(
-                model=model,
-                tools=[],
-                available_tools=[],
-                system_message={"mode": "replace", "content": ""},
-                tool_search={"enabled": False},
-                capi={"enable_web_socket_responses": False},
-                enable_session_telemetry=False,
-                skip_custom_instructions=True,
-                streaming=True,
-                include_sub_agent_streaming_events=False,
-                mcp_servers={},
-                custom_agents=[],
-                enable_config_discovery=False,
-                skip_embedding_retrieval=True,
-                enable_on_demand_instruction_discovery=False,
-                enable_file_hooks=False,
-                enable_host_git_operations=False,
-                enable_session_store=False,
-                enable_skills=False,
-                plugin_directories=[],
-                instruction_directories=[],
-                infinite_sessions={"enabled": False},
-                memory={"enabled": False},
-                on_event=events.append,
-            )
-            guard.bind_session(session.session_id)
-            async with session:
-                final_event = await session.send_and_wait(
-                    prompt,
-                    agent_mode="interactive",
-                    timeout=timeout,
-                )
-
-    guard.assert_complete()
-    if final_event is None or not isinstance(final_event.data, AssistantMessageData):
-        raise RuntimeError("Copilot returned no final assistant message")
-    text = final_event.data.content
-    if not isinstance(text, str) or not text.strip():
-        raise RuntimeError("Copilot returned an empty assistant message")
-    if getattr(final_event.data, "tool_requests", None):
-        raise RuntimeError("Copilot returned tool requests in strict one-shot mode")
-
+def _copilot_usage(events: list[object], usage_data_type: type | None) -> tuple[int, int, str | None]:
     input_tokens = 0
     output_tokens = 0
     finish_reason: str | None = None
+    if usage_data_type is None:
+        return input_tokens, output_tokens, finish_reason
+
     for event in events:
         data = getattr(event, "data", None)
-        if isinstance(data, AssistantUsageData):
+        if isinstance(data, usage_data_type):
             input_tokens += _nonnegative_int(data.input_tokens)
             output_tokens += _nonnegative_int(data.output_tokens)
             event_finish_reason = getattr(data, "finish_reason", None)
             if isinstance(event_finish_reason, str) and event_finish_reason:
                 finish_reason = event_finish_reason
+    return input_tokens, output_tokens, finish_reason
+
+
+async def _send_copilot_and_wait(session: object, prompt: str, timeout: float | None) -> object:
+    """Wait for Copilot with a distinguishable runner-owned deadline."""
+
+    async def send() -> object:
+        return await session.send_and_wait(  # type: ignore[attr-defined]
+            prompt,
+            agent_mode="interactive",
+            timeout=None,
+        )
+
+    if timeout is None:
+        return await send()
+
+    task = asyncio.create_task(send())
+    done, _pending = await asyncio.wait({task}, timeout=timeout)
+    if task in done:
+        # A provider/network TimeoutError raised by the task remains a normal
+        # provider failure; only our own elapsed deadline gets the marker below.
+        return task.result()
+
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+    raise _CopilotDeadlineExceeded
+
+
+async def run_copilot(
+    prompt: str,
+    model: str,
+    workspace: str,
+    timeout: float | None,
+    handler: StrictCopilotRequestHandler | None = None,
+) -> ProviderResult:
+    guard = handler or StrictCopilotRequestHandler(prompt)
+    guard.model = model
+    events: list[object] = []
+    usage_data_type: type | None = None
+
+    try:
+        CopilotClient, AssistantMessageData, AssistantUsageData = _load_copilot_sdk()
+        usage_data_type = AssistantUsageData
+        token = _copilot_token()
+
+        with tempfile.TemporaryDirectory(prefix="tlaps-bench-copilot-") as base_directory:
+            async with CopilotClient(
+                github_token=token,
+                use_logged_in_user=False,
+                base_directory=base_directory,
+                working_directory=workspace,
+                mode="empty",
+                request_handler=guard,
+                log_level="none",
+            ) as client:
+                session = await client.create_session(
+                    model=model,
+                    tools=[],
+                    available_tools=[],
+                    system_message={"mode": "replace", "content": ""},
+                    tool_search={"enabled": False},
+                    capi={"enable_web_socket_responses": False},
+                    enable_session_telemetry=False,
+                    skip_custom_instructions=True,
+                    streaming=True,
+                    include_sub_agent_streaming_events=False,
+                    mcp_servers={},
+                    custom_agents=[],
+                    enable_config_discovery=False,
+                    skip_embedding_retrieval=True,
+                    enable_on_demand_instruction_discovery=False,
+                    enable_file_hooks=False,
+                    enable_host_git_operations=False,
+                    enable_session_store=False,
+                    enable_skills=False,
+                    plugin_directories=[],
+                    instruction_directories=[],
+                    infinite_sessions={"enabled": False},
+                    memory={"enabled": False},
+                    on_event=events.append,
+                )
+                guard.bind_session(session.session_id)
+                async with session:
+                    final_event = await _send_copilot_and_wait(session, prompt, timeout)
+
+        guard.assert_complete()
+        if final_event is None or not isinstance(final_event.data, AssistantMessageData):
+            raise RuntimeError("Copilot returned no final assistant message")
+        text = final_event.data.content
+        if not isinstance(text, str) or not text.strip():
+            raise RuntimeError("Copilot returned an empty assistant message")
+        if getattr(final_event.data, "tool_requests", None):
+            raise RuntimeError("Copilot returned tool requests in strict one-shot mode")
+    except Exception as exc:
+        input_tokens, output_tokens, finish_reason = _copilot_usage(events, usage_data_type)
+        audit = guard.audit()
+        if finish_reason is not None:
+            audit["finish_reason"] = finish_reason
+        if timeout is not None and isinstance(exc, _CopilotDeadlineExceeded):
+            raise ProviderTimeoutError(
+                f"Copilot request timed out after {timeout:g}s",
+                audit,
+                input_tokens,
+                output_tokens,
+            ) from exc
+        raise ProviderRunError(str(exc), audit, input_tokens, output_tokens) from exc
+
+    input_tokens, output_tokens, finish_reason = _copilot_usage(events, usage_data_type)
     audit = guard.audit()
     if finish_reason is not None:
         audit["finish_reason"] = finish_reason
@@ -560,11 +625,6 @@ def main(argv: list[str] | None = None) -> int:
         _emit("error", message="empty prompt on stdin")
         _emit("result", status="error", model_requests=0)
         return 1
-    if args.timeout <= 0:
-        _emit("error", message="timeout must be positive")
-        _emit("result", status="error", model_requests=0)
-        return 1
-
     guard = StrictCopilotRequestHandler(prompt, args.model) if args.provider == "copilot" else None
     if args.provider == "litellm":
         audit: dict[str, object] = {
@@ -580,7 +640,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.provider == "litellm":
             result = run_litellm(prompt, args.model)
         else:
-            result = asyncio.run(run_copilot(prompt, args.model, args.workspace, args.timeout, handler=guard))
+            timeout = args.timeout if args.timeout > 0 else None
+            result = asyncio.run(run_copilot(prompt, args.model, args.workspace, timeout, handler=guard))
         audit = result.audit
         _emit("response", text=result.text)
         _emit(
@@ -593,17 +654,30 @@ def main(argv: list[str] | None = None) -> int:
         _emit("result", status="success", model_requests=1)
         return 0
     except Exception as exc:
-        if guard is not None:
-            audit = guard.audit()
-        elif isinstance(exc, ProviderRunError):
+        input_tokens = 0
+        output_tokens = 0
+        if isinstance(exc, ProviderRunError):
             audit = exc.audit
-        _emit("request_audit", **audit)
-        _emit("error", message=str(exc))
+            input_tokens = exc.input_tokens
+            output_tokens = exc.output_tokens
+        elif guard is not None:
+            audit = guard.audit()
         request_count = audit.get(
             "litellm_completion_invocations",
             audit.get("inference_requests", 0),
         )
-        _emit("result", status="error", model_requests=_nonnegative_int(request_count))
+        model_requests = _nonnegative_int(request_count)
+        if model_requests > 0:
+            _emit(
+                "usage",
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                model_requests=model_requests,
+            )
+        _emit("request_audit", **audit)
+        _emit("error", message=str(exc))
+        status = "timeout" if isinstance(exc, ProviderTimeoutError) else "error"
+        _emit("result", status=status, model_requests=model_requests)
         return 1
 
 

--- a/src/evaluator/backends/pi.py
+++ b/src/evaluator/backends/pi.py
@@ -7,8 +7,8 @@ import os
 import shlex
 from pathlib import Path
 
+from .agentic import AgenticBackend
 from .base import (
-    AgentBackend,
     detect_firewall_hosts,
     has_aws_env_credentials,
     has_aws_region,
@@ -18,7 +18,7 @@ from .base import (
 DEFAULT_MODEL = "openai/gpt-5.5"
 
 
-class PiBackend(AgentBackend):
+class PiBackend(AgenticBackend):
     name = "pi"
     install_script = "install-pi.sh"
     session_state_dir = "/root/.pi"

--- a/src/evaluator/modes/base.py
+++ b/src/evaluator/modes/base.py
@@ -167,6 +167,10 @@ class Mode(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; sub
         )
         return os.path.join(prompts_dir, f"{self.name}.txt")
 
+    def one_shot_prompt_template_path(self) -> str:
+        """Prompt template for backends that get exactly one model response."""
+        return os.path.join(os.path.dirname(self.prompt_template_path()), f"{self.name}-one-shot.txt")
+
     def build_prompt(self, benchmark_basename: str, tlapm_path: str, tlapm_lib: str) -> str:
         with open(self.prompt_template_path()) as f:
             template = f.read()
@@ -174,6 +178,47 @@ class Mode(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; sub
             benchmark_basename=benchmark_basename,
             tlapm_path=tlapm_path,
             tlapm_lib=tlapm_lib,
+        )
+
+    def build_one_shot_prompt(self, benchmark_path: str, dependencies: list[str]) -> str:
+        """Build a self-contained prompt for a single, tool-free model call.
+
+        Unlike :meth:`build_prompt`, this prompt cannot assume that the model can
+        inspect a workspace. The target and every dependency are therefore
+        embedded verbatim. Dependencies are de-duplicated and ordered by
+        basename so the same benchmark always produces the same request even if
+        its caller supplies them in a different order.
+        """
+        target_path = os.path.abspath(benchmark_path)
+        benchmark_basename = os.path.basename(target_path)
+
+        with open(target_path, encoding="utf-8") as f:
+            target_contents = f.read()
+
+        dependency_paths = {os.path.abspath(path) for path in dependencies}
+        dependency_paths.discard(target_path)
+        ordered_dependencies = sorted(dependency_paths, key=lambda path: (os.path.basename(path), path))
+
+        dependency_blocks: list[str] = []
+        seen_basenames: set[str] = set()
+        for path in ordered_dependencies:
+            basename = os.path.basename(path)
+            if basename in seen_basenames:
+                raise ValueError(f"duplicate one-shot dependency basename: {basename}")
+            seen_basenames.add(basename)
+            with open(path, encoding="utf-8") as f:
+                contents = f.read()
+            dependency_blocks.append(
+                f"<<<BEGIN DEPENDENCY FILE: {basename}>>>\n{contents}\n<<<END DEPENDENCY FILE: {basename}>>>"
+            )
+
+        dependencies_text = "\n\n".join(dependency_blocks) if dependency_blocks else "(none)"
+        with open(self.one_shot_prompt_template_path(), encoding="utf-8") as f:
+            template = f.read()
+        return template.format(
+            benchmark_basename=benchmark_basename,
+            target_contents=target_contents,
+            dependencies=dependencies_text,
         )
 
     def build_continuation_prompt(self, benchmark_basename: str, tlapm_path: str, tlapm_lib: str) -> str:

--- a/src/evaluator/prompts/proof-completion-one-shot.txt
+++ b/src/evaluator/prompts/proof-completion-one-shot.txt
@@ -1,0 +1,25 @@
+# Task
+
+Produce a complete, valid TLAPS solution for `{benchmark_basename}` from the source files below.
+
+The last theorem in the target file has `PROOF OBVIOUS` as a placeholder proof. Replace that placeholder with a proof that TLAPS can verify. Preceding theorems whose proofs are `PROOF OMITTED` are admitted and may be used as lemmas.
+
+# Response format
+
+Return the complete contents of the target module, from its module header through its final `====`. Return only that module, optionally inside one `tla` Markdown code fence. Do not return a patch, a proof fragment, an explanation, or any dependency module.
+
+# Constraints
+
+Preserve exactly every existing module header, operator definition, declaration, assumption, theorem or lemma statement, and every preceding `PROOF OMITTED`. Only replace the final `PROOF OBVIOUS` proof.
+
+Do not use `PROOF OMITTED` or bare `OMITTED` in the new proof. Do not introduce a top-level `AXIOM`, `ASSUME`, `ASSUMPTION`, `CONSTANT`, or `VARIABLE`, and do not weaken a theorem statement or add hypotheses. The dependency files are read-only context and must not be reproduced or changed.
+
+# Target file
+
+<<<BEGIN TARGET FILE: {benchmark_basename}>>>
+{target_contents}
+<<<END TARGET FILE: {benchmark_basename}>>>
+
+# Read-only dependency files
+
+{dependencies}

--- a/src/evaluator/prompts/proof-from-scratch-one-shot.txt
+++ b/src/evaluator/prompts/proof-from-scratch-one-shot.txt
@@ -1,0 +1,25 @@
+# Task
+
+Produce a complete, valid TLAPS solution for `{benchmark_basename}` from the source files below.
+
+The target file contains a model and a target theorem whose `PROOF OBVIOUS` is a placeholder. Supporting lemmas and proofs have been removed. Supply a genuine proof of the target theorem. You may add helper operator definitions and fully proved helper lemmas above the target theorem when useful.
+
+# Response format
+
+Return the complete contents of the target module, from its module header through its final `====`. Return only that module, optionally inside one `tla` Markdown code fence. Do not return a patch, a proof fragment, an explanation, or any dependency module.
+
+# Constraints
+
+Preserve every existing module header, operator definition, declaration, assumption, and the target theorem statement. New helper operator definitions and helper lemmas may be inserted above the target theorem, but every helper theorem or lemma must have a complete proof.
+
+Do not use `PROOF OMITTED` or bare `OMITTED`. Do not introduce a top-level `AXIOM`, `ASSUME`, `ASSUMPTION`, `CONSTANT`, or `VARIABLE`, and do not weaken the target theorem or add hypotheses. Do not restate the target goal, or a statement that directly implies it, as an unproved or circular helper lemma. The dependency files are read-only context and must not be reproduced or changed.
+
+# Target file
+
+<<<BEGIN TARGET FILE: {benchmark_basename}>>>
+{target_contents}
+<<<END TARGET FILE: {benchmark_basename}>>>
+
+# Read-only dependency files
+
+{dependencies}

--- a/src/evaluator/quota.py
+++ b/src/evaluator/quota.py
@@ -7,7 +7,7 @@ limits the account:
   backend's subscription utilization (via its usage probe, see ``scripts/usage/``)
   and sleep until the window resets when it is over threshold.
 - Reactive retry (``run_with_quota_retry``): after a run, if the backend reports
-  a hard usage cap — the agent did no work (``AgentBackend.detect_quota_block``) —
+  a hard usage cap — the backend did no work (``Backend.detect_quota_block``) —
   sleep until the stated reset and retry rather than grade the no-op run as FAIL.
 
 Both share ``secs_until_reset``, the single "how long until this resets" helper.

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -403,6 +403,9 @@ def _run_agent_with_retries(
             transcript, input_tokens, output_tokens = backend.parse_output(agent_jsonl)
             result["input_tokens"] = input_tokens
             result["output_tokens"] = output_tokens
+            parse_metadata = getattr(backend, "parse_run_metadata", None)
+            if parse_metadata:
+                result.update(parse_metadata(agent_jsonl))
 
             if quota_exhausted:
                 break  # quota owns its own retry budget — never infra-retried
@@ -584,6 +587,7 @@ def run_single_benchmark(item: WorkItem):
     """Run the agent backend on a single benchmark. Returns result dict."""
     backend = item.backend
     mode = item.mode
+    is_one_shot = getattr(backend, "is_one_shot", False) is True
 
     rel_path = os.path.relpath(item.benchmark_path, mode.benchmark_dir())
     module_dir = os.path.basename(os.path.dirname(item.benchmark_path))
@@ -613,6 +617,11 @@ def run_single_benchmark(item: WorkItem):
         # than a genuine model attempt, so a FAIL can be filtered/retried.
         "termination_reason": TerminationReason.OK,
     }
+    if is_one_shot:
+        result["one_shot"] = True
+        # The provider driver replaces this after the run. Keeping an explicit
+        # zero makes pre-run quota skips and startup failures auditable too.
+        result["model_requests"] = 0
     if item.max_continuations > 0:
         # Run-level config, stamped on EVERY result — first-attempt PASSes and
         # non-genuine early exits included — so the continuation metric can
@@ -648,8 +657,13 @@ def run_single_benchmark(item: WorkItem):
         for dep in deps:
             shutil.copy2(dep, os.path.join(input_dir, os.path.basename(dep)))
 
-        # Build prompt
-        prompt = mode.build_prompt(basename, item.tlapm_path, item.tlapm_lib)
+        # One-shot providers cannot inspect the workspace, so the mode packs the
+        # canonical target and dependencies into a provider-neutral prompt.
+        # Agentic backends retain the existing tool-oriented prompt unchanged.
+        if is_one_shot:
+            prompt = mode.build_one_shot_prompt(item.benchmark_path, deps)
+        else:
+            prompt = mode.build_prompt(basename, item.tlapm_path, item.tlapm_lib)
         with open(os.path.join(input_dir, "prompt.txt"), "w") as f:
             f.write(prompt)
 
@@ -666,6 +680,14 @@ def run_single_benchmark(item: WorkItem):
         )
         workspace, canonical_dir = run.workspace, run.canonical_dir
 
+        materialized: bool | None = None
+        if is_one_shot and not run.quota_exhausted and result["termination_reason"] != TerminationReason.INFRA_ERROR:
+            destination = os.path.join(workspace, basename)
+            materialized = backend.materialize_solution(agent_jsonl, destination)
+            result["materialized"] = materialized
+            if not materialized:
+                result["materialization_error"] = "one-shot response did not contain exactly one complete TLA+ module"
+
         with open(os.path.join(agent_dir, "transcript.txt"), "w") as f:
             f.write(f"Benchmark: {rel_path}\n")
             f.write(f"Time: {result['time_secs']:.0f}s\n")
@@ -674,7 +696,7 @@ def run_single_benchmark(item: WorkItem):
             f.write(run.transcript)
 
         solution_path = os.path.join(workspace, basename)
-        if os.path.isfile(solution_path):
+        if os.path.isfile(solution_path) and (not is_one_shot or materialized is True):
             shutil.copy2(solution_path, os.path.join(agent_dir, "solution.tla"))
 
         agent_check_file = os.path.join(workspace, name_no_ext + ".result")
@@ -701,6 +723,26 @@ def run_single_benchmark(item: WorkItem):
             # a bogus PASS). Mark ERROR (retriable via --resume), skip the grader.
             result["check_verdict"] = "ERROR"
             result["error"] = f"startup/infra failure ({run.infra_reasons[-1]}); exhausted infra retries"
+            with open(os.path.join(result_dir, "result.json"), "w") as f:
+                json.dump(result, f, indent=2)
+            return result
+
+        if is_one_shot and result["termination_reason"] == TerminationReason.INFRA_ERROR:
+            # Strict one-shot auditing is fail-closed even if the first request
+            # produced tokens before the SDK tried a forbidden second request.
+            # Such a run violated the measurement contract and is not gradeable.
+            result["check_verdict"] = "ERROR"
+            result["error"] = "one-shot request contract violation"
+            with open(os.path.join(result_dir, "result.json"), "w") as f:
+                json.dump(result, f, indent=2)
+            return result
+
+        if is_one_shot and materialized is not True:
+            # This is a genuine model attempt, but not a gradeable submission.
+            # Do not grade the untouched canonical placeholder: a trivial task
+            # could otherwise turn malformed model output into a bogus PASS.
+            result["check_verdict"] = "FAIL"
+            result["error"] = result["materialization_error"]
             with open(os.path.join(result_dir, "result.json"), "w") as f:
                 json.dump(result, f, indent=2)
             return result
@@ -1335,10 +1377,11 @@ def main():
     parser.add_argument(
         "--infra-retries",
         type=int,
-        default=3,
+        default=None,
         help="Extra agent attempts after a transient startup/infrastructure failure "
         "(agent died with 0 output tokens), so 3 = up to 4 attempts total "
-        "(default: 3; 0 = no retries, the failure still ends as ERROR)",
+        "(default: 3 for agentic backends, 0 for one-shot; 0 = no retries, "
+        "the failure still ends as ERROR)",
     )
     parser.add_argument(
         "--max-continuations",
@@ -1410,6 +1453,18 @@ def main():
             2, f"{parser.prog}: error: no benchmarks found for mode {mode.name!r} under {mode.benchmark_dir()}\n"
         )
 
+    # Resolve capability-dependent defaults only after task discovery. This
+    # preserves the useful fail-fast behavior for a misspelled --filter: no
+    # backend validation, auth probe, image build, or model request happens.
+    is_one_shot = getattr(backend, "is_one_shot", False) is True
+    supports_continuations = getattr(backend, "supports_continuations", True) is not False
+    if args.infra_retries is None:
+        args.infra_retries = getattr(backend, "default_infra_retries", 3)
+    if is_one_shot and args.infra_retries != 0:
+        parser.error("strict one-shot backends require --infra-retries 0")
+    if not supports_continuations and args.max_continuations != 0:
+        parser.error(f"backend {backend.name!r} does not support --max-continuations")
+
     auth_err = backend.check_auth()
     if auth_err:
         print(f"ERROR: {auth_err}")
@@ -1442,8 +1497,10 @@ def main():
         # id, unknown CLI flag, missing credentials, or an auth host the
         # firewall blocks) otherwise produces a whole sweep of silent 0-token
         # FAILs that look like honest "couldn't prove it" results.
-        if not args.skip_preflight:
+        if not args.skip_preflight and getattr(backend, "supports_model_preflight", True) is not False:
             _run_preflight(backend)
+        elif not args.skip_preflight:
+            print("Preflight: skipped — strict one-shot backends cannot spend an extra model request")
     else:
         # Local mode: require tlapm and checker on host
         ensure_tlapm()

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -405,7 +405,10 @@ def _run_agent_with_retries(
             result["output_tokens"] = output_tokens
             parse_metadata = getattr(backend, "parse_run_metadata", None)
             if parse_metadata:
+                runner_error = result.get("error")
                 result.update(parse_metadata(agent_jsonl))
+                if runner_error:
+                    result["error"] = runner_error
 
             if quota_exhausted:
                 break  # quota owns its own retry budget — never infra-retried
@@ -599,6 +602,7 @@ def run_single_benchmark(item: WorkItem):
     input_dir = os.path.join(result_dir, "input")
     agent_dir = os.path.join(result_dir, "agent")
     grading_dir = os.path.join(result_dir, "grading")
+    _reset_benchmark_artifacts(item.output_dir, result_dir)
     for d in (input_dir, agent_dir, grading_dir):
         os.makedirs(d, exist_ok=True)
 
@@ -681,12 +685,12 @@ def run_single_benchmark(item: WorkItem):
         workspace, canonical_dir = run.workspace, run.canonical_dir
 
         materialized: bool | None = None
-        if is_one_shot and not run.quota_exhausted and result["termination_reason"] != TerminationReason.INFRA_ERROR:
+        if is_one_shot and not run.quota_exhausted and result["termination_reason"] == TerminationReason.OK:
             destination = os.path.join(workspace, basename)
             materialized = backend.materialize_solution(agent_jsonl, destination)
             result["materialized"] = materialized
             if not materialized:
-                result["materialization_error"] = "one-shot response did not contain exactly one complete TLA+ module"
+                result["materialization_error"] = "one-shot response could not be uniquely materialized"
 
         with open(os.path.join(agent_dir, "transcript.txt"), "w") as f:
             f.write(f"Benchmark: {rel_path}\n")
@@ -737,6 +741,15 @@ def run_single_benchmark(item: WorkItem):
                 json.dump(result, f, indent=2)
             return result
 
+        if is_one_shot and result["termination_reason"] == TerminationReason.TIMEOUT:
+            # Preserve the outer watchdog or propagated provider deadline instead
+            # of materializing a truncated response and replacing the timeout with
+            # a malformed-response failure.
+            result["check_verdict"] = "TIMEOUT"
+            with open(os.path.join(result_dir, "result.json"), "w") as f:
+                json.dump(result, f, indent=2)
+            return result
+
         if is_one_shot and materialized is not True:
             # This is a genuine model attempt, but not a gradeable submission.
             # Do not grade the untouched canonical placeholder: a trivial task
@@ -771,6 +784,40 @@ def run_single_benchmark(item: WorkItem):
             shutil.rmtree(canonical_dir, ignore_errors=True)
 
     return result
+
+
+def _reset_benchmark_artifacts(output_dir: str, result_dir: str) -> None:
+    """Remove runner-owned artifacts without following generated-path symlinks."""
+    output_root = os.path.abspath(output_dir)
+    result_path = os.path.abspath(result_dir)
+    if os.path.commonpath((output_root, result_path)) != output_root:
+        raise RuntimeError(f"benchmark result path escapes output directory: {result_dir}")
+
+    # The user may intentionally make --output-dir itself a symlink, but the
+    # runner-generated module/theorem components must be real directories. A
+    # symlink there could redirect cleanup into unrelated data outside the run.
+    current = output_root
+    for component in os.path.relpath(result_path, output_root).split(os.sep):
+        if component == ".":
+            continue
+        current = os.path.join(current, component)
+        if os.path.islink(current):
+            raise RuntimeError(f"refusing to clean symlinked benchmark result path: {current}")
+
+    resolved_root = os.path.realpath(output_root)
+    resolved_result = os.path.realpath(result_path)
+    if os.path.commonpath((resolved_root, resolved_result)) != resolved_root:
+        raise RuntimeError(f"benchmark result path resolves outside output directory: {result_dir}")
+
+    os.makedirs(result_dir, exist_ok=True)
+    for name in ("input", "agent", "grading", "continuations", "result.json"):
+        path = os.path.join(result_dir, name)
+        if not os.path.lexists(path):
+            continue
+        if os.path.isdir(path) and not os.path.islink(path):
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
 
 
 def _stash_failed_attempt(agent_dir: str, attempt: int) -> None:
@@ -933,7 +980,7 @@ def _run_agent_container(
 ) -> None:
     """Run agent inside a Docker container with live output streaming."""
     runner = ContainerRunner()
-    cmd = backend.build_command("/workspace", "/results")
+    cmd = _build_agent_command(backend, "/workspace", "/results", item.timeout)
 
     config = ContainerConfig(
         workspace=workspace,
@@ -1070,7 +1117,7 @@ def _run_agent_local(
     canonical_dir: str | None = None,
 ) -> None:
     """Run agent as a local subprocess (existing behavior)."""
-    cmd = backend.build_command(workspace, agent_dir)
+    cmd = _build_agent_command(backend, workspace, agent_dir, item.timeout)
     shell_cmd = "source ~/.zshrc 2>/dev/null; source ~/.bashrc 2>/dev/null; exec " + " ".join(
         shlex.quote(c) for c in cmd
     )
@@ -1139,6 +1186,14 @@ def _run_agent_local(
         result["error"] = str(e)
         if proc is not None:
             kill_agent_tree(proc, workspace)
+
+
+def _build_agent_command(backend, workspace: str, result_dir: str, timeout: int) -> list[str]:
+    """Build a backend command, forwarding the outer limit to one-shot drivers."""
+    cmd = backend.build_command(workspace, result_dir)
+    if getattr(backend, "is_one_shot", False) is True:
+        cmd.extend(("--timeout", str(timeout if timeout > 0 else 0)))
+    return cmd
 
 
 def _run_grader_container(

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -1,5 +1,5 @@
 """
-Run an agent CLI on TLAPS benchmarks to attempt automated proof writing.
+Run evaluator backends on TLAPS benchmarks to attempt automated proof writing.
 
 For each benchmark:
 1. Creates an isolated workspace (fresh git repo with only benchmark files)
@@ -36,7 +36,7 @@ from dataclasses import dataclass
 from common.container import ContainerConfig, ContainerRunner, DockerUnavailableError, ensure_image, forward_env
 from evaluator import quota
 from evaluator.backends import get_backend, list_backends
-from evaluator.backends.base import AgentBackend
+from evaluator.backends.base import Backend, SubmissionDisposition
 from evaluator.modes import get_mode, list_modes
 from evaluator.modes.base import Mode
 from evaluator.score import (
@@ -232,7 +232,7 @@ class WorkItem:
     output_dir: str
     timeout: int
     check_timeout: int
-    backend: AgentBackend
+    backend: Backend
     mode: Mode
     tlapm_path: str
     tlapm_lib: str
@@ -248,7 +248,7 @@ class WorkItem:
     use_container: bool = False
     # Extra agent attempts after a transient startup/infra failure (INFRA_ERROR
     # with 0 output tokens); 0 disables retrying (the failure still ends ERROR).
-    infra_retries: int = 3
+    infra_retries: int | None = None
     # Continuation rounds after a genuine non-PASS: re-run the agent in the SAME
     # workspace so it builds on its own partial proof (see _run_continuations).
     # 0 disables. pass@1 (check_verdict) is unaffected either way.
@@ -300,8 +300,8 @@ def _make_workspace(backend_name: str, name_no_ext: str, benchmark_path: str, ba
 
 
 @dataclass
-class AgentRunOutcome:
-    """What _run_agent_with_retries leaves behind for the caller to grade/record."""
+class ExecutionOutcome:
+    """What one backend execution leaves behind for grading and recording."""
 
     workspace: str
     canonical_dir: str
@@ -311,7 +311,7 @@ class AgentRunOutcome:
     infra_reasons: list[str]
 
 
-def _run_agent_with_retries(
+def _run_backend_with_retries(
     item: WorkItem,
     prompt: str,
     agent_dir: str,
@@ -323,7 +323,7 @@ def _run_agent_with_retries(
     basename: str,
     name_no_ext: str,
     fixed_workspace: str | None = None,
-) -> AgentRunOutcome:
+) -> ExecutionOutcome:
     """One agent-run lifecycle, shared by the first attempt and continuation
     rounds: run the agent (sleeping through hard provider quota caps, see
     quota.run_with_quota_retry), parse its output, classify the termination,
@@ -372,11 +372,11 @@ def _run_agent_with_retries(
                     os.remove(agent_stderr)
                 t0 = time.time()
                 if item.use_container:
-                    _run_agent_container(
+                    _run_backend_container(
                         item, backend, workspace, agent_dir, agent_jsonl, prompt, result, canonical_dir
                     )
                 else:
-                    _run_agent_local(
+                    _run_backend_local(
                         item,
                         backend,
                         mode,
@@ -388,7 +388,13 @@ def _run_agent_with_retries(
                         checker_bin,
                         canonical_dir,
                     )
-                active_secs += time.time() - t0
+                elapsed = time.time() - t0
+                # Cooperative backends may spend a bounded grace period flushing
+                # audit events after the logical deadline. That is not extra model
+                # time and must not inflate the benchmark runtime metric.
+                if item.timeout > 0 and result.get("agent_exit") == -1 and "timeout after" in result.get("error", ""):
+                    elapsed = min(elapsed, item.timeout)
+                active_secs += elapsed
 
             quota_exhausted = not quota.run_with_quota_retry(
                 _run_once,
@@ -419,6 +425,9 @@ def _run_agent_with_retries(
             ctx = TerminationContext(
                 backend=backend.name,
                 jsonl_path=agent_jsonl,
+                approach=backend.approach,
+                provider=backend.provider,
+                request_audit_validator=backend.validate_request_audit,
                 agent_exit=result.get("agent_exit"),
                 error=result.get("error", ""),
                 stderr_path=agent_stderr,
@@ -459,7 +468,7 @@ def _run_agent_with_retries(
     if infra_reasons:
         result["infra_retries"] = attempt  # retries performed (0-based final attempt index)
         result["infra_retry_reasons"] = infra_reasons
-    return AgentRunOutcome(workspace, canonical_dir, transcript, quota_exhausted, infra_retriable, infra_reasons)
+    return ExecutionOutcome(workspace, canonical_dir, transcript, quota_exhausted, infra_retriable, infra_reasons)
 
 
 def _resume_should_skip(result: dict) -> bool:
@@ -587,10 +596,13 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
 
 
 def run_single_benchmark(item: WorkItem):
-    """Run the agent backend on a single benchmark. Returns result dict."""
+    """Run one evaluator backend on a single benchmark. Returns result dict."""
     backend = item.backend
     mode = item.mode
-    is_one_shot = getattr(backend, "is_one_shot", False) is True
+
+    # Enforce backend capabilities at the actual execution boundary, before an
+    # invalid direct Python call can clear prior artifacts or touch quota/state.
+    item.infra_retries = backend.validate_options(item.infra_retries, item.max_continuations)
 
     rel_path = os.path.relpath(item.benchmark_path, mode.benchmark_dir())
     module_dir = os.path.basename(os.path.dirname(item.benchmark_path))
@@ -620,12 +632,8 @@ def run_single_benchmark(item: WorkItem):
         # INFRA_ERROR marks a result that was cut short by infrastructure rather
         # than a genuine model attempt, so a FAIL can be filtered/retried.
         "termination_reason": TerminationReason.OK,
+        **backend.initial_result_metadata(),
     }
-    if is_one_shot:
-        result["one_shot"] = True
-        # The provider driver replaces this after the run. Keeping an explicit
-        # zero makes pre-run quota skips and startup failures auditable too.
-        result["model_requests"] = 0
     if item.max_continuations > 0:
         # Run-level config, stamped on EVERY result — first-attempt PASSes and
         # non-genuine early exits included — so the continuation metric can
@@ -661,13 +669,14 @@ def run_single_benchmark(item: WorkItem):
         for dep in deps:
             shutil.copy2(dep, os.path.join(input_dir, os.path.basename(dep)))
 
-        # One-shot providers cannot inspect the workspace, so the mode packs the
-        # canonical target and dependencies into a provider-neutral prompt.
-        # Agentic backends retain the existing tool-oriented prompt unchanged.
-        if is_one_shot:
-            prompt = mode.build_one_shot_prompt(item.benchmark_path, deps)
-        else:
-            prompt = mode.build_prompt(basename, item.tlapm_path, item.tlapm_lib)
+        prompt = backend.build_prompt(
+            mode,
+            item.benchmark_path,
+            deps,
+            basename,
+            item.tlapm_path,
+            item.tlapm_lib,
+        )
         with open(os.path.join(input_dir, "prompt.txt"), "w") as f:
             f.write(prompt)
 
@@ -679,18 +688,22 @@ def run_single_benchmark(item: WorkItem):
         # (INFRA_ERROR + 0 output tokens) says nothing about the model, so it is
         # retried on a fresh workspace instead of graded. Everything else gets
         # exactly one attempt.
-        run = _run_agent_with_retries(
+        run = _run_backend_with_retries(
             item, prompt, agent_dir, agent_jsonl, agent_stderr, result, checker_bin, deps, basename, name_no_ext
         )
         workspace, canonical_dir = run.workspace, run.canonical_dir
 
-        materialized: bool | None = None
-        if is_one_shot and not run.quota_exhausted and result["termination_reason"] == TerminationReason.OK:
-            destination = os.path.join(workspace, basename)
-            materialized = backend.materialize_solution(agent_jsonl, destination)
-            result["materialized"] = materialized
-            if not materialized:
-                result["materialization_error"] = "one-shot response could not be uniquely materialized"
+        destination = os.path.join(workspace, basename)
+        submission = backend.prepare_submission(
+            agent_jsonl,
+            destination,
+            result["termination_reason"],
+            result.get("error", ""),
+            allow_materialization=not run.quota_exhausted and not run.infra_retriable,
+        )
+        result.update(submission.metadata)
+        if submission.error is not None:
+            result["error"] = submission.error
 
         with open(os.path.join(agent_dir, "transcript.txt"), "w") as f:
             f.write(f"Benchmark: {rel_path}\n")
@@ -700,7 +713,7 @@ def run_single_benchmark(item: WorkItem):
             f.write(run.transcript)
 
         solution_path = os.path.join(workspace, basename)
-        if os.path.isfile(solution_path) and (not is_one_shot or materialized is True):
+        if submission.copy_solution and os.path.isfile(solution_path):
             shutil.copy2(solution_path, os.path.join(agent_dir, "solution.tla"))
 
         agent_check_file = os.path.join(workspace, name_no_ext + ".result")
@@ -726,36 +739,14 @@ def run_single_benchmark(item: WorkItem):
             # workspace would turn infra noise into a proof verdict (FAIL, or even
             # a bogus PASS). Mark ERROR (retriable via --resume), skip the grader.
             result["check_verdict"] = "ERROR"
-            result["error"] = f"startup/infra failure ({run.infra_reasons[-1]}); exhausted infra retries"
+            if not result.get("error"):
+                result["error"] = f"startup/infra failure ({run.infra_reasons[-1]}); exhausted infra retries"
             with open(os.path.join(result_dir, "result.json"), "w") as f:
                 json.dump(result, f, indent=2)
             return result
 
-        if is_one_shot and result["termination_reason"] == TerminationReason.INFRA_ERROR:
-            # Strict one-shot auditing is fail-closed even if the first request
-            # produced tokens before the SDK tried a forbidden second request.
-            # Such a run violated the measurement contract and is not gradeable.
-            result["check_verdict"] = "ERROR"
-            result["error"] = "one-shot request contract violation"
-            with open(os.path.join(result_dir, "result.json"), "w") as f:
-                json.dump(result, f, indent=2)
-            return result
-
-        if is_one_shot and result["termination_reason"] == TerminationReason.TIMEOUT:
-            # Preserve the outer watchdog or propagated provider deadline instead
-            # of materializing a truncated response and replacing the timeout with
-            # a malformed-response failure.
-            result["check_verdict"] = "TIMEOUT"
-            with open(os.path.join(result_dir, "result.json"), "w") as f:
-                json.dump(result, f, indent=2)
-            return result
-
-        if is_one_shot and materialized is not True:
-            # This is a genuine model attempt, but not a gradeable submission.
-            # Do not grade the untouched canonical placeholder: a trivial task
-            # could otherwise turn malformed model output into a bogus PASS.
-            result["check_verdict"] = "FAIL"
-            result["error"] = result["materialization_error"]
+        if submission.disposition != SubmissionDisposition.GRADE:
+            result["check_verdict"] = submission.disposition
             with open(os.path.join(result_dir, "result.json"), "w") as f:
                 json.dump(result, f, indent=2)
             return result
@@ -889,7 +880,7 @@ def _run_continuations(
         # this round's evidence only if this round's agent (re)wrote it.
         check_mtime_before = os.stat(agent_check_file).st_mtime_ns if os.path.isfile(agent_check_file) else None
 
-        run = _run_agent_with_retries(
+        run = _run_backend_with_retries(
             item,
             prompt,
             round_dir,
@@ -968,7 +959,7 @@ def _prepare_session_dir(session_dir: str) -> None:
             f.write("# tlaps-bench session data (may contain credentials) — do not commit\n*\n")
 
 
-def _run_agent_container(
+def _run_backend_container(
     item: WorkItem,
     backend,
     workspace: str,
@@ -978,9 +969,11 @@ def _run_agent_container(
     result: dict,
     canonical_dir: str | None = None,
 ) -> None:
-    """Run agent inside a Docker container with live output streaming."""
+    """Run a backend inside Docker with live output and timeout draining."""
     runner = ContainerRunner()
-    cmd = _build_agent_command(backend, "/workspace", "/results", item.timeout)
+    timeout = item.timeout if item.timeout and item.timeout > 0 else None
+    propagated_deadline = time.time() + timeout if timeout and backend.capabilities.cooperative_deadline else None
+    cmd = _build_backend_command(backend, "/workspace", "/results", propagated_deadline)
 
     config = ContainerConfig(
         workspace=workspace,
@@ -1018,7 +1011,6 @@ def _run_agent_container(
     # at grading.
     config.env["TLAPS_CHECK_TIMEOUT"] = str(item.check_timeout)
 
-    timeout = item.timeout if item.timeout and item.timeout > 0 else None
     container_run = None
     try:
         container_run = runner.run(config, cmd, stdin_data=prompt)
@@ -1040,13 +1032,26 @@ def _run_agent_container(
             fcntl.fcntl(proc.stderr, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
         stderr_chunks: list[str] = []
+        logical_deadline = propagated_deadline or (time.time() + timeout if timeout else None)
+        grace = backend.capabilities.timeout_drain_grace if propagated_deadline is not None else 0.0
+        hard_deadline = logical_deadline + grace if logical_deadline is not None else None
+        timed_out = False
 
         # Stream stdout to file in real-time (and stderr separately)
         with open(agent_jsonl, "w") as jsonl_f:
-            deadline = (time.time() + timeout) if timeout else None
             while True:
-                # Poll with 5s timeout so deadline is checked even if agent hangs
-                ready, _, _ = select.select([proc.stdout], [], [], 5.0)
+                now = time.time()
+                if logical_deadline is not None and now >= logical_deadline:
+                    timed_out = True
+                if timed_out and hard_deadline is not None and now >= hard_deadline:
+                    runner.kill(container_run)
+                    result["agent_exit"] = -1
+                    result["error"] = f"{backend.name} timeout after {item.timeout}s"
+                    return
+
+                boundary = hard_deadline if timed_out else logical_deadline
+                poll_timeout = min(5.0, max(boundary - now, 0.0)) if boundary is not None else 5.0
+                ready, _, _ = select.select([proc.stdout], [], [], poll_timeout)
                 # Drain stderr opportunistically
                 if proc.stderr:
                     try:
@@ -1071,13 +1076,10 @@ def _run_agent_container(
                             sys.stdout.flush()
                 elif proc.poll() is not None:
                     break
-                if deadline and time.time() > deadline:
-                    runner.kill(container_run)
-                    result["agent_exit"] = -1
-                    result["error"] = f"{backend.name} timeout after {item.timeout}s"
-                    return
 
-        result["agent_exit"] = proc.returncode
+        if logical_deadline is not None and time.time() >= logical_deadline:
+            timed_out = True
+        result["agent_exit"] = -1 if timed_out else proc.returncode
         # Drain any remaining stderr
         if proc.stderr:
             try:
@@ -1090,7 +1092,9 @@ def _run_agent_container(
         if stderr:
             with open(os.path.join(agent_dir, "stderr.txt"), "w") as f:
                 f.write(stderr)
-        if proc.returncode == 137:
+        if timed_out:
+            result["error"] = f"{backend.name} timeout after {item.timeout}s"
+        elif proc.returncode == 137:
             result["error"] = "container OOM killed (exit 137)"
     except Exception as e:
         result["agent_exit"] = -2
@@ -1104,7 +1108,7 @@ def _run_agent_container(
             runner.cleanup_credential_tmps()
 
 
-def _run_agent_local(
+def _run_backend_local(
     item: WorkItem,
     backend,
     mode,
@@ -1116,14 +1120,16 @@ def _run_agent_local(
     checker_bin: str,
     canonical_dir: str | None = None,
 ) -> None:
-    """Run agent as a local subprocess (existing behavior)."""
-    cmd = _build_agent_command(backend, workspace, agent_dir, item.timeout)
+    """Run a backend as a local subprocess with its declared timeout policy."""
+    timeout = item.timeout if item.timeout and item.timeout > 0 else None
+    propagated_deadline = time.time() + timeout if timeout and backend.capabilities.cooperative_deadline else None
+    cmd = _build_backend_command(backend, workspace, agent_dir, propagated_deadline)
     shell_cmd = "source ~/.zshrc 2>/dev/null; source ~/.bashrc 2>/dev/null; exec " + " ".join(
         shlex.quote(c) for c in cmd
     )
 
-    _to = item.timeout if item.timeout and item.timeout > 0 else None
     timed_out = {"v": False}
+    hard_kill_timer: threading.Timer | None = None
     proc = None
 
     agent_env = dict(os.environ)
@@ -1153,17 +1159,33 @@ def _run_agent_local(
                 start_new_session=True,
             )
 
-            def _watchdog():
+            logical_deadline = propagated_deadline or (time.time() + timeout if timeout else None)
+            grace = backend.capabilities.timeout_drain_grace if propagated_deadline is not None else 0.0
+
+            def _hard_kill() -> None:
                 timed_out["v"] = True
                 kill_agent_tree(proc, workspace)
 
-            timer = threading.Timer(_to, _watchdog) if _to else None
+            def _logical_timeout() -> None:
+                timed_out["v"] = True
+                if grace <= 0:
+                    _hard_kill()
+
+            timer_delay = max(logical_deadline - time.time(), 0.0) if logical_deadline is not None else None
+            timer = threading.Timer(timer_delay, _logical_timeout) if timer_delay is not None else None
             if timer:
                 timer.daemon = True
                 timer.start()
+            if logical_deadline is not None and grace > 0:
+                hard_delay = max(logical_deadline + grace - time.time(), 0.0)
+                hard_kill_timer = threading.Timer(hard_delay, _hard_kill)
+                hard_kill_timer.daemon = True
+                hard_kill_timer.start()
             try:
-                _bt = (_to + 600) if _to else None
-                _, stderr = proc.communicate(input=prompt, timeout=_bt)
+                hard_wait = (
+                    max(logical_deadline + grace - time.time(), 0.0) + 600 if logical_deadline is not None else None
+                )
+                _, stderr = proc.communicate(input=prompt, timeout=hard_wait)
             except subprocess.TimeoutExpired:
                 timed_out["v"] = True
                 kill_agent_tree(proc, workspace)
@@ -1171,8 +1193,12 @@ def _run_agent_local(
                     proc.wait(timeout=30)
                 stderr = ""
             finally:
+                if logical_deadline is not None and time.time() >= logical_deadline:
+                    timed_out["v"] = True
                 if timer:
                     timer.cancel()
+                if hard_kill_timer:
+                    hard_kill_timer.cancel()
         result["agent_exit"] = proc.returncode
         if stderr:
             with open(os.path.join(agent_dir, "stderr.txt"), "w") as f:
@@ -1188,12 +1214,15 @@ def _run_agent_local(
             kill_agent_tree(proc, workspace)
 
 
-def _build_agent_command(backend, workspace: str, result_dir: str, timeout: int) -> list[str]:
-    """Build a backend command, forwarding the outer limit to one-shot drivers."""
-    cmd = backend.build_command(workspace, result_dir)
-    if getattr(backend, "is_one_shot", False) is True:
-        cmd.extend(("--timeout", str(timeout if timeout > 0 else 0)))
-    return cmd
+def _build_backend_command(
+    backend: Backend,
+    workspace: str,
+    result_dir: str,
+    deadline: float | None,
+) -> list[str]:
+    """Build a command through the backend's approach-specific lifecycle hook."""
+
+    return backend.build_run_command(workspace, result_dir, deadline)
 
 
 def _run_grader_container(
@@ -1372,13 +1401,15 @@ def _run_preflight(backend) -> None:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Run an agent CLI on TLAPS benchmarks")
-    parser.add_argument("--backend", default="codex", choices=list_backends(), help="Agent backend (default: codex)")
+    parser = argparse.ArgumentParser(description="Run evaluator backends on TLAPS benchmarks")
+    parser.add_argument(
+        "--backend", default="codex", choices=list_backends(), help="Evaluator backend (default: codex)"
+    )
     parser.add_argument(
         "--mode", default="proof-completion", choices=list_modes(), help="Benchmark mode (default: proof-completion)"
     )
     parser.add_argument("--model", default=None, help="Override the backend default model")
-    parser.add_argument("--jobs", type=int, default=1, help="Parallel agent runs")
+    parser.add_argument("--jobs", type=int, default=1, help="Parallel backend runs")
     parser.add_argument("--filter", default=None, help="Only run benchmarks matching pattern")
     parser.add_argument(
         "--timeout",
@@ -1511,14 +1542,10 @@ def main():
     # Resolve capability-dependent defaults only after task discovery. This
     # preserves the useful fail-fast behavior for a misspelled --filter: no
     # backend validation, auth probe, image build, or model request happens.
-    is_one_shot = getattr(backend, "is_one_shot", False) is True
-    supports_continuations = getattr(backend, "supports_continuations", True) is not False
-    if args.infra_retries is None:
-        args.infra_retries = getattr(backend, "default_infra_retries", 3)
-    if is_one_shot and args.infra_retries != 0:
-        parser.error("strict one-shot backends require --infra-retries 0")
-    if not supports_continuations and args.max_continuations != 0:
-        parser.error(f"backend {backend.name!r} does not support --max-continuations")
+    try:
+        args.infra_retries = backend.validate_options(args.infra_retries, args.max_continuations)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     auth_err = backend.check_auth()
     if auth_err:
@@ -1552,10 +1579,10 @@ def main():
         # id, unknown CLI flag, missing credentials, or an auth host the
         # firewall blocks) otherwise produces a whole sweep of silent 0-token
         # FAILs that look like honest "couldn't prove it" results.
-        if not args.skip_preflight and getattr(backend, "supports_model_preflight", True) is not False:
+        if not args.skip_preflight and backend.capabilities.model_preflight:
             _run_preflight(backend)
         elif not args.skip_preflight:
-            print("Preflight: skipped — strict one-shot backends cannot spend an extra model request")
+            print(f"Preflight: skipped — backend {backend.name!r} does not support a model preflight request")
     else:
         # Local mode: require tlapm and checker on host
         ensure_tlapm()

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -219,6 +219,60 @@ def copilot_session_error(ctx: TerminationContext) -> str | None:
     return TerminationReason.INFRA_ERROR
 
 
+def one_shot_result_error(ctx: TerminationContext) -> str | None:
+    """One-shot rule: require one response, audit, and clean provider result.
+
+    The shared one-shot driver emits a terminal ``result`` event. Provider,
+    authentication, transport, or request-guard failures end with
+    ``status == "error"`` and no complete response; grading the untouched
+    ``PROOF OBVIOUS`` file would misreport that infrastructure failure as a
+    model capability failure.
+
+    A clean response whose text is not a complete TLA+ module remains a genuine
+    attempt: the runner records the materialization failure as FAIL without
+    grading the untouched placeholder.
+    """
+    if not ctx.backend.endswith("_oneshot"):
+        return None
+    events = ctx.events()
+    if not events:
+        return None
+    responses = [event for event in events if event.get("type") == "response"]
+    audits = [event for event in events if event.get("type") == "request_audit"]
+    results = [event for event in events if event.get("type") == "result"]
+    if len(responses) != 1 or len(audits) != 1 or len(results) != 1:
+        return TerminationReason.INFRA_ERROR
+
+    def is_count(value: object, expected: int) -> bool:
+        return isinstance(value, int) and not isinstance(value, bool) and value == expected
+
+    terminal = results[0]
+    if terminal.get("status") != "success" or not is_count(terminal.get("model_requests"), 1):
+        return TerminationReason.INFRA_ERROR
+    audit = audits[0]
+    provider = ctx.backend.removesuffix("_oneshot")
+    if audit.get("provider") != provider:
+        return TerminationReason.INFRA_ERROR
+    if provider == "copilot" and not (
+        audit.get("wire_audited") is True
+        and is_count(audit.get("inference_requests"), 1)
+        and is_count(audit.get("inference_attempts"), 1)
+        and is_count(audit.get("blocked_requests"), 0)
+        and audit.get("system_removed") is True
+        and audit.get("tools_removed") is True
+    ):
+        return TerminationReason.INFRA_ERROR
+    if provider == "litellm" and not (
+        audit.get("wire_audited") is False
+        and is_count(audit.get("litellm_completion_invocations"), 1)
+        and audit.get("litellm_retries_disabled") is True
+        and audit.get("system_supplied") is False
+        and audit.get("tools_supplied") is False
+    ):
+        return TerminationReason.INFRA_ERROR
+    return None
+
+
 def agent_startup_failure(ctx: TerminationContext) -> str | None:
     """Backend-independent rule: the CLI died before emitting a single event
     (observed on Copilot: transient model-list/auth/DNS startup failures with a
@@ -251,6 +305,7 @@ INFRA_RULES: list[Rule] = [
     codex_turn_failed,
     claude_code_result_error,
     copilot_session_error,
+    one_shot_result_error,
     agent_startup_failure,
 ]
 

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -18,7 +18,8 @@ inspects a ``TerminationContext`` and returns a reason if it fires, else
 :func:`copilot_session_error`), each branching on ``ctx.backend`` to read its
 own event vocabulary, plus one backend-independent startup rule
 (:func:`agent_startup_failure`) for the CLI dying before emitting a single
-event. Add more by appending to :data:`INFRA_RULES`.
+event. The one-shot rule may also return TIMEOUT for a strictly audited
+provider deadline. Add more by appending to :data:`INFRA_RULES`.
 
 This module only CLASSIFIES. Acting on the classification (the runner auto-
 retries an INFRA_ERROR run whose model did no work) is left to the caller.
@@ -220,16 +221,20 @@ def copilot_session_error(ctx: TerminationContext) -> str | None:
 
 
 def one_shot_result_error(ctx: TerminationContext) -> str | None:
-    """One-shot rule: require one response, audit, and clean provider result.
+    """One-shot rule: require an audited terminal result and one clean response.
 
     The shared one-shot driver emits a terminal ``result`` event. Provider,
     authentication, transport, or request-guard failures end with
-    ``status == "error"`` and no complete response; grading the untouched
+    ``status == "error"`` and no successful response; grading the untouched
     ``PROOF OBVIOUS`` file would misreport that infrastructure failure as a
     model capability failure.
 
-    A clean response whose text is not a complete TLA+ module remains a genuine
-    attempt: the runner records the materialization failure as FAIL without
+    A propagated provider deadline ends with ``status == "timeout"`` and is a
+    time limit just like the outer runner watchdog, not infrastructure.
+
+    A clean, unique, non-empty response remains a genuine attempt regardless of
+    its text: the runner materializes it and leaves TLA+ syntax and semantics to
+    the grader. Missing or ambiguous response content is recorded as FAIL without
     grading the untouched placeholder.
     """
     if not ctx.backend.endswith("_oneshot"):
@@ -237,18 +242,18 @@ def one_shot_result_error(ctx: TerminationContext) -> str | None:
     events = ctx.events()
     if not events:
         return None
-    responses = [event for event in events if event.get("type") == "response"]
     audits = [event for event in events if event.get("type") == "request_audit"]
     results = [event for event in events if event.get("type") == "result"]
-    if len(responses) != 1 or len(audits) != 1 or len(results) != 1:
+    if len(audits) != 1 or len(results) != 1:
         return TerminationReason.INFRA_ERROR
 
     def is_count(value: object, expected: int) -> bool:
         return isinstance(value, int) and not isinstance(value, bool) and value == expected
 
     terminal = results[0]
-    if terminal.get("status") != "success" or not is_count(terminal.get("model_requests"), 1):
+    if not is_count(terminal.get("model_requests"), 1):
         return TerminationReason.INFRA_ERROR
+
     audit = audits[0]
     provider = ctx.backend.removesuffix("_oneshot")
     if audit.get("provider") != provider:
@@ -269,6 +274,17 @@ def one_shot_result_error(ctx: TerminationContext) -> str | None:
         and audit.get("system_supplied") is False
         and audit.get("tools_supplied") is False
     ):
+        return TerminationReason.INFRA_ERROR
+    if provider not in {"copilot", "litellm"}:
+        return TerminationReason.INFRA_ERROR
+
+    responses = [event for event in events if event.get("type") == "response"]
+    if terminal.get("status") == "timeout":
+        return TerminationReason.TIMEOUT if not responses else TerminationReason.INFRA_ERROR
+
+    if len(responses) != 1:
+        return TerminationReason.INFRA_ERROR
+    if terminal.get("status") != "success":
         return TerminationReason.INFRA_ERROR
     return None
 
@@ -328,8 +344,8 @@ def classify(ctx: TerminationContext) -> str:
     """Return the run's TerminationReason.
 
     A wall-clock timeout (a LIMIT, backend-independent) takes precedence over the
-    per-backend INFRA rules, so every backend agrees on it; otherwise the first
-    INFRA rule that fires wins, else OK.
+    per-backend rules, so every backend agrees on it; otherwise the first rule
+    that fires wins (including an audited one-shot provider deadline), else OK.
     """
     if is_wall_clock_timeout(ctx):
         return TerminationReason.TIMEOUT

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -60,7 +60,8 @@ class TerminationContext:
     """The evidence a rule may inspect.
 
     ``backend`` lets a rule apply only to the backend whose event format it
-    understands. ``events()`` lazily parses the agent's JSONL event stream
+    understands. ``approach`` and ``provider`` identify cross-provider contracts
+    without encoding semantics in a backend-name suffix. ``events()`` lazily parses the backend's JSONL event stream
     (empty list on a missing/unreadable file), so rules that don't need it pay
     nothing. ``agent_exit`` and ``error`` are the runner's already-recorded
     fields, available to rules that key off them instead of the stream.
@@ -70,16 +71,25 @@ class TerminationContext:
 
     backend: str
     jsonl_path: str | None
+    approach: str = "agentic"
+    provider: str | None = None
+    request_audit_validator: Callable[[dict[str, object], int], bool] | None = None
     agent_exit: int | None = None
     error: str = ""
     stderr_path: str | None = None
     _events: list | None = None
+    _event_stream_valid: bool | None = None
     _stderr: str | None = None
 
     def events(self) -> list:
         if self._events is None:
-            self._events = _read_events(self.jsonl_path)
+            self._events, self._event_stream_valid = _read_event_stream(self.jsonl_path)
         return self._events
+
+    def event_stream_valid(self) -> bool:
+        if self._events is None:
+            self._events, self._event_stream_valid = _read_event_stream(self.jsonl_path)
+        return self._event_stream_valid is True
 
     def stderr(self) -> str:
         if self._stderr is None:
@@ -87,12 +97,18 @@ class TerminationContext:
         return self._stderr
 
 
-def _read_events(path: str | None) -> list:
-    """Parse a JSONL event stream into a list of dicts, tolerantly (skip blank
-    and unparseable lines; empty list if the file is absent)."""
+def _read_event_stream(path: str | None) -> tuple[list[dict], bool]:
+    """Parse JSONL dictionaries and separately retain stream-integrity evidence.
+
+    Agentic rules keep their historical tolerance by consuming only ``events``.
+    Strict approaches can fail closed when a non-blank line is malformed, is not
+    a JSON object, or the stream cannot be read.
+    """
+
     if not path:
-        return []
-    out: list = []
+        return [], False
+    out: list[dict] = []
+    valid = True
     try:
         with open(path) as f:
             for raw in f:
@@ -100,12 +116,17 @@ def _read_events(path: str | None) -> list:
                 if not raw:
                     continue
                 try:
-                    out.append(json.loads(raw))
+                    event = json.loads(raw)
                 except json.JSONDecodeError:
+                    valid = False
                     continue
-    except FileNotFoundError:
-        return []
-    return out
+                if isinstance(event, dict):
+                    out.append(event)
+                else:
+                    valid = False
+    except (OSError, UnicodeError):
+        return [], False
+    return out, valid
 
 
 def _read_text(path: str | None) -> str:
@@ -237,11 +258,11 @@ def one_shot_result_error(ctx: TerminationContext) -> str | None:
     the grader. Missing or ambiguous response content is recorded as FAIL without
     grading the untouched placeholder.
     """
-    if not ctx.backend.endswith("_oneshot"):
+    if ctx.approach != "one_shot":
         return None
     events = ctx.events()
-    if not events:
-        return None
+    if not ctx.event_stream_valid() or not events:
+        return TerminationReason.INFRA_ERROR
     audits = [event for event in events if event.get("type") == "request_audit"]
     results = [event for event in events if event.get("type") == "result"]
     if len(audits) != 1 or len(results) != 1:
@@ -251,38 +272,19 @@ def one_shot_result_error(ctx: TerminationContext) -> str | None:
         return isinstance(value, int) and not isinstance(value, bool) and value == expected
 
     terminal = results[0]
-    if not is_count(terminal.get("model_requests"), 1):
+    request_count = terminal.get("model_requests")
+    if not isinstance(request_count, int) or isinstance(request_count, bool) or request_count not in {0, 1}:
         return TerminationReason.INFRA_ERROR
 
     audit = audits[0]
-    provider = ctx.backend.removesuffix("_oneshot")
-    if audit.get("provider") != provider:
-        return TerminationReason.INFRA_ERROR
-    if provider == "copilot" and not (
-        audit.get("wire_audited") is True
-        and is_count(audit.get("inference_requests"), 1)
-        and is_count(audit.get("inference_attempts"), 1)
-        and is_count(audit.get("blocked_requests"), 0)
-        and audit.get("system_removed") is True
-        and audit.get("tools_removed") is True
-    ):
-        return TerminationReason.INFRA_ERROR
-    if provider == "litellm" and not (
-        audit.get("wire_audited") is False
-        and is_count(audit.get("litellm_completion_invocations"), 1)
-        and audit.get("litellm_retries_disabled") is True
-        and audit.get("system_supplied") is False
-        and audit.get("tools_supplied") is False
-    ):
-        return TerminationReason.INFRA_ERROR
-    if provider not in {"copilot", "litellm"}:
+    if ctx.request_audit_validator is None or not ctx.request_audit_validator(audit, request_count):
         return TerminationReason.INFRA_ERROR
 
     responses = [event for event in events if event.get("type") == "response"]
     if terminal.get("status") == "timeout":
         return TerminationReason.TIMEOUT if not responses else TerminationReason.INFRA_ERROR
 
-    if len(responses) != 1:
+    if not is_count(request_count, 1) or len(responses) != 1:
         return TerminationReason.INFRA_ERROR
     if terminal.get("status") != "success":
         return TerminationReason.INFRA_ERROR

--- a/src/tlaps_bench/cli.py
+++ b/src/tlaps_bench/cli.py
@@ -2,7 +2,7 @@ import sys
 
 # (subcommand, one-line help) — order is the order shown in --help.
 SUBCOMMANDS = [
-    ("run", "Run an agent backend (codex / claude_code / copilot / litellm) on the benchmarks"),
+    ("run", "Run an evaluator backend on the benchmarks"),
     ("check", "Check a single benchmark proof for correctness and cheating"),
     ("validate", "Batch-validate source proofs with tlapm"),
     ("generate", "Generate benchmarks (--mode proof-completion|proof-from-scratch; default proof-completion)"),

--- a/tests/evaluator/test_container.py
+++ b/tests/evaluator/test_container.py
@@ -491,7 +491,7 @@ class TestRunPreflight:
 
 
 class TestRunAgentContainerSessionWiring:
-    """_run_agent_container composes keep_container / session_dir onto the config."""
+    """_run_backend_container composes keep_container / session_dir onto the config."""
 
     def _capture_config(self, tmp_path, *, keep_container=False, session_dir=""):
         from evaluator import runner as runner_mod
@@ -519,7 +519,7 @@ class TestRunAgentContainerSessionWiring:
 
         result: dict = {}
         with patch.object(runner_mod, "ContainerRunner", _FakeRunner):
-            runner_mod._run_agent_container(
+            runner_mod._run_backend_container(
                 item,
                 backend,
                 str(tmp_path / "ws"),

--- a/tests/evaluator/test_continuation.py
+++ b/tests/evaluator/test_continuation.py
@@ -14,6 +14,7 @@ import json
 import os
 
 from evaluator import runner
+from evaluator.backends.agentic import AgenticBackend
 from evaluator.termination import TerminationReason
 
 BENCH_TEXT = "---- MODULE Bar ----\n====\n"
@@ -27,7 +28,7 @@ STARTUP = {"exit": 1, "stderr": "Error: Failed to load models\n"}
 GENUINE = {"exit": 0, "events": CLEAN_EVENTS, "out_tokens": 500}
 
 
-class _ScriptedBackend:
+class _ScriptedBackend(AgenticBackend):
     """Backend whose per-call behavior is scripted (see _install_agent)."""
 
     name = "copilot"
@@ -37,6 +38,9 @@ class _ScriptedBackend:
 
     def parse_output(self, jsonl_path):
         return ("", 0, self.out_tokens)
+
+    def build_command(self, workspace, result_dir):
+        return ["fake-agent"]
 
     def detect_quota_block(self, jsonl_path):
         return None
@@ -84,7 +88,7 @@ def _work_item(tmp_path, backend, max_continuations=0, infra_retries=0):
 
 
 def _install_agent(monkeypatch, backend, calls_spec):
-    """Patch _run_agent_local with a scripted agent: one spec dict per call
+    """Patch _run_backend_local with a scripted agent: one spec dict per call
     ({"exit": int, "events": [...], "stderr": str, "out_tokens": int,
     "mutate": fn(workspace)}), recording workspace/prompt/canonical per call."""
     calls = {"n": 0, "workspaces": [], "prompts": [], "agent_dirs": [], "canonical_dirs": []}
@@ -109,7 +113,7 @@ def _install_agent(monkeypatch, backend, calls_spec):
         if "mutate" in spec:
             spec["mutate"](workspace)
 
-    monkeypatch.setattr(runner, "_run_agent_local", fake_run)
+    monkeypatch.setattr(runner, "_run_backend_local", fake_run)
     return calls
 
 

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -14,6 +14,7 @@ import os
 import pytest
 
 from evaluator import runner
+from evaluator.backends.agentic import AgenticBackend
 from evaluator.termination import TerminationReason
 
 BENCH_TEXT = "---- MODULE Bar ----\n====\n"
@@ -27,7 +28,7 @@ STARTUP = {"exit": 1, "stderr": "Error: Failed to load models\n\nError: Failed t
 GENUINE_FAIL = {"exit": 0, "events": CLEAN_EVENTS, "out_tokens": 500}
 
 
-class _ScriptedBackend:
+class _ScriptedBackend(AgenticBackend):
     """Backend whose per-attempt behavior is scripted (see _install_agent)."""
 
     name = "copilot"
@@ -37,6 +38,9 @@ class _ScriptedBackend:
 
     def parse_output(self, jsonl_path):
         return ("", 0, self.out_tokens)
+
+    def build_command(self, workspace, result_dir):
+        return ["fake-agent"]
 
     def detect_quota_block(self, jsonl_path):
         return None
@@ -80,7 +84,7 @@ def _work_item(tmp_path, backend, infra_retries=3):
 
 
 def _install_agent(monkeypatch, backend, attempts):
-    """Patch _run_agent_local with a scripted agent: one spec dict per attempt
+    """Patch _run_backend_local with a scripted agent: one spec dict per attempt
     ({"exit": int, "events": [...], "stderr": str, "out_tokens": int,
     "error": str, "mutate": fn(workspace)})."""
     calls = {"n": 0, "workspaces": [], "canonical_dirs": []}
@@ -107,7 +111,7 @@ def _install_agent(monkeypatch, backend, attempts):
         if "mutate_canonical" in spec:
             spec["mutate_canonical"](canonical_dir)
 
-    monkeypatch.setattr(runner, "_run_agent_local", fake_run)
+    monkeypatch.setattr(runner, "_run_backend_local", fake_run)
     return calls
 
 

--- a/tests/evaluator/test_oneshot_backends.py
+++ b/tests/evaluator/test_oneshot_backends.py
@@ -1,0 +1,402 @@
+"""Shared one-shot backend contract and provider wiring."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+from evaluator import runner
+from evaluator.backends import get_backend, list_backends
+from evaluator.backends.copilot_oneshot import CopilotOneShotBackend
+from evaluator.backends.litellm_oneshot import LiteLLMOneShotBackend
+
+MODULE = "---- MODULE Example ----\nTHEOREM Target == TRUE\nPROOF OBVIOUS\n====\n"
+
+
+def _write_events(path, *events):
+    path.write_text("".join(json.dumps(event) + "\n" for event in events))
+
+
+class _OneShotMode:
+    name = "proof-completion"
+    description = "test mode"
+
+    def __init__(self, benchmark_root):
+        self._benchmark_root = str(benchmark_root)
+
+    def benchmark_dir(self):
+        return self._benchmark_root
+
+    def get_benchmark_files(self, filter_pattern=None):
+        return [os.path.join(self._benchmark_root, "Suite", "Example.tla")]
+
+    def get_dependencies(self, benchmark_path):
+        return []
+
+    def checker_binary_path(self):
+        return "/bin/true"
+
+    def build_one_shot_prompt(self, benchmark_path, dependencies):
+        return "return one complete module"
+
+
+def test_registry_exposes_both_oneshot_providers():
+    assert "litellm_oneshot" in list_backends()
+    assert "copilot_oneshot" in list_backends()
+    assert isinstance(get_backend("litellm_oneshot", model="openai/gpt-5"), LiteLLMOneShotBackend)
+    assert isinstance(get_backend("copilot_oneshot", model="gpt-5"), CopilotOneShotBackend)
+
+
+def test_shared_command_and_capabilities(tmp_path):
+    backend = LiteLLMOneShotBackend(model="anthropic/claude-sonnet-4-6")
+
+    assert backend.build_command("/workspace", "/results") == [
+        "python3",
+        "/opt/oneshot_runner.py",
+        "--provider",
+        "litellm",
+        "--workspace",
+        "/workspace",
+        "--result-dir",
+        "/results",
+        "--model",
+        "anthropic/claude-sonnet-4-6",
+    ]
+    assert backend.is_one_shot is True
+    assert backend.supports_model_preflight is False
+    assert backend.supports_continuations is False
+    assert backend.default_infra_retries == 0
+
+
+def test_shared_command_uses_source_runner_for_native_execution(tmp_path):
+    backend = CopilotOneShotBackend(model="gpt-5")
+
+    command = backend.build_command(str(tmp_path), str(tmp_path / "results"))
+
+    assert command[0] == "python3"
+    assert command[1].endswith("/src/evaluator/backends/oneshot_runner.py")
+    assert command[2:5] == ["--provider", "copilot", "--workspace"]
+
+
+def test_parse_output_and_request_metadata(tmp_path):
+    events = tmp_path / "output.jsonl"
+    events.write_text(
+        "not json\n"
+        + json.dumps({"type": "response", "text": MODULE})
+        + "\n"
+        + json.dumps({"type": "usage", "input_tokens": 120, "output_tokens": 80})
+        + "\n"
+        + json.dumps(
+            {
+                "type": "request_audit",
+                "provider": "copilot",
+                "inference_requests": 1,
+                "request_sha256": "abc123",
+                "system_removed": True,
+                "tools_removed": True,
+            }
+        )
+        + "\n"
+    )
+    backend = CopilotOneShotBackend(model="gpt-5")
+
+    transcript, input_tokens, output_tokens = backend.parse_output(str(events))
+    metadata = backend.parse_run_metadata(str(events))
+
+    assert transcript == f"[AGENT] {MODULE}\n"
+    assert (input_tokens, output_tokens) == (120, 80)
+    assert metadata == {
+        "one_shot": True,
+        "provider": "copilot",
+        "request_sha256": "abc123",
+        "system_removed": True,
+        "tools_removed": True,
+        "model_requests": 1,
+    }
+
+
+def test_materializes_raw_complete_module_atomically(tmp_path):
+    events = tmp_path / "output.jsonl"
+    destination = tmp_path / "Example.tla"
+    destination.write_text("original\n")
+    _write_events(events, {"type": "response", "text": f"\n{MODULE}\n"})
+
+    assert LiteLLMOneShotBackend().materialize_solution(str(events), str(destination)) is True
+    assert destination.read_text() == MODULE
+
+
+def test_materializes_unique_tla_fence(tmp_path):
+    events = tmp_path / "output.jsonl"
+    destination = tmp_path / "Example.tla"
+    _write_events(events, {"type": "response", "text": f"```tla\n{MODULE}```"})
+
+    assert CopilotOneShotBackend().materialize_solution(str(events), str(destination)) is True
+    assert destination.read_text() == MODULE
+
+
+def test_materialize_rejects_snippets_patches_and_multiple_fences(tmp_path):
+    backend = LiteLLMOneShotBackend()
+    destination = tmp_path / "Example.tla"
+    destination.write_text("original\n")
+    invalid_responses = [
+        "PROOF OBVIOUS",
+        f"@@ -1,2 +1,2 @@\n+{MODULE}",
+        f"```tla\n{MODULE}```\n```tla\n{MODULE}```",
+        f"```text\n{MODULE}```",
+        f"Here is the module:\n```tla\n{MODULE}```",
+        f"{MODULE}\nignored after the module",
+    ]
+
+    for index, response in enumerate(invalid_responses):
+        events = tmp_path / f"output-{index}.jsonl"
+        _write_events(events, {"type": "response", "text": response})
+        assert backend.materialize_solution(str(events), str(destination)) is False
+        assert destination.read_text() == "original\n"
+
+
+def test_materialize_rejects_ambiguous_response_events(tmp_path):
+    events = tmp_path / "output.jsonl"
+    destination = tmp_path / "Example.tla"
+    _write_events(events, {"type": "response", "text": MODULE}, {"type": "response", "text": MODULE})
+
+    assert LiteLLMOneShotBackend().materialize_solution(str(events), str(destination)) is False
+    assert not destination.exists()
+
+
+def test_materialize_rejects_valid_module_mixed_with_another_response(tmp_path):
+    events = tmp_path / "output.jsonl"
+    destination = tmp_path / "Example.tla"
+    _write_events(events, {"type": "response", "text": "preface"}, {"type": "response", "text": MODULE})
+
+    assert LiteLLMOneShotBackend().materialize_solution(str(events), str(destination)) is False
+    assert not destination.exists()
+
+
+def test_copilot_oneshot_requires_explicit_token_and_has_no_session(monkeypatch):
+    for key in CopilotOneShotBackend.env_keys:
+        monkeypatch.delenv(key, raising=False)
+    backend = CopilotOneShotBackend()
+
+    assert backend.check_auth() == "copilot_oneshot: COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN not set"
+    assert backend.session_state_dir is None
+    assert backend.install_script == "install-copilot-sdk.sh"
+    assert "api.github.com" in backend.firewall_hosts()
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    assert backend.check_auth() is None
+
+
+def test_litellm_oneshot_reuses_litellm_auth_and_firewall(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    backend = LiteLLMOneShotBackend(model="anthropic/claude-sonnet-4-6")
+
+    assert backend.check_auth() == "litellm: ANTHROPIC_API_KEY not set for anthropic model"
+    assert backend.install_script == "install-litellm-oneshot.sh"
+    assert "api.anthropic.com" in backend.firewall_hosts()
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    assert backend.check_auth() is None
+
+
+def test_malformed_response_is_genuine_fail_without_grading_untouched_target(tmp_path, monkeypatch):
+    benchmark_root = tmp_path / "benchmark"
+    benchmark = benchmark_root / "Suite" / "Example.tla"
+    benchmark.parent.mkdir(parents=True)
+    benchmark.write_text(MODULE)
+    output_dir = tmp_path / "results"
+    backend = LiteLLMOneShotBackend()
+    mode = _OneShotMode(benchmark_root)
+    item = runner.WorkItem(
+        benchmark_path=str(benchmark),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=backend,
+        mode=mode,  # ty:ignore[invalid-argument-type]
+        tlapm_path="/bin/true",
+        tlapm_lib="",
+        infra_retries=0,
+    )
+    grader_calls = []
+
+    def fake_agent(
+        item_, backend_, mode_, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir=None
+    ):
+        with open(agent_jsonl, "w") as stream:
+            stream.write(json.dumps({"type": "response", "text": "PROOF OBVIOUS"}) + "\n")
+            stream.write(
+                json.dumps({"type": "usage", "input_tokens": 10, "output_tokens": 3, "model_requests": 1}) + "\n"
+            )
+            stream.write(
+                json.dumps(
+                    {
+                        "type": "request_audit",
+                        "provider": "litellm",
+                        "litellm_completion_invocations": 1,
+                        "wire_audited": False,
+                        "litellm_retries_disabled": True,
+                        "system_supplied": False,
+                        "tools_supplied": False,
+                    }
+                )
+                + "\n"
+            )
+            stream.write(json.dumps({"type": "result", "status": "success", "model_requests": 1}) + "\n")
+        result["agent_exit"] = 0
+
+    def fake_grader(item_, workspace, basename, grading_dir, check_result_path, result, canonical_dir=None):
+        grader_calls.append(workspace)
+        result["check_verdict"] = "PASS"
+
+    monkeypatch.setattr(runner, "_run_agent_local", fake_agent)
+    monkeypatch.setattr(runner, "_run_grader_local", fake_grader)
+
+    result = runner.run_single_benchmark(item)
+    solution = output_dir / "Suite" / "Example" / "agent" / "solution.tla"
+
+    assert result["termination_reason"] == "OK"
+    assert result["check_verdict"] == "FAIL"
+    assert result["materialized"] is False
+    assert result["model_requests"] == 1
+    assert grader_calls == []
+    assert not solution.exists()
+
+
+def test_second_request_violation_is_error_even_after_model_output(tmp_path, monkeypatch):
+    benchmark_root = tmp_path / "benchmark"
+    benchmark = benchmark_root / "Suite" / "Example.tla"
+    benchmark.parent.mkdir(parents=True)
+    benchmark.write_text(MODULE)
+    output_dir = tmp_path / "results"
+    backend = LiteLLMOneShotBackend()
+    item = runner.WorkItem(
+        benchmark_path=str(benchmark),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=backend,
+        mode=_OneShotMode(benchmark_root),  # ty:ignore[invalid-argument-type]
+        tlapm_path="/bin/true",
+        tlapm_lib="",
+        infra_retries=0,
+    )
+    materialize_calls = []
+    grader_calls = []
+
+    def fake_agent(
+        item_, backend_, mode_, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir=None
+    ):
+        with open(agent_jsonl, "w") as stream:
+            stream.write(json.dumps({"type": "response", "text": MODULE}) + "\n")
+            stream.write(
+                json.dumps({"type": "usage", "input_tokens": 40, "output_tokens": 20, "model_requests": 1}) + "\n"
+            )
+            stream.write(json.dumps({"type": "request_audit", "inference_requests": 2}) + "\n")
+            stream.write(json.dumps({"type": "result", "status": "error", "model_requests": 2}) + "\n")
+        result["agent_exit"] = 1
+
+    def fake_materialize(jsonl_path, destination):
+        materialize_calls.append((jsonl_path, destination))
+        return True
+
+    def fake_grader(item_, workspace, basename, grading_dir, check_result_path, result, canonical_dir=None):
+        grader_calls.append(workspace)
+        result["check_verdict"] = "PASS"
+
+    monkeypatch.setattr(runner, "_run_agent_local", fake_agent)
+    monkeypatch.setattr(backend, "materialize_solution", fake_materialize)
+    monkeypatch.setattr(runner, "_run_grader_local", fake_grader)
+
+    result = runner.run_single_benchmark(item)
+    solution = output_dir / "Suite" / "Example" / "agent" / "solution.tla"
+
+    assert result["termination_reason"] == "INFRA_ERROR"
+    assert result["check_verdict"] == "ERROR"
+    assert result["error"] == "one-shot request contract violation"
+    assert result["model_requests"] == 2
+    assert result["output_tokens"] == 20
+    assert "materialized" not in result
+    assert materialize_calls == []
+    assert grader_calls == []
+    assert not solution.exists()
+
+
+def _install_cli_fakes(monkeypatch, tmp_path, preflight_calls, captured_items):
+    benchmark_root = tmp_path / "benchmark"
+    mode = _OneShotMode(benchmark_root)
+    monkeypatch.setattr(runner, "get_mode", lambda *args: mode)
+    monkeypatch.setattr(runner, "ensure_image", lambda force=False: None)
+    monkeypatch.setattr(runner, "_run_preflight", lambda backend: preflight_calls.append(backend.name))
+    monkeypatch.setattr(runner, "update_summary", lambda *args: None)
+
+    def fake_run(item):
+        captured_items.append(item)
+        return {
+            "benchmark": "Suite/Example.tla",
+            "check_verdict": "FAIL",
+            "time_secs": 0,
+            "input_tokens": 1,
+            "output_tokens": 1,
+        }
+
+    monkeypatch.setattr(runner, "run_single_benchmark", fake_run)
+
+
+def test_cli_uses_zero_infra_retries_and_skips_model_preflight_for_oneshot(tmp_path, monkeypatch):
+    preflight_calls = []
+    captured_items = []
+    _install_cli_fakes(monkeypatch, tmp_path, preflight_calls, captured_items)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "tlaps-bench",
+            "--backend",
+            "litellm_oneshot",
+            "--output-dir",
+            str(tmp_path / "results"),
+        ],
+    )
+
+    runner.main()
+
+    assert len(captured_items) == 1
+    assert captured_items[0].infra_retries == 0
+    assert preflight_calls == []
+
+
+@pytest.mark.parametrize(
+    "extra_args, expected_error",
+    [
+        (["--infra-retries", "1"], "strict one-shot backends require --infra-retries 0"),
+        (["--max-continuations", "1"], "does not support --max-continuations"),
+    ],
+)
+def test_cli_rejects_non_oneshot_controls(tmp_path, monkeypatch, capsys, extra_args, expected_error):
+    preflight_calls = []
+    captured_items = []
+    _install_cli_fakes(monkeypatch, tmp_path, preflight_calls, captured_items)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "tlaps-bench",
+            "--backend",
+            "litellm_oneshot",
+            "--output-dir",
+            str(tmp_path / "results"),
+            *extra_args,
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.main()
+
+    assert exc_info.value.code == 2
+    assert expected_error in capsys.readouterr().err
+    assert preflight_calls == []
+    assert captured_items == []

--- a/tests/evaluator/test_oneshot_backends.py
+++ b/tests/evaluator/test_oneshot_backends.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
 from evaluator import runner
 from evaluator.backends import get_backend, list_backends
+from evaluator.backends.agentic import AgenticBackend
 from evaluator.backends.copilot_oneshot import CopilotOneShotBackend
 from evaluator.backends.litellm_oneshot import LiteLLMOneShotBackend
+from evaluator.backends.oneshot import OneShotBackend
 
 MODULE = "---- MODULE Example ----\nTHEOREM Target == TRUE\nPROOF OBVIOUS\n====\n"
 
@@ -65,10 +68,12 @@ def test_shared_command_and_capabilities(tmp_path):
         "--model",
         "anthropic/claude-sonnet-4-6",
     ]
-    assert backend.is_one_shot is True
-    assert backend.supports_model_preflight is False
-    assert backend.supports_continuations is False
-    assert backend.default_infra_retries == 0
+    assert isinstance(backend, OneShotBackend)
+    assert not isinstance(backend, AgenticBackend)
+    assert backend.approach == "one_shot"
+    assert backend.capabilities.model_preflight is False
+    assert backend.capabilities.max_continuations == 0
+    assert backend.capabilities.default_infra_retries == 0
 
 
 def test_shared_command_uses_module_runner_for_native_execution(tmp_path):
@@ -92,6 +97,9 @@ def test_parse_output_and_request_metadata(tmp_path):
             {
                 "type": "request_audit",
                 "provider": "copilot",
+                "model_requests": 1,
+                "audit_scope": "wire",
+                "contract_ok": True,
                 "inference_requests": 1,
                 "request_sha256": "abc123",
                 "system_removed": True,
@@ -110,6 +118,8 @@ def test_parse_output_and_request_metadata(tmp_path):
     assert metadata == {
         "one_shot": True,
         "provider": "copilot",
+        "audit_scope": "wire",
+        "contract_ok": True,
         "request_sha256": "abc123",
         "system_removed": True,
         "tools_removed": True,
@@ -217,7 +227,7 @@ def test_litellm_oneshot_reuses_litellm_auth_and_firewall(monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     backend = LiteLLMOneShotBackend(model="anthropic/claude-sonnet-4-6")
 
-    assert backend.check_auth() == "litellm: ANTHROPIC_API_KEY not set for anthropic model"
+    assert backend.check_auth() == "litellm_oneshot: ANTHROPIC_API_KEY not set for anthropic model"
     assert backend.install_script == "install-litellm-oneshot.sh"
     assert "api.anthropic.com" in backend.firewall_hosts()
 
@@ -259,6 +269,14 @@ def test_unstructured_response_is_materialized_and_left_to_grader(tmp_path, monk
                     {
                         "type": "request_audit",
                         "provider": "litellm",
+                        "model_requests": 1,
+                        "request_attempts": 1,
+                        "blocked_requests": 0,
+                        "system_prompt_present": False,
+                        "tools_present": False,
+                        "retries_enabled": False,
+                        "audit_scope": "adapter",
+                        "contract_ok": True,
                         "litellm_completion_invocations": 1,
                         "wire_audited": False,
                         "litellm_retries_disabled": True,
@@ -275,7 +293,7 @@ def test_unstructured_response_is_materialized_and_left_to_grader(tmp_path, monk
         grader_calls.append(workspace)
         result["check_verdict"] = "PASS"
 
-    monkeypatch.setattr(runner, "_run_agent_local", fake_agent)
+    monkeypatch.setattr(runner, "_run_backend_local", fake_agent)
     monkeypatch.setattr(runner, "_run_grader_local", fake_grader)
 
     result = runner.run_single_benchmark(item)
@@ -318,7 +336,21 @@ def test_second_request_violation_is_error_even_after_model_output(tmp_path, mon
             stream.write(
                 json.dumps({"type": "usage", "input_tokens": 40, "output_tokens": 20, "model_requests": 1}) + "\n"
             )
-            stream.write(json.dumps({"type": "request_audit", "inference_requests": 2}) + "\n")
+            stream.write(
+                json.dumps(
+                    {
+                        "type": "request_audit",
+                        "provider": "copilot",
+                        "model_requests": 1,
+                        "audit_scope": "wire",
+                        "contract_ok": False,
+                        "inference_requests": 1,
+                        "inference_attempts": 2,
+                        "blocked_requests": 1,
+                    }
+                )
+                + "\n"
+            )
             stream.write(json.dumps({"type": "result", "status": "error", "model_requests": 2}) + "\n")
         result["agent_exit"] = 1
 
@@ -330,7 +362,7 @@ def test_second_request_violation_is_error_even_after_model_output(tmp_path, mon
         grader_calls.append(workspace)
         result["check_verdict"] = "PASS"
 
-    monkeypatch.setattr(runner, "_run_agent_local", fake_agent)
+    monkeypatch.setattr(runner, "_run_backend_local", fake_agent)
     monkeypatch.setattr(backend, "materialize_solution", fake_materialize)
     monkeypatch.setattr(runner, "_run_grader_local", fake_grader)
 
@@ -424,3 +456,109 @@ def test_cli_rejects_non_oneshot_controls(tmp_path, monkeypatch, capsys, extra_a
     assert expected_error in capsys.readouterr().err
     assert preflight_calls == []
     assert captured_items == []
+
+
+@pytest.mark.parametrize(
+    ("infra_retries", "max_continuations", "expected_error"),
+    [
+        (0.0, 0, "--infra-retries must be an integer"),
+        (False, 0, "--infra-retries must be an integer"),
+        (-1, 0, "--infra-retries must be >= 0"),
+        (1, 0, "strict one-shot backends require --infra-retries 0"),
+        (0, 0.0, "--max-continuations must be an integer"),
+        (0, False, "--max-continuations must be an integer"),
+        (0, 1, "does not support --max-continuations"),
+    ],
+)
+def test_direct_work_item_rejects_unsupported_controls_before_side_effects(
+    tmp_path,
+    monkeypatch,
+    infra_retries,
+    max_continuations,
+    expected_error,
+):
+    benchmark_root = tmp_path / "benchmark"
+    benchmark = benchmark_root / "Suite" / "Example.tla"
+    benchmark.parent.mkdir(parents=True)
+    benchmark.write_text(MODULE)
+    output_dir = tmp_path / "results"
+    result_dir = output_dir / "Suite" / "Example"
+    result_dir.mkdir(parents=True)
+    existing = result_dir / "result.json"
+    existing.write_text('{"keep": true}')
+    item = runner.WorkItem(
+        benchmark_path=str(benchmark),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=LiteLLMOneShotBackend(),
+        mode=_OneShotMode(benchmark_root),  # ty:ignore[invalid-argument-type]
+        tlapm_path="/bin/true",
+        tlapm_lib="",
+        infra_retries=infra_retries,
+        max_continuations=max_continuations,
+    )
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *args: pytest.fail("quota must not run"))
+
+    with pytest.raises(ValueError, match=expected_error):
+        runner.run_single_benchmark(item)
+
+    assert existing.read_text() == '{"keep": true}'
+
+
+def test_direct_work_item_uses_oneshot_retry_default_and_runs_once(tmp_path, monkeypatch):
+    benchmark_root = tmp_path / "benchmark"
+    benchmark = benchmark_root / "Suite" / "Example.tla"
+    benchmark.parent.mkdir(parents=True)
+    benchmark.write_text(MODULE)
+    item = runner.WorkItem(
+        benchmark_path=str(benchmark),
+        output_dir=str(tmp_path / "results"),
+        timeout=10,
+        check_timeout=10,
+        backend=LiteLLMOneShotBackend(),
+        mode=_OneShotMode(benchmark_root),  # ty:ignore[invalid-argument-type]
+        tlapm_path="/bin/true",
+        tlapm_lib="",
+    )
+    calls = []
+
+    def fake_backend(
+        item_, backend, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir=None
+    ):
+        calls.append(workspace)
+        _write_events(
+            Path(agent_jsonl),
+            {"type": "response", "text": MODULE},
+            {"type": "usage", "input_tokens": 3, "output_tokens": 2, "model_requests": 1},
+            {
+                "type": "request_audit",
+                "provider": "litellm",
+                "model_requests": 1,
+                "request_attempts": 1,
+                "blocked_requests": 0,
+                "system_prompt_present": False,
+                "tools_present": False,
+                "retries_enabled": False,
+                "audit_scope": "adapter",
+                "contract_ok": True,
+                "litellm_completion_invocations": 1,
+                "wire_audited": False,
+                "litellm_retries_disabled": True,
+                "system_supplied": False,
+                "tools_supplied": False,
+            },
+            {"type": "result", "status": "success", "model_requests": 1},
+        )
+        result["agent_exit"] = 0
+
+    def fake_grader(item_, workspace, basename, grading_dir, check_result_path, result, canonical_dir=None):
+        result["check_verdict"] = "FAIL"
+
+    monkeypatch.setattr(runner, "_run_backend_local", fake_backend)
+    monkeypatch.setattr(runner, "_run_grader_local", fake_grader)
+
+    runner.run_single_benchmark(item)
+
+    assert item.infra_retries == 0
+    assert len(calls) == 1

--- a/tests/evaluator/test_oneshot_backends.py
+++ b/tests/evaluator/test_oneshot_backends.py
@@ -71,14 +71,13 @@ def test_shared_command_and_capabilities(tmp_path):
     assert backend.default_infra_retries == 0
 
 
-def test_shared_command_uses_source_runner_for_native_execution(tmp_path):
+def test_shared_command_uses_module_runner_for_native_execution(tmp_path):
     backend = CopilotOneShotBackend(model="gpt-5")
 
     command = backend.build_command(str(tmp_path), str(tmp_path / "results"))
 
-    assert command[0] == "python3"
-    assert command[1].endswith("/src/evaluator/backends/oneshot_runner.py")
-    assert command[2:5] == ["--provider", "copilot", "--workspace"]
+    assert command[:3] == [sys.executable, "-m", "evaluator.backends.oneshot_runner"]
+    assert command[3:6] == ["--provider", "copilot", "--workspace"]
 
 
 def test_parse_output_and_request_metadata(tmp_path):
@@ -118,14 +117,25 @@ def test_parse_output_and_request_metadata(tmp_path):
     }
 
 
-def test_materializes_raw_complete_module_atomically(tmp_path):
+def test_materializes_raw_response_verbatim_atomically(tmp_path):
     events = tmp_path / "output.jsonl"
     destination = tmp_path / "Example.tla"
     destination.write_text("original\n")
-    _write_events(events, {"type": "response", "text": f"\n{MODULE}\n"})
+    response = f"\n{MODULE}\n"
+    _write_events(events, {"type": "response", "text": response})
 
     assert LiteLLMOneShotBackend().materialize_solution(str(events), str(destination)) is True
-    assert destination.read_text() == MODULE
+    assert destination.read_text() == response
+
+
+def test_materializes_module_with_leading_comments_verbatim(tmp_path):
+    events = tmp_path / "output.jsonl"
+    destination = tmp_path / "Example.tla"
+    response = "\\* Contributor: Example Author\n\\* Source: Example Paper\n\n" + MODULE
+    _write_events(events, {"type": "response", "text": response})
+
+    assert LiteLLMOneShotBackend().materialize_solution(str(events), str(destination)) is True
+    assert destination.read_text() == response
 
 
 def test_materializes_unique_tla_fence(tmp_path):
@@ -137,11 +147,11 @@ def test_materializes_unique_tla_fence(tmp_path):
     assert destination.read_text() == MODULE
 
 
-def test_materialize_rejects_snippets_patches_and_multiple_fences(tmp_path):
+def test_materializes_non_tla_structures_verbatim_for_grader_validation(tmp_path):
     backend = LiteLLMOneShotBackend()
     destination = tmp_path / "Example.tla"
     destination.write_text("original\n")
-    invalid_responses = [
+    responses = [
         "PROOF OBVIOUS",
         f"@@ -1,2 +1,2 @@\n+{MODULE}",
         f"```tla\n{MODULE}```\n```tla\n{MODULE}```",
@@ -150,17 +160,31 @@ def test_materialize_rejects_snippets_patches_and_multiple_fences(tmp_path):
         f"{MODULE}\nignored after the module",
     ]
 
-    for index, response in enumerate(invalid_responses):
+    for index, response in enumerate(responses):
         events = tmp_path / f"output-{index}.jsonl"
         _write_events(events, {"type": "response", "text": response})
-        assert backend.materialize_solution(str(events), str(destination)) is False
-        assert destination.read_text() == "original\n"
+        assert backend.materialize_solution(str(events), str(destination)) is True
+        assert destination.read_text() == response
 
 
 def test_materialize_rejects_ambiguous_response_events(tmp_path):
     events = tmp_path / "output.jsonl"
     destination = tmp_path / "Example.tla"
     _write_events(events, {"type": "response", "text": MODULE}, {"type": "response", "text": MODULE})
+
+    assert LiteLLMOneShotBackend().materialize_solution(str(events), str(destination)) is False
+    assert not destination.exists()
+
+
+def test_materialize_rejects_extra_empty_response_event(tmp_path):
+    events = tmp_path / "output.jsonl"
+    destination = tmp_path / "Example.tla"
+    response = "PROOF OBVIOUS"
+    _write_events(
+        events,
+        {"type": "response", "text": "\n  "},
+        {"type": "response", "text": response},
+    )
 
     assert LiteLLMOneShotBackend().materialize_solution(str(events), str(destination)) is False
     assert not destination.exists()
@@ -201,7 +225,7 @@ def test_litellm_oneshot_reuses_litellm_auth_and_firewall(monkeypatch):
     assert backend.check_auth() is None
 
 
-def test_malformed_response_is_genuine_fail_without_grading_untouched_target(tmp_path, monkeypatch):
+def test_unstructured_response_is_materialized_and_left_to_grader(tmp_path, monkeypatch):
     benchmark_root = tmp_path / "benchmark"
     benchmark = benchmark_root / "Suite" / "Example.tla"
     benchmark.parent.mkdir(parents=True)
@@ -258,11 +282,11 @@ def test_malformed_response_is_genuine_fail_without_grading_untouched_target(tmp
     solution = output_dir / "Suite" / "Example" / "agent" / "solution.tla"
 
     assert result["termination_reason"] == "OK"
-    assert result["check_verdict"] == "FAIL"
-    assert result["materialized"] is False
+    assert result["check_verdict"] == "PASS"
+    assert result["materialized"] is True
     assert result["model_requests"] == 1
-    assert grader_calls == []
-    assert not solution.exists()
+    assert len(grader_calls) == 1
+    assert solution.read_text() == "PROOF OBVIOUS"
 
 
 def test_second_request_violation_is_error_even_after_model_output(tmp_path, monkeypatch):

--- a/tests/evaluator/test_oneshot_prompt.py
+++ b/tests/evaluator/test_oneshot_prompt.py
@@ -1,0 +1,95 @@
+"""Provider-neutral prompts for one-shot proof generation."""
+
+from evaluator.modes.proof_completion import ProofCompletion
+from evaluator.modes.proof_from_scratch import ProofFromScratch
+
+TARGET = """\
+---- MODULE Target ----
+EXTENDS Naturals, HelperA
+THEOREM Goal == TRUE
+PROOF OBVIOUS
+====
+"""
+
+
+def _mode(cls, tmp_path):
+    return cls(str(tmp_path), "/bin/true")
+
+
+def test_one_shot_prompt_inlines_target_and_sorted_dependencies(tmp_path):
+    target = tmp_path / "Target_Goal.tla"
+    dep_b = tmp_path / "ZHelper.tla"
+    dep_a = tmp_path / "AHelper.tla"
+    target.write_text(TARGET)
+    dep_b.write_text("---- MODULE ZHelper ----\nZMarker == {2}\n====\n")
+    dep_a.write_text("---- MODULE AHelper ----\nAMarker == {1}\n====\n")
+
+    mode = _mode(ProofCompletion, tmp_path)
+    prompt = mode.build_one_shot_prompt(str(target), [str(dep_b), str(dep_a), str(dep_a)])
+    reversed_prompt = mode.build_one_shot_prompt(str(target), [str(dep_a), str(dep_b)])
+
+    assert prompt == reversed_prompt
+    assert prompt.count(TARGET) == 1
+    assert prompt.count("AMarker == {1}") == 1
+    assert prompt.count("ZMarker == {2}") == 1
+    assert prompt.index("BEGIN DEPENDENCY FILE: AHelper.tla") < prompt.index("BEGIN DEPENDENCY FILE: ZHelper.tla")
+
+
+def test_one_shot_prompt_excludes_target_from_dependency_list(tmp_path):
+    target = tmp_path / "Target_Goal.tla"
+    target.write_text(TARGET)
+
+    prompt = _mode(ProofCompletion, tmp_path).build_one_shot_prompt(str(target), [str(target)])
+
+    assert prompt.count(TARGET) == 1
+    assert "BEGIN DEPENDENCY FILE: Target_Goal.tla" not in prompt
+    assert "# Read-only dependency files\n\n(none)" in prompt
+
+
+def test_one_shot_prompt_rejects_ambiguous_dependency_basenames(tmp_path):
+    target = tmp_path / "Target_Goal.tla"
+    target.write_text(TARGET)
+    first = tmp_path / "first" / "Helper.tla"
+    second = tmp_path / "second" / "Helper.tla"
+    first.parent.mkdir()
+    second.parent.mkdir()
+    first.write_text("---- MODULE Helper ----\nA == 1\n====\n")
+    second.write_text("---- MODULE Helper ----\nB == 2\n====\n")
+
+    mode = _mode(ProofCompletion, tmp_path)
+    try:
+        mode.build_one_shot_prompt(str(target), [str(first), str(second)])
+    except ValueError as exc:
+        assert str(exc) == "duplicate one-shot dependency basename: Helper.tla"
+    else:
+        raise AssertionError("duplicate dependency basenames must be rejected")
+
+
+def test_proof_completion_one_shot_prompt_is_not_agentic(tmp_path):
+    target = tmp_path / "Target_Goal.tla"
+    target.write_text(TARGET)
+    mode = _mode(ProofCompletion, tmp_path)
+
+    prompt = mode.build_one_shot_prompt(str(target), [])
+    agentic_prompt = mode.build_prompt(target.name, "/opt/tlapm", "/opt/tlapm/lib")
+
+    assert "Return the complete contents of the target module" in prompt
+    assert "Only replace the final `PROOF OBVIOUS` proof" in prompt
+    assert "Keep editing" not in prompt
+    assert "run tlapm" not in prompt.lower()
+    assert "check_proof_bin" not in prompt
+    assert "Keep editing" in agentic_prompt
+
+
+def test_proof_from_scratch_one_shot_prompt_allows_fully_proved_helpers(tmp_path):
+    target = tmp_path / "Target_Goal.tla"
+    target.write_text(TARGET)
+
+    prompt = _mode(ProofFromScratch, tmp_path).build_one_shot_prompt(str(target), [])
+
+    assert "Return the complete contents of the target module" in prompt
+    assert "fully proved helper lemmas" in prompt
+    assert "every helper theorem or lemma must have a complete proof" in prompt
+    assert "Do not return a patch" in prompt
+    assert "Keep editing" not in prompt
+    assert "check_proof_bin" not in prompt

--- a/tests/evaluator/test_oneshot_runner.py
+++ b/tests/evaluator/test_oneshot_runner.py
@@ -6,6 +6,7 @@ import asyncio
 import io
 import json
 import sys
+import time
 import types
 from types import SimpleNamespace
 
@@ -68,6 +69,73 @@ def test_inference_endpoint_matching(url, endpoint):
 )
 def test_auxiliary_endpoint_matching(url, endpoint):
     assert oneshot_runner._auxiliary_endpoint(url) == endpoint
+
+
+def test_expired_deadline_never_starts_copilot_inference():
+    class Session:
+        async def send_and_wait(self, *_args, **_kwargs):
+            pytest.fail("an expired benchmark deadline must not start inference")
+
+    deadline_events = []
+
+    async def scenario():
+        with pytest.raises(oneshot_runner._CopilotDeadlineExceeded):
+            await oneshot_runner._send_copilot_and_wait(
+                Session(),
+                "EXACT PROMPT",
+                time.time() - 1,
+                lambda: deadline_events.append("timeout"),
+            )
+
+    asyncio.run(scenario())
+
+    assert deadline_events == ["timeout"]
+
+
+def test_deadline_freezes_guard_before_late_runtime_request():
+    handler = _RecordingHandler("EXACT PROMPT")
+    handler.bind_session("session-1")
+    deadline = time.time() + 0.01
+    handler.set_deadline(deadline)
+
+    class Session:
+        runtime_task = None
+
+        async def send_and_wait(self, *_args, **_kwargs):
+            async def runtime_work():
+                await asyncio.sleep(0.03)
+                with pytest.raises(RuntimeError, match="after benchmark deadline"):
+                    await handler.send_request(
+                        _request(
+                            "https://api.githubcopilot.com/responses",
+                            {"model": "test-model", "input": [], "stream": True},
+                        ),
+                        SimpleNamespace(session_id="session-1"),
+                    )
+
+            self.runtime_task = asyncio.create_task(runtime_work())
+            await asyncio.sleep(60)
+
+    snapshots = []
+
+    async def scenario():
+        session = Session()
+
+        def on_deadline():
+            handler.freeze()
+            snapshots.append(handler.audit())
+
+        with pytest.raises(oneshot_runner._CopilotDeadlineExceeded):
+            await oneshot_runner._send_copilot_and_wait(session, "EXACT PROMPT", deadline, on_deadline)
+        await session.runtime_task
+
+    asyncio.run(scenario())
+
+    assert snapshots[0]["deadline_closed"] is True
+    assert snapshots[0]["model_requests"] == 0
+    assert handler.audit()["model_requests"] == 0
+    assert handler.audit()["blocked_requests"] == 1
+    assert handler.forwarded == []
 
 
 @pytest.mark.parametrize(
@@ -184,6 +252,13 @@ def test_copilot_handler_forwards_only_rewritten_first_inference():
     assert forwarded.headers["content-length"] == str(len(forwarded.content))
     assert handler.audit() == {
         "provider": "copilot",
+        "model_requests": 1,
+        "request_attempts": 1,
+        "system_prompt_present": False,
+        "tools_present": False,
+        "retries_enabled": False,
+        "audit_scope": "wire",
+        "contract_ok": True,
         "wire_audited": True,
         "inference_requests": 1,
         "inference_attempts": 1,
@@ -191,6 +266,7 @@ def test_copilot_handler_forwards_only_rewritten_first_inference():
         "unknown_requests": 0,
         "system_removed": True,
         "tools_removed": True,
+        "deadline_closed": False,
         "endpoint": "/responses",
         "request_sha256": handler.request_sha256,
     }
@@ -387,6 +463,53 @@ def test_main_emits_success_terminal_result(monkeypatch, capsys, tmp_path):
     assert events[-1] == {"type": "result", "status": "success", "model_requests": 1}
 
 
+def test_provider_registry_adds_backend_without_runner_branch(monkeypatch, capsys, tmp_path):
+    captured = {}
+
+    class FakeProvider:
+        audit = {
+            "provider": "fake",
+            "model_requests": 1,
+            "audit_scope": "adapter",
+            "contract_ok": True,
+        }
+
+        def invoke(self, on_timeout):
+            return oneshot_runner.ProviderResult("FAKE RESPONSE", 4, 2, self.audit)
+
+    def factory(prompt, model, workspace, deadline):
+        captured.update(prompt=prompt, model=model, workspace=workspace, deadline=deadline)
+        return FakeProvider()
+
+    oneshot_runner.register_provider("fake", factory)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("EXACT PROMPT"))
+    try:
+        exit_code = oneshot_runner.main(
+            [
+                "--provider",
+                "fake",
+                "--workspace",
+                str(tmp_path),
+                "--result-dir",
+                str(tmp_path),
+                "--model",
+                "fake-model",
+            ]
+        )
+    finally:
+        oneshot_runner._PROVIDER_REGISTRY.pop("fake")
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert exit_code == 0
+    assert captured == {
+        "prompt": "EXACT PROMPT",
+        "model": "fake-model",
+        "workspace": str(tmp_path),
+        "deadline": None,
+    }
+    assert [event["type"] for event in events] == ["response", "usage", "request_audit", "result"]
+
+
 def test_main_preserves_one_request_audit_when_response_parsing_fails(monkeypatch, capsys, tmp_path):
     fake_litellm = types.ModuleType("litellm")
     fake_litellm.completion = lambda **_kwargs: SimpleNamespace(
@@ -482,8 +605,8 @@ def test_main_marks_provider_deadline_as_timeout(monkeypatch, capsys, tmp_path):
             str(tmp_path),
             "--model",
             "test-model",
-            "--timeout",
-            "37",
+            "--deadline",
+            str(time.time() + 37),
         ]
     )
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
@@ -581,7 +704,7 @@ def test_copilot_runner_uses_empty_mode_and_strict_session_options(monkeypatch, 
             "EXACT PROMPT",
             "test-model",
             str(tmp_path),
-            123.0,
+            time.time() + 123.0,
             handler=handler,
         )
     )
@@ -617,7 +740,7 @@ def test_copilot_runner_uses_empty_mode_and_strict_session_options(monkeypatch, 
         ("guard", "strict one-shot: expected exactly one inference attempt and one forwarded request"),
         ("session", "session failed after usage"),
         ("transport_timeout", "transport timed out"),
-        ("timeout", "Copilot request timed out after 0.1s"),
+        ("timeout", "Copilot request reached benchmark deadline"),
     ],
 )
 def test_copilot_failure_preserves_received_usage(monkeypatch, tmp_path, failure_mode, error_message):
@@ -688,13 +811,13 @@ def test_copilot_failure_preserves_received_usage(monkeypatch, tmp_path, failure
     monkeypatch.setenv("GH_TOKEN", "secret-token")
 
     with pytest.raises(oneshot_runner.ProviderRunError, match=error_message) as exc_info:
-        timeout = 0.1 if failure_mode == "timeout" else 123.0
+        deadline = time.time() + 0.1 if failure_mode == "timeout" else None
         asyncio.run(
             oneshot_runner.run_copilot(
                 "EXACT PROMPT",
                 "test-model",
                 str(tmp_path),
-                timeout,
+                deadline,
                 handler=handler,
             )
         )
@@ -708,12 +831,135 @@ def test_copilot_failure_preserves_received_usage(monkeypatch, tmp_path, failure
         assert not isinstance(exc_info.value, oneshot_runner.ProviderTimeoutError)
 
 
-@pytest.mark.parametrize("timeout_arg", ["0", "-5"])
-def test_main_maps_nonpositive_copilot_timeout_to_none(monkeypatch, capsys, tmp_path, timeout_arg):
-    captured_timeouts: list[float | None] = []
+def test_copilot_timeout_is_reported_before_slow_sdk_teardown(monkeypatch, tmp_path):
+    class MessageData:
+        pass
 
-    async def fake_run_copilot(_prompt, _model, _workspace, timeout, handler=None):
-        captured_timeouts.append(timeout)
+    class UsageData:
+        def __init__(self, input_tokens, output_tokens):
+            self.input_tokens = input_tokens
+            self.output_tokens = output_tokens
+            self.finish_reason = "length"
+
+    class SlowExitSession:
+        session_id = "session-1"
+
+        def __init__(self, guard, on_event):
+            self.guard = guard
+            self.on_event = on_event
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            await asyncio.sleep(60)
+
+        async def send_and_wait(self, _prompt, **_kwargs):
+            await self.guard.send_request(
+                _request(
+                    "https://api.githubcopilot.com/responses",
+                    {"model": "test-model", "input": [], "stream": True},
+                ),
+                SimpleNamespace(session_id=self.session_id),
+            )
+            self.on_event(SimpleNamespace(data=UsageData(21, 8)))
+            await asyncio.sleep(60)
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.guard = kwargs["request_handler"]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def create_session(self, **kwargs):
+            return SlowExitSession(self.guard, kwargs["on_event"])
+
+    monkeypatch.setattr(oneshot_runner, "_load_copilot_sdk", lambda: (FakeClient, MessageData, UsageData))
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    captured = []
+
+    async def scenario():
+        emitted = asyncio.Event()
+
+        def on_timeout(exc):
+            captured.append(exc)
+            emitted.set()
+
+        task = asyncio.create_task(
+            oneshot_runner.run_copilot(
+                "EXACT PROMPT",
+                "test-model",
+                str(tmp_path),
+                time.time() + 0.02,
+                handler=_RecordingHandler("EXACT PROMPT"),
+                on_timeout=on_timeout,
+            )
+        )
+        await asyncio.wait_for(emitted.wait(), timeout=0.5)
+        assert not task.done(), "timeout must be durable before slow SDK teardown completes"
+        task.cancel()
+        with pytest.raises(oneshot_runner.ProviderTimeoutError):
+            await task
+
+    asyncio.run(scenario())
+
+    assert len(captured) == 1
+    assert isinstance(captured[0], oneshot_runner.ProviderTimeoutError)
+    assert (captured[0].input_tokens, captured[0].output_tokens) == (21, 8)
+    assert captured[0].audit["model_requests"] == 1
+
+
+def test_copilot_deadline_watchdog_covers_sdk_startup(monkeypatch, tmp_path):
+    class MessageData:
+        pass
+
+    class UsageData:
+        pass
+
+    class SlowStartClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            await asyncio.sleep(60)
+
+        async def __aexit__(self, *_args):
+            return None
+
+    monkeypatch.setattr(oneshot_runner, "_load_copilot_sdk", lambda: (SlowStartClient, MessageData, UsageData))
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    captured = []
+
+    async def scenario():
+        task = asyncio.create_task(
+            oneshot_runner.run_copilot(
+                "EXACT PROMPT",
+                "test-model",
+                str(tmp_path),
+                time.time() + 0.02,
+                on_timeout=captured.append,
+            )
+        )
+        with pytest.raises(oneshot_runner.ProviderTimeoutError):
+            await asyncio.wait_for(task, timeout=0.5)
+
+    asyncio.run(scenario())
+
+    assert len(captured) == 1
+    assert captured[0].audit["deadline_closed"] is True
+    assert captured[0].audit["model_requests"] == 0
+
+
+@pytest.mark.parametrize("deadline_arg", ["0", "-5"])
+def test_main_maps_nonpositive_copilot_deadline_to_none(monkeypatch, capsys, tmp_path, deadline_arg):
+    captured_deadlines: list[float | None] = []
+
+    async def fake_run_copilot(_prompt, _model, _workspace, deadline, handler=None, on_timeout=None):
+        captured_deadlines.append(deadline)
         return oneshot_runner.ProviderResult(
             "MODEL RESPONSE",
             12,
@@ -734,12 +980,12 @@ def test_main_maps_nonpositive_copilot_timeout_to_none(monkeypatch, capsys, tmp_
             str(tmp_path),
             "--model",
             "test-model",
-            "--timeout",
-            timeout_arg,
+            "--deadline",
+            deadline_arg,
         ]
     )
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
 
     assert exit_code == 0
-    assert captured_timeouts == [None]
+    assert captured_deadlines == [None]
     assert events[-1] == {"type": "result", "status": "success", "model_requests": 1}

--- a/tests/evaluator/test_oneshot_runner.py
+++ b/tests/evaluator/test_oneshot_runner.py
@@ -311,7 +311,6 @@ def test_litellm_makes_one_call_with_no_tools_system_or_retries(monkeypatch):
             "model": "provider/model",
             "messages": [{"role": "user", "content": "EXACT PROMPT"}],
             "stream": False,
-            "temperature": 0.0,
             "max_tokens": 32_768,
             "num_retries": 0,
         }
@@ -390,7 +389,10 @@ def test_main_emits_success_terminal_result(monkeypatch, capsys, tmp_path):
 
 def test_main_preserves_one_request_audit_when_response_parsing_fails(monkeypatch, capsys, tmp_path):
     fake_litellm = types.ModuleType("litellm")
-    fake_litellm.completion = lambda **_kwargs: SimpleNamespace(choices=[], usage=None)
+    fake_litellm.completion = lambda **_kwargs: SimpleNamespace(
+        choices=[],
+        usage=SimpleNamespace(prompt_tokens=123, completion_tokens=45),
+    )
     monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
     monkeypatch.setattr(sys, "stdin", io.StringIO("EXACT PROMPT"))
 
@@ -409,10 +411,86 @@ def test_main_preserves_one_request_audit_when_response_parsing_fails(monkeypatc
     events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
 
     assert exit_code == 1
-    assert [event["type"] for event in events] == ["request_audit", "error", "result"]
-    assert events[0]["litellm_completion_invocations"] == 1
-    assert events[0]["wire_audited"] is False
+    assert [event["type"] for event in events] == ["usage", "request_audit", "error", "result"]
+    assert events[0] == {
+        "type": "usage",
+        "input_tokens": 123,
+        "output_tokens": 45,
+        "model_requests": 1,
+    }
+    assert events[1]["litellm_completion_invocations"] == 1
+    assert events[1]["wire_audited"] is False
     assert events[-1] == {"type": "result", "status": "error", "model_requests": 1}
+
+
+def test_main_emits_received_copilot_usage_on_failure(monkeypatch, capsys, tmp_path):
+    async def fake_run_copilot(*_args, **_kwargs):
+        raise oneshot_runner.ProviderRunError(
+            "invalid final response",
+            {"provider": "copilot", "inference_requests": 1},
+            input_tokens=55,
+            output_tokens=13,
+        )
+
+    monkeypatch.setattr(oneshot_runner, "run_copilot", fake_run_copilot)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("EXACT PROMPT"))
+
+    exit_code = oneshot_runner.main(
+        [
+            "--provider",
+            "copilot",
+            "--workspace",
+            str(tmp_path),
+            "--result-dir",
+            str(tmp_path),
+            "--model",
+            "test-model",
+        ]
+    )
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+
+    assert exit_code == 1
+    assert events[0] == {
+        "type": "usage",
+        "input_tokens": 55,
+        "output_tokens": 13,
+        "model_requests": 1,
+    }
+    assert events[1] == {"type": "request_audit", "provider": "copilot", "inference_requests": 1}
+    assert events[-1] == {"type": "result", "status": "error", "model_requests": 1}
+
+
+def test_main_marks_provider_deadline_as_timeout(monkeypatch, capsys, tmp_path):
+    async def fake_run_copilot(*_args, **_kwargs):
+        raise oneshot_runner.ProviderTimeoutError(
+            "Copilot request timed out after 37s",
+            {"provider": "copilot", "inference_requests": 1},
+            input_tokens=55,
+            output_tokens=13,
+        )
+
+    monkeypatch.setattr(oneshot_runner, "run_copilot", fake_run_copilot)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("EXACT PROMPT"))
+
+    exit_code = oneshot_runner.main(
+        [
+            "--provider",
+            "copilot",
+            "--workspace",
+            str(tmp_path),
+            "--result-dir",
+            str(tmp_path),
+            "--model",
+            "test-model",
+            "--timeout",
+            "37",
+        ]
+    )
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+
+    assert exit_code == 1
+    assert events[-1] == {"type": "result", "status": "timeout", "model_requests": 1}
+    assert events[-2] == {"type": "error", "message": "Copilot request timed out after 37s"}
 
 
 def test_litellm_import_failure_records_zero_completion_invocations(monkeypatch):
@@ -423,6 +501,7 @@ def test_litellm_import_failure_records_zero_completion_invocations(monkeypatch)
 
     assert exc_info.value.audit["litellm_completion_invocations"] == 0
     assert exc_info.value.audit["wire_audited"] is False
+    assert (exc_info.value.input_tokens, exc_info.value.output_tokens) == (0, 0)
 
 
 def test_copilot_runner_uses_empty_mode_and_strict_session_options(monkeypatch, tmp_path):
@@ -521,7 +600,7 @@ def test_copilot_runner_uses_empty_mode_and_strict_session_options(monkeypatch, 
     assert captured["send"] == {
         "prompt": "EXACT PROMPT",
         "agent_mode": "interactive",
-        "timeout": 123.0,
+        "timeout": None,
     }
     assert result.text == "MODEL RESPONSE"
     assert (result.input_tokens, result.output_tokens) == (20, 8)
@@ -529,3 +608,138 @@ def test_copilot_runner_uses_empty_mode_and_strict_session_options(monkeypatch, 
     assert result.audit["wire_audited"] is True
     assert result.audit["finish_reason"] == "stop"
     assert json.loads(handler.forwarded[0].content)["input"][0]["content"][0]["text"] == "EXACT PROMPT"
+
+
+@pytest.mark.parametrize(
+    ("failure_mode", "error_message"),
+    [
+        ("final", "Copilot returned no final assistant message"),
+        ("guard", "strict one-shot: expected exactly one inference attempt and one forwarded request"),
+        ("session", "session failed after usage"),
+        ("transport_timeout", "transport timed out"),
+        ("timeout", "Copilot request timed out after 0.1s"),
+    ],
+)
+def test_copilot_failure_preserves_received_usage(monkeypatch, tmp_path, failure_mode, error_message):
+    class MessageData:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class UsageData:
+        def __init__(self, input_tokens: int, output_tokens: int, finish_reason: str | None = None) -> None:
+            self.input_tokens = input_tokens
+            self.output_tokens = output_tokens
+            self.finish_reason = finish_reason
+
+    class FakeSession:
+        session_id = "session-1"
+
+        def __init__(self, guard, on_event) -> None:
+            self.guard = guard
+            self.on_event = on_event
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def send_and_wait(self, _prompt, **_kwargs):
+            await self.guard.send_request(
+                _request(
+                    "https://api.githubcopilot.com/responses",
+                    {"model": "test-model", "input": [], "stream": True},
+                ),
+                SimpleNamespace(session_id=self.session_id),
+            )
+            self.on_event(SimpleNamespace(data=UsageData(20, 8, "length")))
+            if failure_mode == "session":
+                raise RuntimeError("session failed after usage")
+            if failure_mode == "transport_timeout":
+                raise TimeoutError("transport timed out")
+            if failure_mode == "timeout":
+                await asyncio.sleep(60)
+            if failure_mode == "guard":
+                self.guard.blocked_requests += 1
+                return SimpleNamespace(data=MessageData("MODEL RESPONSE"))
+            return SimpleNamespace(data=object())
+
+    class FakeClient:
+        def __init__(self, **kwargs) -> None:
+            self.guard = kwargs["request_handler"]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def create_session(self, **kwargs):
+            return FakeSession(self.guard, kwargs["on_event"])
+
+    handler = _RecordingHandler("EXACT PROMPT")
+    monkeypatch.setattr(
+        oneshot_runner,
+        "_load_copilot_sdk",
+        lambda: (FakeClient, MessageData, UsageData),
+    )
+    for key in oneshot_runner._COPILOT_TOKEN_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+
+    with pytest.raises(oneshot_runner.ProviderRunError, match=error_message) as exc_info:
+        timeout = 0.1 if failure_mode == "timeout" else 123.0
+        asyncio.run(
+            oneshot_runner.run_copilot(
+                "EXACT PROMPT",
+                "test-model",
+                str(tmp_path),
+                timeout,
+                handler=handler,
+            )
+        )
+
+    assert (exc_info.value.input_tokens, exc_info.value.output_tokens) == (20, 8)
+    assert exc_info.value.audit["inference_requests"] == 1
+    assert exc_info.value.audit["finish_reason"] == "length"
+    if failure_mode == "timeout":
+        assert isinstance(exc_info.value, oneshot_runner.ProviderTimeoutError)
+    if failure_mode == "transport_timeout":
+        assert not isinstance(exc_info.value, oneshot_runner.ProviderTimeoutError)
+
+
+@pytest.mark.parametrize("timeout_arg", ["0", "-5"])
+def test_main_maps_nonpositive_copilot_timeout_to_none(monkeypatch, capsys, tmp_path, timeout_arg):
+    captured_timeouts: list[float | None] = []
+
+    async def fake_run_copilot(_prompt, _model, _workspace, timeout, handler=None):
+        captured_timeouts.append(timeout)
+        return oneshot_runner.ProviderResult(
+            "MODEL RESPONSE",
+            12,
+            7,
+            {"provider": "copilot", "inference_requests": 1},
+        )
+
+    monkeypatch.setattr(oneshot_runner, "run_copilot", fake_run_copilot)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("EXACT PROMPT"))
+
+    exit_code = oneshot_runner.main(
+        [
+            "--provider",
+            "copilot",
+            "--workspace",
+            str(tmp_path),
+            "--result-dir",
+            str(tmp_path),
+            "--model",
+            "test-model",
+            "--timeout",
+            timeout_arg,
+        ]
+    )
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+
+    assert exit_code == 0
+    assert captured_timeouts == [None]
+    assert events[-1] == {"type": "result", "status": "success", "model_requests": 1}

--- a/tests/evaluator/test_oneshot_runner.py
+++ b/tests/evaluator/test_oneshot_runner.py
@@ -1,0 +1,531 @@
+"""Unit tests for the provider-neutral strict one-shot runner."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import sys
+import types
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from evaluator.backends import oneshot_runner
+
+
+class _RecordingHandler(oneshot_runner.StrictCopilotRequestHandler):
+    def __init__(self, prompt: str) -> None:
+        super().__init__(prompt)
+        self.forwarded: list[httpx.Request] = []
+
+    async def _forward(self, request: httpx.Request, _ctx: object) -> httpx.Response:
+        self.forwarded.append(request)
+        return httpx.Response(200, request=request, content=b"{}")
+
+
+def _request(url: str, payload: dict | None = None) -> httpx.Request:
+    if payload is None:
+        return httpx.Request("GET", url, headers={"authorization": "Bearer secret"})
+    return httpx.Request(
+        "POST",
+        url,
+        headers={
+            "authorization": "Bearer secret",
+            "content-type": "application/json",
+            "content-length": "999",
+            "content-encoding": "gzip",
+        },
+        content=json.dumps(payload).encode(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("url", "endpoint"),
+    [
+        ("https://example.test/v1/chat/completions?api-version=1", "/chat/completions"),
+        ("https://example.test/models/x/responses", "/responses"),
+        ("https://example.test/v1/messages", "/v1/messages"),
+        ("https://example.test/messages/", "/messages"),
+        ("https://example.test/models", None),
+        ("https://example.test/models/session", None),
+        ("https://example.test/policy", None),
+    ],
+)
+def test_inference_endpoint_matching(url, endpoint):
+    assert oneshot_runner._inference_endpoint(url) == endpoint
+
+
+@pytest.mark.parametrize(
+    ("url", "endpoint"),
+    [
+        ("https://example.test/models", "/models"),
+        ("https://example.test/models/session", "/models/session"),
+        ("https://example.test/policy", "/policy"),
+        ("https://example.test/unknown", None),
+    ],
+)
+def test_auxiliary_endpoint_matching(url, endpoint):
+    assert oneshot_runner._auxiliary_endpoint(url) == endpoint
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "payload", "message_key"),
+    [
+        (
+            "/responses",
+            {
+                "model": "test-model",
+                "instructions": "hidden system text",
+                "input": [{"role": "user", "content": "<current_datetime>now</current_datetime>\nPROMPT"}],
+                "tools": [{"type": "function", "name": "read_file"}],
+                "tool_choice": "auto",
+                "previous_response_id": "resp-old",
+                "stream": True,
+            },
+            "input",
+        ),
+        (
+            "/chat/completions",
+            {
+                "model": "test-model",
+                "instructions": "cross-schema hidden instructions",
+                "input": [{"role": "user", "content": "cross-schema hidden input"}],
+                "messages": [
+                    {"role": "system", "content": "hidden"},
+                    {"role": "user", "content": "decorated prompt"},
+                ],
+                "prompt": "cross-schema hidden prompt",
+                "context": "cross-schema hidden context",
+                "custom_prompt_container": {"text": "unknown hidden context"},
+                "tools": [{"type": "function"}],
+                "functions": [{"name": "old-style-tool"}],
+            },
+            "messages",
+        ),
+        (
+            "/v1/messages",
+            {
+                "model": "test-model",
+                "system": "hidden",
+                "messages": [{"role": "user", "content": "decorated prompt"}],
+                "tools": [{"name": "read_file"}],
+                "functions": [{"name": "cross-schema-tool"}],
+                "conversation": [{"role": "assistant", "content": "old answer"}],
+                "history": ["old prompt"],
+            },
+            "messages",
+        ),
+    ],
+)
+def test_rewrite_replaces_context_with_one_user_prompt(endpoint, payload, message_key):
+    rewritten = oneshot_runner._rewrite_inference_payload(endpoint, payload, "EXACT PROMPT")
+
+    assert rewritten["model"] == "test-model"
+    assert "hidden" not in json.dumps(rewritten)
+    assert "decorated" not in json.dumps(rewritten)
+    assert "current_datetime" not in json.dumps(rewritten)
+    assert "unknown hidden context" not in json.dumps(rewritten)
+    assert "tools" not in rewritten
+    assert "tool_choice" not in rewritten
+    if message_key == "input":
+        assert rewritten[message_key] == [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "EXACT PROMPT"}],
+                "type": "message",
+            }
+        ]
+    else:
+        assert rewritten[message_key] == [{"role": "user", "content": "EXACT PROMPT"}]
+
+
+def test_rewrite_fails_closed_on_nested_hidden_context_in_retained_control_field():
+    with pytest.raises(RuntimeError, match="retained hidden context field history"):
+        oneshot_runner._rewrite_inference_payload(
+            "/responses",
+            {"model": "test-model", "reasoning": {"history": ["old prompt"]}},
+            "EXACT PROMPT",
+        )
+
+
+def test_copilot_handler_forwards_only_rewritten_first_inference():
+    handler = _RecordingHandler("EXACT PROMPT")
+    handler.bind_session("session-1")
+    ctx = SimpleNamespace(session_id="session-1")
+    original = _request(
+        "https://api.githubcopilot.com/responses",
+        {
+            "model": "test-model",
+            "instructions": "SDK system prompt",
+            "input": [{"role": "user", "content": "SDK-added context\nEXACT PROMPT"}],
+            "tools": [{"type": "function", "name": "shell"}],
+            "stream": True,
+        },
+    )
+
+    asyncio.run(handler.send_request(original, ctx))
+
+    assert len(handler.forwarded) == 1
+    forwarded = handler.forwarded[0]
+    body = json.loads(forwarded.content)
+    assert body["input"] == [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "EXACT PROMPT"}],
+            "type": "message",
+        }
+    ]
+    assert "instructions" not in body
+    assert "tools" not in body
+    assert forwarded.headers["authorization"] == "Bearer secret"
+    assert "content-encoding" not in forwarded.headers
+    assert forwarded.headers["content-length"] == str(len(forwarded.content))
+    assert handler.audit() == {
+        "provider": "copilot",
+        "wire_audited": True,
+        "inference_requests": 1,
+        "inference_attempts": 1,
+        "blocked_requests": 0,
+        "unknown_requests": 0,
+        "system_removed": True,
+        "tools_removed": True,
+        "endpoint": "/responses",
+        "request_sha256": handler.request_sha256,
+    }
+    assert "secret" not in json.dumps(handler.audit())
+    assert "EXACT PROMPT" not in json.dumps(handler.audit())
+
+    with pytest.raises(RuntimeError, match="blocked inference request after the first"):
+        asyncio.run(handler.send_request(original, ctx))
+    assert len(handler.forwarded) == 1
+    assert handler.inference_attempts == 2
+    assert handler.blocked_requests == 1
+
+
+def test_copilot_handler_audits_and_blocks_wrong_session_before_forwarding():
+    handler = _RecordingHandler("prompt")
+    handler.bind_session("expected-session")
+
+    with pytest.raises(RuntimeError, match="unexpected session id"):
+        asyncio.run(
+            handler.send_request(
+                _request("https://api.githubcopilot.com/chat/completions", {"messages": []}),
+                SimpleNamespace(session_id="other-session"),
+            )
+        )
+
+    assert handler.forwarded == []
+    assert handler.audit()["inference_attempts"] == 1
+    assert handler.audit()["inference_requests"] == 0
+    assert handler.audit()["blocked_requests"] == 1
+    assert handler.audit()["endpoint"] == "/chat/completions"
+
+
+def test_copilot_handler_audits_sanitizer_rejection_before_forwarding():
+    handler = _RecordingHandler("prompt")
+    handler.bind_session("session-1")
+
+    with pytest.raises(RuntimeError, match="retained hidden context field history"):
+        asyncio.run(
+            handler.send_request(
+                _request(
+                    "https://api.githubcopilot.com/responses",
+                    {"model": "test-model", "reasoning": {"history": ["old prompt"]}},
+                ),
+                SimpleNamespace(session_id="session-1"),
+            )
+        )
+
+    assert handler.forwarded == []
+    assert handler.audit()["inference_attempts"] == 1
+    assert handler.audit()["inference_requests"] == 0
+    assert handler.audit()["blocked_requests"] == 1
+
+
+def test_copilot_handler_does_not_count_catalog_requests():
+    handler = _RecordingHandler("prompt")
+    asyncio.run(
+        handler.send_request(
+            _request("https://api.githubcopilot.com/models"),
+            SimpleNamespace(session_id=None),
+        )
+    )
+
+    assert len(handler.forwarded) == 1
+    assert handler.audit()["inference_attempts"] == 0
+    assert handler.audit()["inference_requests"] == 0
+
+
+def test_copilot_handler_blocks_unknown_model_endpoint_before_forwarding():
+    handler = _RecordingHandler("prompt")
+
+    with pytest.raises(RuntimeError, match="blocked unknown model-layer endpoint"):
+        asyncio.run(
+            handler.send_request(
+                _request("https://api.githubcopilot.com/future/inference"),
+                SimpleNamespace(session_id=None),
+            )
+        )
+
+    assert handler.forwarded == []
+    assert handler.audit()["inference_attempts"] == 0
+    assert handler.audit()["inference_requests"] == 0
+    assert handler.audit()["unknown_requests"] == 1
+    assert handler.audit()["blocked_requests"] == 1
+
+
+def test_copilot_handler_fails_closed_on_websocket():
+    handler = _RecordingHandler("prompt")
+    with pytest.raises(RuntimeError, match="WebSocket inference is disabled"):
+        asyncio.run(handler.open_websocket(SimpleNamespace(session_id="session-1")))
+    assert handler.inference_attempts == 1
+    assert handler.blocked_requests == 1
+    assert handler.forwarded == []
+
+
+def test_litellm_makes_one_call_with_no_tools_system_or_retries(monkeypatch):
+    calls: list[dict] = []
+
+    def completion(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="MODEL RESPONSE"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=12, completion_tokens=7),
+        )
+
+    fake_litellm = types.ModuleType("litellm")
+    fake_litellm.completion = completion
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    result = oneshot_runner.run_litellm("EXACT PROMPT", "provider/model")
+
+    assert calls == [
+        {
+            "model": "provider/model",
+            "messages": [{"role": "user", "content": "EXACT PROMPT"}],
+            "stream": False,
+            "temperature": 0.0,
+            "max_tokens": 32_768,
+            "num_retries": 0,
+        }
+    ]
+    assert result.text == "MODEL RESPONSE"
+    assert (result.input_tokens, result.output_tokens) == (12, 7)
+    assert result.audit["litellm_completion_invocations"] == 1
+    assert result.audit["wire_audited"] is False
+    assert result.audit["litellm_retries_disabled"] is True
+    assert result.audit["system_supplied"] is False
+    assert result.audit["tools_supplied"] is False
+    assert result.audit["finish_reason"] == "stop"
+    assert "EXACT PROMPT" not in json.dumps(result.audit)
+
+
+def test_litellm_clamps_output_budget_to_pinned_model_metadata(monkeypatch):
+    calls: list[dict] = []
+
+    def completion(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="MODEL RESPONSE"))],
+            usage=None,
+        )
+
+    fake_litellm = types.ModuleType("litellm")
+    fake_litellm.completion = completion
+    fake_litellm.model_cost = {"provider/small-model": {"max_output_tokens": 8_192}}
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    result = oneshot_runner.run_litellm("EXACT PROMPT", "provider/small-model")
+
+    assert calls[0]["max_tokens"] == 8_192
+    assert result.audit["max_tokens"] == 8_192
+
+
+def test_main_emits_success_terminal_result(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(
+        oneshot_runner,
+        "run_litellm",
+        lambda _prompt, _model: oneshot_runner.ProviderResult(
+            "MODEL RESPONSE",
+            12,
+            7,
+            {
+                "provider": "litellm",
+                "model": "provider/model",
+                "litellm_completion_invocations": 1,
+                "wire_audited": False,
+                "litellm_retries_disabled": True,
+                "system_supplied": False,
+                "tools_supplied": False,
+            },
+        ),
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO("EXACT PROMPT"))
+
+    exit_code = oneshot_runner.main(
+        [
+            "--provider",
+            "litellm",
+            "--workspace",
+            str(tmp_path),
+            "--result-dir",
+            str(tmp_path),
+            "--model",
+            "provider/model",
+        ]
+    )
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+
+    assert exit_code == 0
+    assert [event["type"] for event in events] == ["response", "usage", "request_audit", "result"]
+    assert events[-1] == {"type": "result", "status": "success", "model_requests": 1}
+
+
+def test_main_preserves_one_request_audit_when_response_parsing_fails(monkeypatch, capsys, tmp_path):
+    fake_litellm = types.ModuleType("litellm")
+    fake_litellm.completion = lambda **_kwargs: SimpleNamespace(choices=[], usage=None)
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("EXACT PROMPT"))
+
+    exit_code = oneshot_runner.main(
+        [
+            "--provider",
+            "litellm",
+            "--workspace",
+            str(tmp_path),
+            "--result-dir",
+            str(tmp_path),
+            "--model",
+            "provider/model",
+        ]
+    )
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+
+    assert exit_code == 1
+    assert [event["type"] for event in events] == ["request_audit", "error", "result"]
+    assert events[0]["litellm_completion_invocations"] == 1
+    assert events[0]["wire_audited"] is False
+    assert events[-1] == {"type": "result", "status": "error", "model_requests": 1}
+
+
+def test_litellm_import_failure_records_zero_completion_invocations(monkeypatch):
+    monkeypatch.setitem(sys.modules, "litellm", None)
+
+    with pytest.raises(oneshot_runner.ProviderRunError) as exc_info:
+        oneshot_runner.run_litellm("EXACT PROMPT", "provider/model")
+
+    assert exc_info.value.audit["litellm_completion_invocations"] == 0
+    assert exc_info.value.audit["wire_audited"] is False
+
+
+def test_copilot_runner_uses_empty_mode_and_strict_session_options(monkeypatch, tmp_path):
+    captured: dict[str, dict] = {}
+
+    class MessageData:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class UsageData:
+        def __init__(self, input_tokens: int, output_tokens: int, finish_reason: str | None = None) -> None:
+            self.input_tokens = input_tokens
+            self.output_tokens = output_tokens
+            self.finish_reason = finish_reason
+
+    class FakeSession:
+        session_id = "session-1"
+
+        def __init__(self, guard, on_event) -> None:
+            self.guard = guard
+            self.on_event = on_event
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def send_and_wait(self, prompt, **kwargs):
+            captured["send"] = {"prompt": prompt, **kwargs}
+            request = _request(
+                "https://api.githubcopilot.com/responses",
+                {
+                    "model": "test-model",
+                    "instructions": "",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": f"<current_datetime>now</current_datetime>\n{prompt}",
+                        }
+                    ],
+                    "tools": [],
+                    "stream": True,
+                },
+            )
+            await self.guard.send_request(request, SimpleNamespace(session_id=self.session_id))
+            self.on_event(SimpleNamespace(data=UsageData(20, 8, "stop")))
+            return SimpleNamespace(data=MessageData("MODEL RESPONSE"))
+
+    class FakeClient:
+        def __init__(self, **kwargs) -> None:
+            captured["client"] = kwargs
+            self.guard = kwargs["request_handler"]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def create_session(self, **kwargs):
+            captured["session"] = kwargs
+            return FakeSession(self.guard, kwargs["on_event"])
+
+    handler = _RecordingHandler("EXACT PROMPT")
+    monkeypatch.setattr(
+        oneshot_runner,
+        "_load_copilot_sdk",
+        lambda: (FakeClient, MessageData, UsageData),
+    )
+    for key in oneshot_runner._COPILOT_TOKEN_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+
+    result = asyncio.run(
+        oneshot_runner.run_copilot(
+            "EXACT PROMPT",
+            "test-model",
+            str(tmp_path),
+            123.0,
+            handler=handler,
+        )
+    )
+
+    client_options = captured["client"]
+    assert client_options["github_token"] == "secret-token"
+    assert client_options["use_logged_in_user"] is False
+    assert client_options["mode"] == "empty"
+    assert client_options["request_handler"] is handler
+    session_options = captured["session"]
+    assert session_options["available_tools"] == []
+    assert session_options["system_message"] == {"mode": "replace", "content": ""}
+    assert session_options["capi"] == {"enable_web_socket_responses": False}
+    assert session_options["infinite_sessions"] == {"enabled": False}
+    assert session_options["memory"] == {"enabled": False}
+    assert captured["send"] == {
+        "prompt": "EXACT PROMPT",
+        "agent_mode": "interactive",
+        "timeout": 123.0,
+    }
+    assert result.text == "MODEL RESPONSE"
+    assert (result.input_tokens, result.output_tokens) == (20, 8)
+    assert result.audit["inference_requests"] == 1
+    assert result.audit["wire_audited"] is True
+    assert result.audit["finish_reason"] == "stop"
+    assert json.loads(handler.forwarded[0].content)["input"][0]["content"][0]["text"] == "EXACT PROMPT"

--- a/tests/evaluator/test_oneshot_runner_regressions.py
+++ b/tests/evaluator/test_oneshot_runner_regressions.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
+import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from evaluator import runner
+from evaluator.backends.agentic import AgenticBackend
+from evaluator.backends.copilot_oneshot import CopilotOneShotBackend
 from evaluator.backends.litellm_oneshot import LiteLLMOneShotBackend
 
 MODULE = "---- MODULE Example ----\nTHEOREM Target == TRUE\nPROOF OBVIOUS\n====\n"
@@ -60,6 +65,14 @@ def _write_clean_response(path: str) -> None:
         {
             "type": "request_audit",
             "provider": "litellm",
+            "model_requests": 1,
+            "request_attempts": 1,
+            "blocked_requests": 0,
+            "system_prompt_present": False,
+            "tools_present": False,
+            "retries_enabled": False,
+            "audit_scope": "adapter",
+            "contract_ok": True,
             "litellm_completion_invocations": 1,
             "wire_audited": False,
             "litellm_retries_disabled": True,
@@ -77,6 +90,14 @@ def _write_provider_timeout(path: str, timeout: int) -> None:
         {
             "type": "request_audit",
             "provider": "litellm",
+            "model_requests": 1,
+            "request_attempts": 1,
+            "blocked_requests": 0,
+            "system_prompt_present": False,
+            "tools_present": False,
+            "retries_enabled": False,
+            "audit_scope": "adapter",
+            "contract_ok": True,
             "litellm_completion_invocations": 1,
             "wire_audited": False,
             "litellm_retries_disabled": True,
@@ -109,7 +130,7 @@ def test_rerun_clears_owned_artifacts_and_preserves_unknown_files(tmp_path, monk
         _write_clean_response(agent_jsonl)
         result["agent_exit"] = 0
 
-    monkeypatch.setattr(runner, "_run_agent_local", fake_agent)
+    monkeypatch.setattr(runner, "_run_backend_local", fake_agent)
     monkeypatch.setattr(item.backend, "materialize_solution", lambda *args: False)
     monkeypatch.setattr(runner, "_run_grader_local", lambda *args: pytest.fail("grader must not run"))
 
@@ -170,7 +191,7 @@ def test_oneshot_timeout_skips_materialization_and_grading(tmp_path, monkeypatch
         result["agent_exit"] = -1
         result["error"] = "litellm_oneshot timeout after 37s"
 
-    monkeypatch.setattr(runner, "_run_agent_local", fake_agent)
+    monkeypatch.setattr(runner, "_run_backend_local", fake_agent)
     monkeypatch.setattr(
         item.backend,
         "materialize_solution",
@@ -201,7 +222,7 @@ def test_provider_timeout_event_preserves_timeout_and_error(tmp_path, monkeypatc
         _write_provider_timeout(agent_jsonl, item_.timeout)
         result["agent_exit"] = 1
 
-    monkeypatch.setattr(runner, "_run_agent_local", fake_agent)
+    monkeypatch.setattr(runner, "_run_backend_local", fake_agent)
     monkeypatch.setattr(
         item.backend,
         "materialize_solution",
@@ -219,17 +240,27 @@ def test_provider_timeout_event_preserves_timeout_and_error(tmp_path, monkeypatc
     assert json.loads((result_dir / "result.json").read_text()) == result
 
 
-@pytest.mark.parametrize(("timeout", "forwarded"), [(40_000, "40000"), (0, "0"), (-5, "0")])
-def test_oneshot_command_forwards_outer_timeout(timeout, forwarded, tmp_path):
+def test_copilot_command_receives_absolute_deadline(tmp_path):
+    backend = CopilotOneShotBackend()
+    deadline = time.time() + 40_000
+
+    command = runner._build_backend_command(backend, str(tmp_path), str(tmp_path / "results"), deadline)
+
+    assert command[-2] == "--deadline"
+    assert float(command[-1]) == pytest.approx(deadline, abs=1e-6)
+
+
+def test_litellm_command_has_no_cooperative_deadline(tmp_path):
     backend = LiteLLMOneShotBackend()
 
-    command = runner._build_agent_command(backend, str(tmp_path), str(tmp_path / "results"), timeout)
+    command = runner._build_backend_command(backend, str(tmp_path), str(tmp_path / "results"), None)
 
-    assert command[-2:] == ["--timeout", forwarded]
+    assert command[-2:] == ["--deadline", "0"]
 
 
-def test_local_runner_launches_oneshot_with_outer_timeout(tmp_path, monkeypatch):
+def test_local_runner_launches_copilot_with_absolute_deadline(tmp_path, monkeypatch):
     item, _result_dir = _make_item(tmp_path, timeout=40_000)
+    item.backend = CopilotOneShotBackend()
     agent_dir = tmp_path / "agent"
     agent_dir.mkdir()
     captured = {}
@@ -249,7 +280,7 @@ def test_local_runner_launches_oneshot_with_outer_timeout(tmp_path, monkeypatch)
     monkeypatch.setattr(runner.subprocess, "Popen", fake_popen)
 
     result = {}
-    runner._run_agent_local(
+    runner._run_backend_local(
         item,
         item.backend,
         item.mode,
@@ -261,13 +292,16 @@ def test_local_runner_launches_oneshot_with_outer_timeout(tmp_path, monkeypatch)
         "/bin/true",
     )
 
-    assert "--timeout 40000" in captured["command"][2]
+    match = re.search(r"--deadline ([0-9.]+)", captured["command"][2])
+    assert match is not None
+    assert float(match.group(1)) > time.time() + 39_000
     assert captured["communicate"]["input"] == "prompt"
     assert result["agent_exit"] == 0
 
 
-def test_container_runner_launches_oneshot_with_outer_timeout(tmp_path, monkeypatch):
+def test_container_runner_launches_copilot_with_absolute_deadline(tmp_path, monkeypatch):
     item, _result_dir = _make_item(tmp_path, timeout=40_000)
+    item.backend = CopilotOneShotBackend()
     agent_dir = tmp_path / "agent"
     agent_dir.mkdir()
     captured = {}
@@ -293,7 +327,7 @@ def test_container_runner_launches_oneshot_with_outer_timeout(tmp_path, monkeypa
     monkeypatch.setattr(runner, "ContainerRunner", FakeContainerRunner)
 
     result = {}
-    runner._run_agent_container(
+    runner._run_backend_container(
         item,
         item.backend,
         str(tmp_path),
@@ -303,18 +337,169 @@ def test_container_runner_launches_oneshot_with_outer_timeout(tmp_path, monkeypa
         result,
     )
 
-    assert captured["command"][-2:] == ["--timeout", "40000"]
+    assert captured["command"][-2] == "--deadline"
+    assert float(captured["command"][-1]) > time.time() + 39_000
     assert captured["stdin_data"] == "prompt"
     assert result["agent_exit"] == 0
 
 
 def test_agentic_command_is_unchanged_by_timeout_forwarding():
-    class Backend:
-        is_one_shot = False
-
+    class Backend(AgenticBackend):
         def build_command(self, workspace, result_dir):
             return ["agent", workspace, result_dir]
 
-    command = runner._build_agent_command(Backend(), "/workspace", "/results", 300)
+        def parse_output(self, jsonl_path):
+            return "", 0, 0
+
+    command = runner._build_backend_command(Backend(), "/workspace", "/results", None)
 
     assert command == ["agent", "/workspace", "/results"]
+
+
+def test_copilot_timeout_drains_audit_before_outer_hard_kill(tmp_path, monkeypatch):
+    driver = tmp_path / "cooperative_timeout.py"
+    driver.write_text(
+        """\
+import argparse
+import json
+import time
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--deadline", type=float, required=True)
+args = parser.parse_args()
+while time.time() < args.deadline:
+    time.sleep(0.005)
+events = [
+    {"type": "usage", "input_tokens": 17, "output_tokens": 9, "model_requests": 1},
+    {
+        "type": "request_audit",
+        "provider": "copilot",
+        "model_requests": 1,
+        "audit_scope": "wire",
+        "contract_ok": True,
+        "inference_requests": 1,
+        "inference_attempts": 1,
+        "blocked_requests": 0,
+        "system_removed": True,
+        "tools_removed": True,
+    },
+    {"type": "error", "message": "Copilot request reached benchmark deadline"},
+    {"type": "result", "status": "timeout", "model_requests": 1},
+]
+for event in events:
+    print(json.dumps(event), flush=True)
+# Simulate slow SDK/session cleanup after terminal evidence is already durable.
+time.sleep(0.15)
+raise SystemExit(1)
+"""
+    )
+
+    class CooperativeCopilot(CopilotOneShotBackend):
+        def build_command(self, workspace, result_dir):
+            return [sys.executable, str(driver)]
+
+    item, result_dir = _make_item(tmp_path, timeout=0.2)
+    item.backend = CooperativeCopilot()
+    monkeypatch.setattr(
+        item.backend,
+        "materialize_solution",
+        lambda *args: pytest.fail("timeout must not materialize"),
+    )
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args: pytest.fail("timeout must not grade"))
+
+    result = runner.run_single_benchmark(item)
+    events = [json.loads(line) for line in (result_dir / "agent" / "output.jsonl").read_text().splitlines()]
+
+    assert [event["type"] for event in events] == ["usage", "request_audit", "error", "result"]
+    assert result["termination_reason"] == "TIMEOUT"
+    assert result["check_verdict"] == "TIMEOUT"
+    assert result["model_requests"] == 1
+    assert (result["input_tokens"], result["output_tokens"]) == (17, 9)
+    assert result["time_secs"] == pytest.approx(0.2, abs=0.02)
+
+
+def test_zero_request_provider_error_preserves_root_cause(tmp_path, monkeypatch):
+    item, result_dir = _make_item(tmp_path)
+
+    def fake_backend(
+        item_, backend, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir=None
+    ):
+        events = [
+            {
+                "type": "request_audit",
+                "provider": "litellm",
+                "model_requests": 0,
+                "audit_scope": "adapter",
+                "contract_ok": True,
+            },
+            {"type": "error", "message": "HTTP 401 Unauthorized"},
+            {"type": "result", "status": "error", "model_requests": 0},
+        ]
+        Path(agent_jsonl).write_text("".join(json.dumps(event) + "\n" for event in events))
+        result["agent_exit"] = 1
+
+    monkeypatch.setattr(runner, "_run_backend_local", fake_backend)
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args: pytest.fail("provider error must not grade"))
+
+    result = runner.run_single_benchmark(item)
+
+    assert result["check_verdict"] == "ERROR"
+    assert result["termination_reason"] == "INFRA_ERROR"
+    assert result["error"] == "HTTP 401 Unauthorized"
+    assert json.loads((result_dir / "result.json").read_text())["error"] == "HTTP 401 Unauthorized"
+
+
+def test_post_request_contract_error_preserves_root_cause(tmp_path, monkeypatch):
+    item, _result_dir = _make_item(tmp_path)
+
+    def fake_backend(
+        item_, backend, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir=None
+    ):
+        events = [
+            {"type": "usage", "input_tokens": 11, "output_tokens": 4, "model_requests": 1},
+            {
+                "type": "request_audit",
+                "provider": "litellm",
+                "model_requests": 1,
+                "audit_scope": "adapter",
+                "contract_ok": False,
+            },
+            {"type": "error", "message": "strict one-shot: blocked second request"},
+            {"type": "result", "status": "error", "model_requests": 1},
+        ]
+        Path(agent_jsonl).write_text("".join(json.dumps(event) + "\n" for event in events))
+        result["agent_exit"] = 1
+
+    monkeypatch.setattr(runner, "_run_backend_local", fake_backend)
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args: pytest.fail("contract error must not grade"))
+
+    result = runner.run_single_benchmark(item)
+
+    assert result["check_verdict"] == "ERROR"
+    assert result["termination_reason"] == "INFRA_ERROR"
+    assert result["error"] == "strict one-shot: blocked second request"
+    assert (result["input_tokens"], result["output_tokens"]) == (11, 4)
+
+
+def test_clean_empty_oneshot_stream_is_infra_not_capability_fail(tmp_path, monkeypatch):
+    item, _result_dir = _make_item(tmp_path)
+
+    def fake_backend(
+        item_, backend, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir=None
+    ):
+        Path(agent_jsonl).write_text("")
+        result["agent_exit"] = 0
+
+    monkeypatch.setattr(runner, "_run_backend_local", fake_backend)
+    monkeypatch.setattr(
+        item.backend,
+        "materialize_solution",
+        lambda *args: pytest.fail("invalid stream must not materialize"),
+    )
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args: pytest.fail("invalid stream must not grade"))
+
+    result = runner.run_single_benchmark(item)
+
+    assert result["check_verdict"] == "ERROR"
+    assert result["termination_reason"] == "INFRA_ERROR"
+    assert result["model_requests"] == 0

--- a/tests/evaluator/test_oneshot_runner_regressions.py
+++ b/tests/evaluator/test_oneshot_runner_regressions.py
@@ -1,0 +1,320 @@
+"""Regression coverage for one-shot orchestration in evaluator.runner."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from evaluator import runner
+from evaluator.backends.litellm_oneshot import LiteLLMOneShotBackend
+
+MODULE = "---- MODULE Example ----\nTHEOREM Target == TRUE\nPROOF OBVIOUS\n====\n"
+
+
+class _OneShotMode:
+    name = "proof-completion"
+
+    def __init__(self, benchmark_root: Path):
+        self._benchmark_root = str(benchmark_root)
+
+    def benchmark_dir(self) -> str:
+        return self._benchmark_root
+
+    def get_dependencies(self, benchmark_path: str) -> list[str]:
+        return []
+
+    def checker_binary_path(self) -> str:
+        return "/bin/true"
+
+    def build_one_shot_prompt(self, benchmark_path: str, dependencies: list[str]) -> str:
+        return "return one response"
+
+
+def _make_item(tmp_path: Path, timeout: int = 10) -> tuple[runner.WorkItem, Path]:
+    benchmark_root = tmp_path / "benchmark"
+    benchmark = benchmark_root / "Suite" / "Example.tla"
+    benchmark.parent.mkdir(parents=True)
+    benchmark.write_text(MODULE)
+    item = runner.WorkItem(
+        benchmark_path=str(benchmark),
+        output_dir=str(tmp_path / "results"),
+        timeout=timeout,
+        check_timeout=10,
+        backend=LiteLLMOneShotBackend(),
+        mode=_OneShotMode(benchmark_root),  # type: ignore[arg-type]
+        tlapm_path="/bin/true",
+        tlapm_lib="",
+        infra_retries=0,
+    )
+    return item, Path(item.output_dir) / "Suite" / "Example"
+
+
+def _write_clean_response(path: str) -> None:
+    events = [
+        {"type": "response", "text": MODULE},
+        {"type": "usage", "input_tokens": 10, "output_tokens": 5, "model_requests": 1},
+        {
+            "type": "request_audit",
+            "provider": "litellm",
+            "litellm_completion_invocations": 1,
+            "wire_audited": False,
+            "litellm_retries_disabled": True,
+            "system_supplied": False,
+            "tools_supplied": False,
+        },
+        {"type": "result", "status": "success", "model_requests": 1},
+    ]
+    Path(path).write_text("".join(json.dumps(event) + "\n" for event in events))
+
+
+def _write_provider_timeout(path: str, timeout: int) -> None:
+    events = [
+        {"type": "usage", "input_tokens": 10, "output_tokens": 5, "model_requests": 1},
+        {
+            "type": "request_audit",
+            "provider": "litellm",
+            "litellm_completion_invocations": 1,
+            "wire_audited": False,
+            "litellm_retries_disabled": True,
+            "system_supplied": False,
+            "tools_supplied": False,
+        },
+        {"type": "error", "message": f"provider request timed out after {timeout}s"},
+        {"type": "result", "status": "timeout", "model_requests": 1},
+    ]
+    Path(path).write_text("".join(json.dumps(event) + "\n" for event in events))
+
+
+def test_rerun_clears_owned_artifacts_and_preserves_unknown_files(tmp_path, monkeypatch):
+    item, result_dir = _make_item(tmp_path)
+    for name in ("input", "agent", "grading", "continuations"):
+        stale_dir = result_dir / name
+        stale_dir.mkdir(parents=True, exist_ok=True)
+        (stale_dir / "stale.txt").write_text(name)
+    (result_dir / "agent" / "solution.tla").write_text("stale solution")
+    (result_dir / "grading" / "check.result").write_text("PASS")
+    (result_dir / "result.json").write_text('{"stale": true}')
+    (result_dir / "review-notes.txt").write_text("keep me")
+    unknown_dir = result_dir / "attachments"
+    unknown_dir.mkdir()
+    (unknown_dir / "evidence.txt").write_text("keep me too")
+
+    def fake_agent(
+        item_, backend, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir=None
+    ):
+        _write_clean_response(agent_jsonl)
+        result["agent_exit"] = 0
+
+    monkeypatch.setattr(runner, "_run_agent_local", fake_agent)
+    monkeypatch.setattr(item.backend, "materialize_solution", lambda *args: False)
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args: pytest.fail("grader must not run"))
+
+    result = runner.run_single_benchmark(item)
+
+    assert result["check_verdict"] == "FAIL"
+    assert not (result_dir / "agent" / "solution.tla").exists()
+    assert not (result_dir / "grading" / "check.result").exists()
+    assert not (result_dir / "continuations").exists()
+    assert not any(result_dir.glob("*/stale.txt"))
+    assert (result_dir / "input" / "benchmark.tla").read_text() == MODULE
+    assert (result_dir / "review-notes.txt").read_text() == "keep me"
+    assert (unknown_dir / "evidence.txt").read_text() == "keep me too"
+    assert "stale" not in json.loads((result_dir / "result.json").read_text())
+
+
+def test_quota_skipped_rerun_removes_old_result_json(tmp_path, monkeypatch):
+    item, result_dir = _make_item(tmp_path)
+    result_dir.mkdir(parents=True)
+    (result_dir / "result.json").write_text('{"check_verdict": "PASS"}')
+    (result_dir / "review-notes.txt").write_text("keep me")
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *args, **kwargs: False)
+
+    result = runner.run_single_benchmark(item)
+
+    assert result["termination_reason"] == "QUOTA_EXHAUSTED"
+    assert not (result_dir / "result.json").exists()
+    assert (result_dir / "review-notes.txt").read_text() == "keep me"
+
+
+def test_rerun_refuses_symlinked_result_path(tmp_path):
+    item, result_dir = _make_item(tmp_path)
+    outside = tmp_path / "outside"
+    stale_agent = outside / "agent"
+    stale_agent.mkdir(parents=True)
+    evidence = stale_agent / "keep.txt"
+    evidence.write_text("do not delete")
+    result_dir.parent.mkdir(parents=True)
+    result_dir.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="symlinked benchmark result path"):
+        runner.run_single_benchmark(item)
+
+    assert evidence.read_text() == "do not delete"
+
+
+def test_oneshot_timeout_skips_materialization_and_grading(tmp_path, monkeypatch):
+    item, result_dir = _make_item(tmp_path, timeout=37)
+    materialize_calls = []
+    grader_calls = []
+
+    def fake_agent(
+        item_, backend, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir=None
+    ):
+        _write_clean_response(agent_jsonl)
+        with Path(agent_jsonl).open("a") as stream:
+            stream.write(json.dumps({"type": "error", "message": "earlier provider error"}) + "\n")
+        result["agent_exit"] = -1
+        result["error"] = "litellm_oneshot timeout after 37s"
+
+    monkeypatch.setattr(runner, "_run_agent_local", fake_agent)
+    monkeypatch.setattr(
+        item.backend,
+        "materialize_solution",
+        lambda *args: materialize_calls.append(args) or True,
+    )
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args: grader_calls.append(args))
+
+    result = runner.run_single_benchmark(item)
+
+    assert result["termination_reason"] == "TIMEOUT"
+    assert result["check_verdict"] == "TIMEOUT"
+    assert result["error"] == "litellm_oneshot timeout after 37s"
+    assert "materialized" not in result
+    assert materialize_calls == []
+    assert grader_calls == []
+    assert not (result_dir / "agent" / "solution.tla").exists()
+    assert json.loads((result_dir / "result.json").read_text()) == result
+
+
+def test_provider_timeout_event_preserves_timeout_and_error(tmp_path, monkeypatch):
+    item, result_dir = _make_item(tmp_path, timeout=37)
+    materialize_calls = []
+    grader_calls = []
+
+    def fake_agent(
+        item_, backend, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker_bin, canonical_dir=None
+    ):
+        _write_provider_timeout(agent_jsonl, item_.timeout)
+        result["agent_exit"] = 1
+
+    monkeypatch.setattr(runner, "_run_agent_local", fake_agent)
+    monkeypatch.setattr(
+        item.backend,
+        "materialize_solution",
+        lambda *args: materialize_calls.append(args) or True,
+    )
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args: grader_calls.append(args))
+
+    result = runner.run_single_benchmark(item)
+
+    assert result["termination_reason"] == "TIMEOUT"
+    assert result["check_verdict"] == "TIMEOUT"
+    assert result["error"] == "provider request timed out after 37s"
+    assert materialize_calls == []
+    assert grader_calls == []
+    assert json.loads((result_dir / "result.json").read_text()) == result
+
+
+@pytest.mark.parametrize(("timeout", "forwarded"), [(40_000, "40000"), (0, "0"), (-5, "0")])
+def test_oneshot_command_forwards_outer_timeout(timeout, forwarded, tmp_path):
+    backend = LiteLLMOneShotBackend()
+
+    command = runner._build_agent_command(backend, str(tmp_path), str(tmp_path / "results"), timeout)
+
+    assert command[-2:] == ["--timeout", forwarded]
+
+
+def test_local_runner_launches_oneshot_with_outer_timeout(tmp_path, monkeypatch):
+    item, _result_dir = _make_item(tmp_path, timeout=40_000)
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    captured = {}
+
+    class FakeProcess:
+        returncode = 0
+
+        def communicate(self, **kwargs):
+            captured["communicate"] = kwargs
+            return None, ""
+
+    def fake_popen(command, **kwargs):
+        captured["command"] = command
+        captured["popen"] = kwargs
+        return FakeProcess()
+
+    monkeypatch.setattr(runner.subprocess, "Popen", fake_popen)
+
+    result = {}
+    runner._run_agent_local(
+        item,
+        item.backend,
+        item.mode,
+        str(tmp_path),
+        str(agent_dir),
+        str(agent_dir / "output.jsonl"),
+        "prompt",
+        result,
+        "/bin/true",
+    )
+
+    assert "--timeout 40000" in captured["command"][2]
+    assert captured["communicate"]["input"] == "prompt"
+    assert result["agent_exit"] == 0
+
+
+def test_container_runner_launches_oneshot_with_outer_timeout(tmp_path, monkeypatch):
+    item, _result_dir = _make_item(tmp_path, timeout=40_000)
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    captured = {}
+
+    class FakeContainerRunner:
+        def run(self, config, command, stdin_data):
+            captured["command"] = command
+            captured["stdin_data"] = stdin_data
+            proc = subprocess.Popen(
+                ["/bin/true"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            return SimpleNamespace(proc=proc)
+
+        def kill(self, _container_run):
+            pytest.fail("completed fake container must not be killed")
+
+        def cleanup_credential_tmps(self):
+            return None
+
+    monkeypatch.setattr(runner, "ContainerRunner", FakeContainerRunner)
+
+    result = {}
+    runner._run_agent_container(
+        item,
+        item.backend,
+        str(tmp_path),
+        str(agent_dir),
+        str(agent_dir / "output.jsonl"),
+        "prompt",
+        result,
+    )
+
+    assert captured["command"][-2:] == ["--timeout", "40000"]
+    assert captured["stdin_data"] == "prompt"
+    assert result["agent_exit"] == 0
+
+
+def test_agentic_command_is_unchanged_by_timeout_forwarding():
+    class Backend:
+        is_one_shot = False
+
+        def build_command(self, workspace, result_dir):
+            return ["agent", workspace, result_dir]
+
+    command = runner._build_agent_command(Backend(), "/workspace", "/results", 300)
+
+    assert command == ["agent", "/workspace", "/results"]

--- a/tests/evaluator/test_oneshot_runner_regressions.py
+++ b/tests/evaluator/test_oneshot_runner_regressions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -310,8 +311,10 @@ def test_container_runner_launches_copilot_with_absolute_deadline(tmp_path, monk
         def run(self, config, command, stdin_data):
             captured["command"] = command
             captured["stdin_data"] = stdin_data
+            true_bin = shutil.which("true")
+            assert true_bin is not None
             proc = subprocess.Popen(
-                ["/bin/true"],
+                [true_bin],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -171,6 +171,50 @@ def test_one_shot_provider_error_is_infra(tmp_path):
     assert classify(_ctx(path, backend="copilot_oneshot", agent_exit=1)) == TerminationReason.INFRA_ERROR
 
 
+def test_one_shot_provider_deadline_is_timeout(tmp_path):
+    stream = [
+        {"type": "usage", "input_tokens": 10, "output_tokens": 4, "model_requests": 1},
+        {
+            "type": "request_audit",
+            "provider": "copilot",
+            "wire_audited": True,
+            "inference_requests": 1,
+            "inference_attempts": 1,
+            "blocked_requests": 0,
+            "system_removed": True,
+            "tools_removed": True,
+        },
+        {"type": "error", "message": "Copilot request timed out after 37s"},
+        {"type": "result", "status": "timeout", "model_requests": 1},
+    ]
+    path = _write_jsonl(tmp_path / "oneshot-timeout.jsonl", stream)
+
+    assert classify(_ctx(path, backend="copilot_oneshot", agent_exit=1)) == TerminationReason.TIMEOUT
+
+
+@pytest.mark.parametrize(
+    ("provider", "requests"),
+    [("wrong", 1), ("copilot", 0), ("copilot", 2)],
+)
+def test_one_shot_provider_deadline_requires_strict_single_request_audit(tmp_path, provider, requests):
+    stream = [
+        {
+            "type": "request_audit",
+            "provider": provider,
+            "wire_audited": True,
+            "inference_requests": requests,
+            "inference_attempts": requests,
+            "blocked_requests": 0,
+            "system_removed": True,
+            "tools_removed": True,
+        },
+        {"type": "result", "status": "timeout", "model_requests": requests},
+    ]
+    path = _write_jsonl(tmp_path / f"oneshot-invalid-timeout-{provider}-{requests}.jsonl", stream)
+
+    assert classify(_ctx(path, backend="copilot_oneshot", agent_exit=1)) == TerminationReason.INFRA_ERROR
+
+
 def test_one_shot_clean_response_is_genuine(tmp_path):
     stream = [
         {"type": "response", "text": "not a complete module"},

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -13,6 +13,8 @@ Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_termination.py
 import json
 import os
 
+import pytest
+
 from evaluator.termination import (
     INFRA_RULES,
     TerminationContext,
@@ -23,6 +25,7 @@ from evaluator.termination import (
     codex_turn_failed,
     copilot_session_error,
     is_wall_clock_timeout,
+    one_shot_result_error,
     startup_error_snippet,
 )
 
@@ -154,7 +157,159 @@ def test_registry_is_the_extension_point():
     assert codex_turn_failed in INFRA_RULES
     assert claude_code_result_error in INFRA_RULES
     assert copilot_session_error in INFRA_RULES
+    assert one_shot_result_error in INFRA_RULES
     assert agent_startup_failure in INFRA_RULES
+
+
+def test_one_shot_provider_error_is_infra(tmp_path):
+    stream = [
+        {"type": "request_audit", "inference_requests": 0},
+        {"type": "error", "message": "authentication failed"},
+        {"type": "result", "status": "error", "model_requests": 0},
+    ]
+    path = _write_jsonl(tmp_path / "oneshot-error.jsonl", stream)
+    assert classify(_ctx(path, backend="copilot_oneshot", agent_exit=1)) == TerminationReason.INFRA_ERROR
+
+
+def test_one_shot_clean_response_is_genuine(tmp_path):
+    stream = [
+        {"type": "response", "text": "not a complete module"},
+        {"type": "usage", "input_tokens": 10, "output_tokens": 4, "model_requests": 1},
+        {
+            "type": "request_audit",
+            "provider": "litellm",
+            "litellm_completion_invocations": 1,
+            "wire_audited": False,
+            "litellm_retries_disabled": True,
+            "system_supplied": False,
+            "tools_supplied": False,
+        },
+        {"type": "result", "status": "success", "model_requests": 1},
+    ]
+    path = _write_jsonl(tmp_path / "oneshot-success.jsonl", stream)
+    assert classify(_ctx(path, backend="litellm_oneshot")) == TerminationReason.OK
+
+
+def test_one_shot_clean_copilot_response_is_genuine(tmp_path):
+    stream = [
+        {"type": "response", "text": "not a complete module"},
+        {
+            "type": "request_audit",
+            "provider": "copilot",
+            "wire_audited": True,
+            "inference_requests": 1,
+            "inference_attempts": 1,
+            "blocked_requests": 0,
+            "system_removed": True,
+            "tools_removed": True,
+        },
+        {"type": "result", "status": "success", "model_requests": 1},
+    ]
+
+    path = _write_jsonl(tmp_path / "copilot-oneshot-success.jsonl", stream)
+    assert classify(_ctx(path, backend="copilot_oneshot")) == TerminationReason.OK
+
+
+@pytest.mark.parametrize(
+    "backend,audit",
+    [
+        (
+            "litellm_oneshot",
+            {
+                "provider": "litellm",
+                "wire_audited": False,
+                "litellm_completion_invocations": 1,
+                "litellm_retries_disabled": True,
+                "system_supplied": True,
+                "tools_supplied": False,
+            },
+        ),
+        (
+            "copilot_oneshot",
+            {
+                "provider": "copilot",
+                "wire_audited": True,
+                "inference_requests": 1,
+                "inference_attempts": 1,
+                "blocked_requests": 0,
+                "system_removed": False,
+                "tools_removed": True,
+            },
+        ),
+    ],
+)
+def test_one_shot_context_audit_regression_is_infra(tmp_path, backend, audit):
+    stream = [
+        {"type": "response", "text": "not a complete module"},
+        {"type": "request_audit", **audit},
+        {"type": "result", "status": "success", "model_requests": 1},
+    ]
+
+    path = _write_jsonl(tmp_path / f"{backend}-context-regression.jsonl", stream)
+    assert classify(_ctx(path, backend=backend)) == TerminationReason.INFRA_ERROR
+
+
+def test_one_shot_truncated_stream_is_infra(tmp_path):
+    path = _write_jsonl(tmp_path / "oneshot-truncated.jsonl", [{"type": "request_audit"}])
+    assert classify(_ctx(path, backend="litellm_oneshot")) == TerminationReason.INFRA_ERROR
+
+
+@pytest.mark.parametrize("event_type", ["response", "request_audit", "result"])
+def test_one_shot_duplicate_contract_event_is_infra(tmp_path, event_type):
+    stream = [
+        {"type": "response", "text": "not a complete module"},
+        {
+            "type": "request_audit",
+            "provider": "litellm",
+            "litellm_completion_invocations": 1,
+            "wire_audited": False,
+            "litellm_retries_disabled": True,
+            "system_supplied": False,
+            "tools_supplied": False,
+        },
+        {"type": "result", "status": "success", "model_requests": 1},
+    ]
+    stream.append(next(event.copy() for event in stream if event["type"] == event_type))
+
+    path = _write_jsonl(tmp_path / f"oneshot-duplicate-{event_type}.jsonl", stream)
+    assert classify(_ctx(path, backend="litellm_oneshot")) == TerminationReason.INFRA_ERROR
+
+
+@pytest.mark.parametrize(
+    "backend,audit",
+    [
+        (
+            "litellm_oneshot",
+            {
+                "provider": "litellm",
+                "litellm_completion_invocations": 2,
+                "wire_audited": False,
+                "litellm_retries_disabled": True,
+                "system_supplied": False,
+                "tools_supplied": False,
+            },
+        ),
+        (
+            "copilot_oneshot",
+            {
+                "provider": "copilot",
+                "wire_audited": True,
+                "inference_requests": 2,
+                "inference_attempts": 2,
+                "blocked_requests": 0,
+            },
+        ),
+    ],
+)
+def test_one_shot_success_with_two_requests_is_infra(tmp_path, backend, audit):
+    stream = [
+        {"type": "response", "text": "not a complete module"},
+        {"type": "request_audit", **audit},
+        {"type": "result", "status": "success", "model_requests": 2},
+    ]
+
+    path = _write_jsonl(tmp_path / f"{backend}-two-requests.jsonl", stream)
+    assert classify(_ctx(path, backend=backend)) == TerminationReason.INFRA_ERROR
 
 
 # --- quota exhaustion: runner-owned, never produced by classify() -----------

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -15,6 +15,8 @@ import os
 
 import pytest
 
+from evaluator.backends import get_backend
+from evaluator.backends.agentic import AgenticBackend
 from evaluator.termination import (
     INFRA_RULES,
     TerminationContext,
@@ -68,8 +70,56 @@ def _write_jsonl(path, events):
     return str(path)
 
 
-def _ctx(path, backend="codex", agent_exit=None, error=""):
-    return TerminationContext(backend=backend, jsonl_path=path, agent_exit=agent_exit, error=error)
+def _ctx(path, backend="codex", agent_exit=None, error="", approach=None, provider=None):
+    if approach is None:
+        approach = "one_shot" if backend.endswith("_oneshot") else "agentic"
+    if provider is None and approach == "one_shot":
+        provider = backend.removesuffix("_oneshot")
+    validator = (
+        get_backend(backend).validate_request_audit if approach == "one_shot" and backend.endswith("_oneshot") else None
+    )
+    return TerminationContext(
+        backend=backend,
+        jsonl_path=path,
+        approach=approach,
+        provider=provider,
+        request_audit_validator=validator,
+        agent_exit=agent_exit,
+        error=error,
+    )
+
+
+def _strict_audit(provider, requests=1, contract_ok=True, **evidence):
+    audit = {
+        "provider": provider,
+        "model_requests": requests,
+        "request_attempts": requests,
+        "blocked_requests": 0,
+        "system_prompt_present": False,
+        "tools_present": False,
+        "retries_enabled": False,
+        "audit_scope": "wire" if provider == "copilot" else "adapter",
+        "contract_ok": contract_ok,
+    }
+    if provider == "copilot":
+        audit.update(
+            wire_audited=True,
+            inference_requests=requests,
+            inference_attempts=requests,
+            unknown_requests=0,
+            system_removed=requests == 1,
+            tools_removed=requests == 1,
+        )
+    else:
+        audit.update(
+            wire_audited=False,
+            litellm_completion_invocations=requests,
+            litellm_retries_disabled=True,
+            system_supplied=False,
+            tools_supplied=False,
+        )
+    audit.update(evidence)
+    return audit
 
 
 def test_turn_failed_is_infra(tmp_path):
@@ -163,7 +213,7 @@ def test_registry_is_the_extension_point():
 
 def test_one_shot_provider_error_is_infra(tmp_path):
     stream = [
-        {"type": "request_audit", "inference_requests": 0},
+        {"type": "request_audit", **_strict_audit("copilot", requests=0)},
         {"type": "error", "message": "authentication failed"},
         {"type": "result", "status": "error", "model_requests": 0},
     ]
@@ -176,7 +226,7 @@ def test_one_shot_provider_deadline_is_timeout(tmp_path):
         {"type": "usage", "input_tokens": 10, "output_tokens": 4, "model_requests": 1},
         {
             "type": "request_audit",
-            "provider": "copilot",
+            **_strict_audit("copilot"),
             "wire_audited": True,
             "inference_requests": 1,
             "inference_attempts": 1,
@@ -193,14 +243,14 @@ def test_one_shot_provider_deadline_is_timeout(tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("provider", "requests"),
-    [("wrong", 1), ("copilot", 0), ("copilot", 2)],
+    ("provider", "requests", "contract_ok"),
+    [("wrong", 1, True), ("copilot", 2, False), ("copilot", 1, False)],
 )
-def test_one_shot_provider_deadline_requires_strict_single_request_audit(tmp_path, provider, requests):
+def test_one_shot_provider_deadline_requires_valid_audit(tmp_path, provider, requests, contract_ok):
     stream = [
         {
             "type": "request_audit",
-            "provider": provider,
+            **_strict_audit(provider, requests=requests, contract_ok=contract_ok),
             "wire_audited": True,
             "inference_requests": requests,
             "inference_attempts": requests,
@@ -215,13 +265,24 @@ def test_one_shot_provider_deadline_requires_strict_single_request_audit(tmp_pat
     assert classify(_ctx(path, backend="copilot_oneshot", agent_exit=1)) == TerminationReason.INFRA_ERROR
 
 
+def test_one_shot_deadline_before_request_is_still_timeout(tmp_path):
+    stream = [
+        {"type": "request_audit", **_strict_audit("copilot", requests=0)},
+        {"type": "error", "message": "benchmark deadline reached during startup"},
+        {"type": "result", "status": "timeout", "model_requests": 0},
+    ]
+    path = _write_jsonl(tmp_path / "oneshot-startup-timeout.jsonl", stream)
+
+    assert classify(_ctx(path, backend="copilot_oneshot", agent_exit=1)) == TerminationReason.TIMEOUT
+
+
 def test_one_shot_clean_response_is_genuine(tmp_path):
     stream = [
         {"type": "response", "text": "not a complete module"},
         {"type": "usage", "input_tokens": 10, "output_tokens": 4, "model_requests": 1},
         {
             "type": "request_audit",
-            "provider": "litellm",
+            **_strict_audit("litellm"),
             "litellm_completion_invocations": 1,
             "wire_audited": False,
             "litellm_retries_disabled": True,
@@ -239,7 +300,7 @@ def test_one_shot_clean_copilot_response_is_genuine(tmp_path):
         {"type": "response", "text": "not a complete module"},
         {
             "type": "request_audit",
-            "provider": "copilot",
+            **_strict_audit("copilot"),
             "wire_audited": True,
             "inference_requests": 1,
             "inference_attempts": 1,
@@ -260,7 +321,7 @@ def test_one_shot_clean_copilot_response_is_genuine(tmp_path):
         (
             "litellm_oneshot",
             {
-                "provider": "litellm",
+                **_strict_audit("litellm", contract_ok=True),
                 "wire_audited": False,
                 "litellm_completion_invocations": 1,
                 "litellm_retries_disabled": True,
@@ -271,7 +332,7 @@ def test_one_shot_clean_copilot_response_is_genuine(tmp_path):
         (
             "copilot_oneshot",
             {
-                "provider": "copilot",
+                **_strict_audit("copilot", contract_ok=True),
                 "wire_audited": True,
                 "inference_requests": 1,
                 "inference_attempts": 1,
@@ -293,9 +354,95 @@ def test_one_shot_context_audit_regression_is_infra(tmp_path, backend, audit):
     assert classify(_ctx(path, backend=backend)) == TerminationReason.INFRA_ERROR
 
 
+@pytest.mark.parametrize(
+    ("backend", "field", "value"),
+    [
+        ("litellm_oneshot", "model_requests", True),
+        ("litellm_oneshot", "request_attempts", 1.0),
+        ("litellm_oneshot", "blocked_requests", False),
+        ("litellm_oneshot", "litellm_completion_invocations", True),
+        ("copilot_oneshot", "model_requests", 1.0),
+        ("copilot_oneshot", "request_attempts", True),
+        ("copilot_oneshot", "blocked_requests", 0.0),
+        ("copilot_oneshot", "inference_requests", True),
+        ("copilot_oneshot", "inference_attempts", 1.0),
+        ("copilot_oneshot", "unknown_requests", False),
+    ],
+)
+def test_one_shot_audit_counts_require_exact_integers(tmp_path, backend, field, value):
+    provider = backend.removesuffix("_oneshot")
+    audit = _strict_audit(provider)
+    audit[field] = value
+    stream = [
+        {"type": "response", "text": "candidate"},
+        {"type": "request_audit", **audit},
+        {"type": "result", "status": "success", "model_requests": 1},
+    ]
+    path = _write_jsonl(tmp_path / f"{backend}-{field}.jsonl", stream)
+
+    assert classify(_ctx(path, backend=backend)) == TerminationReason.INFRA_ERROR
+
+
+@pytest.mark.parametrize("field", ["system_removed", "tools_removed"])
+def test_copilot_zero_request_audit_requires_explicit_context_evidence(tmp_path, field):
+    audit = _strict_audit("copilot", requests=0)
+    audit.pop(field)
+    stream = [
+        {"type": "request_audit", **audit},
+        {"type": "result", "status": "timeout", "model_requests": 0},
+    ]
+    path = _write_jsonl(tmp_path / f"copilot-missing-{field}.jsonl", stream)
+
+    assert classify(_ctx(path, backend="copilot_oneshot")) == TerminationReason.INFRA_ERROR
+
+
 def test_one_shot_truncated_stream_is_infra(tmp_path):
     path = _write_jsonl(tmp_path / "oneshot-truncated.jsonl", [{"type": "request_audit"}])
     assert classify(_ctx(path, backend="litellm_oneshot")) == TerminationReason.INFRA_ERROR
+
+
+def test_one_shot_non_utf8_stream_fails_closed(tmp_path):
+    path = tmp_path / "oneshot-invalid-utf8.jsonl"
+    path.write_bytes(b'{"type":"response","text":"candidate"}\n\xff\n')
+
+    assert classify(_ctx(str(path), backend="litellm_oneshot")) == TerminationReason.INFRA_ERROR
+
+
+@pytest.mark.parametrize("contents", [None, "", "  \n", "not json\n", "[]\n", "null\n", '"text"\n'])
+def test_one_shot_missing_or_corrupt_stream_fails_closed(tmp_path, contents):
+    path = tmp_path / "invalid-one-shot.jsonl"
+    if contents is not None:
+        path.write_text(contents)
+
+    ctx = TerminationContext(
+        backend="custom-evaluator",
+        jsonl_path=str(path),
+        approach="one_shot",
+        provider="litellm",
+        agent_exit=0,
+    )
+
+    assert classify(ctx) == TerminationReason.INFRA_ERROR
+
+
+def test_one_shot_rejects_junk_mixed_with_valid_contract(tmp_path):
+    path = tmp_path / "mixed-one-shot.jsonl"
+    valid_events = [
+        {"type": "response", "text": "candidate"},
+        {"type": "request_audit", **_strict_audit("litellm")},
+        {"type": "result", "status": "success", "model_requests": 1},
+    ]
+    path.write_text("junk\n" + "".join(json.dumps(event) + "\n" for event in valid_events))
+
+    ctx = TerminationContext(
+        backend="custom-evaluator",
+        jsonl_path=str(path),
+        approach="one_shot",
+        provider="litellm",
+        agent_exit=0,
+    )
+
+    assert classify(ctx) == TerminationReason.INFRA_ERROR
 
 
 @pytest.mark.parametrize("event_type", ["response", "request_audit", "result"])
@@ -304,7 +451,7 @@ def test_one_shot_duplicate_contract_event_is_infra(tmp_path, event_type):
         {"type": "response", "text": "not a complete module"},
         {
             "type": "request_audit",
-            "provider": "litellm",
+            **_strict_audit("litellm"),
             "litellm_completion_invocations": 1,
             "wire_audited": False,
             "litellm_retries_disabled": True,
@@ -325,7 +472,7 @@ def test_one_shot_duplicate_contract_event_is_infra(tmp_path, event_type):
         (
             "litellm_oneshot",
             {
-                "provider": "litellm",
+                **_strict_audit("litellm", requests=2, contract_ok=False),
                 "litellm_completion_invocations": 2,
                 "wire_audited": False,
                 "litellm_retries_disabled": True,
@@ -336,7 +483,7 @@ def test_one_shot_duplicate_contract_event_is_infra(tmp_path, event_type):
         (
             "copilot_oneshot",
             {
-                "provider": "copilot",
+                **_strict_audit("copilot", requests=2, contract_ok=False),
                 "wire_audited": True,
                 "inference_requests": 2,
                 "inference_attempts": 2,
@@ -381,8 +528,11 @@ def test_classify_never_returns_quota_exhausted(tmp_path):
 # them without a real backend, tlapm, or API key.
 
 
-class _FakeBackend:
+class _FakeBackend(AgenticBackend):
     name = "codex"
+
+    def build_command(self, workspace, result_dir):
+        return ["fake-agent"]
 
     def parse_output(self, jsonl_path):
         return ("", 0, 0)  # transcript, input_tokens, output_tokens


### PR DESCRIPTION
## Summary

- make `AgenticBackend` and `OneShotBackend` first-class sibling approaches under a neutral `Backend` lifecycle
- route prompt construction, command and deadline handling, option validation, result metadata, request-audit validation, and submission preparation through backend hooks
- provide a provider-neutral `OneShotProvider` registry with LiteLLM and official GitHub Copilot SDK implementations
- enforce one logical LiteLLM invocation with retries disabled and one wire-audited Copilot inference request with hidden context and tools removed
- propagate an absolute Copilot deadline, freeze and cancel forwarding before durable timeout evidence, then use a bounded cleanup-only grace
- fail closed on malformed event streams, contradictory or ill-typed audits, repeated requests, and invalid direct API controls while preserving provider root errors