### PR TITLE
Add optional reasoning effort support

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -59,6 +59,14 @@ uv run tlaps-bench run --backend litellm --model claude-sonnet-4-6
 uv run tlaps-bench run --backend litellm_oneshot --model claude-sonnet-4-6
 ```
 
+### Reasoning effort
+
+Use the optional `--reasoning-effort` flag to override a model's reasoning budget:
+
+```bash
+uv run tlaps-bench run --backend codex --model gpt-5.6-sol --reasoning-effort low
+```
+
 ### Authentication
 
 The runner passes credentials into the container in two ways:
@@ -139,6 +147,7 @@ uv run tlaps-bench run [flags]
 | `--backend` | `codex` | Evaluator backend to use |
 | `--mode` | `proof-completion` | Benchmark mode |
 | `--model` | (backend default) | Override the model |
+| `--reasoning-effort` | (backend behavior) | Pass a backend/model-specific reasoning effort; omitted preserves existing behavior |
 | `--filter` | (all benchmarks) | Substring match on path, comma-separated |
 | `--jobs` | `1` | Number of parallel backend runs |
 | `--timeout` | `28800` | Per-benchmark backend timeout in seconds |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -147,7 +147,7 @@ uv run tlaps-bench run [flags]
 | `--backend` | `codex` | Evaluator backend to use |
 | `--mode` | `proof-completion` | Benchmark mode |
 | `--model` | (backend default) | Override the model |
-| `--reasoning-effort` | (backend behavior) | Pass a backend/model-specific reasoning effort; omitted preserves existing behavior |
+| `--reasoning-effort` | (backend behavior) | Pass a backend/model-specific reasoning effort |
 | `--filter` | (all benchmarks) | Substring match on path, comma-separated |
 | `--jobs` | `1` | Number of parallel backend runs |
 | `--timeout` | `28800` | Per-benchmark backend timeout in seconds |

--- a/src/evaluator/backends/base.py
+++ b/src/evaluator/backends/base.py
@@ -179,13 +179,25 @@ class Backend(ABC):
     session_state_dir: str | None = None
     capabilities = BackendCapabilities()
     reasoning_effort: str | None = None
-    supports_reasoning_effort = False
+    reasoning_effort_values: tuple[str, ...] = ()
 
     def set_reasoning_effort(self, reasoning_effort: str | None) -> None:
         """Validate and store an optional backend-native reasoning effort."""
 
-        if reasoning_effort is not None and not self.supports_reasoning_effort:
+        if reasoning_effort is None:
+            self.reasoning_effort = None
+            return
+        if reasoning_effort == "":
+            raise ValueError(
+                f"backend {self.name!r}: --reasoning-effort cannot be empty; omit the option to use the backend default"
+            )
+        if not self.reasoning_effort_values:
             raise ValueError(f"backend {self.name!r} does not support --reasoning-effort")
+        if reasoning_effort not in self.reasoning_effort_values:
+            choices = ", ".join(self.reasoning_effort_values)
+            raise ValueError(
+                f"backend {self.name!r}: invalid --reasoning-effort {reasoning_effort!r}; choose from: {choices}"
+            )
         self.reasoning_effort = reasoning_effort
 
     def get_credential_mounts(self) -> list[str]:

--- a/src/evaluator/backends/base.py
+++ b/src/evaluator/backends/base.py
@@ -178,6 +178,15 @@ class Backend(ABC):
     # a persistent host dir here. None = no session dir (e.g. litellm).
     session_state_dir: str | None = None
     capabilities = BackendCapabilities()
+    reasoning_effort: str | None = None
+    supports_reasoning_effort = False
+
+    def set_reasoning_effort(self, reasoning_effort: str | None) -> None:
+        """Validate and store an optional backend-native reasoning effort."""
+
+        if reasoning_effort is not None and not self.supports_reasoning_effort:
+            raise ValueError(f"backend {self.name!r} does not support --reasoning-effort")
+        self.reasoning_effort = reasoning_effort
 
     def get_credential_mounts(self) -> list[str]:
         """Credential directories this backend needs mounted for the current run."""
@@ -225,6 +234,8 @@ class Backend(ABC):
         metadata: dict[str, object] = {"approach": self.approach}
         if self.provider is not None:
             metadata["provider"] = self.provider
+        if self.reasoning_effort is not None:
+            metadata["reasoning_effort"] = self.reasoning_effort
         return metadata
 
     def prepare_submission(

--- a/src/evaluator/backends/claude_code.py
+++ b/src/evaluator/backends/claude_code.py
@@ -36,7 +36,7 @@ class ClaudeCodeBackend(AgenticBackend):
         "ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION",
         "DISABLE_PROMPT_CACHING",
     ]
-    supports_reasoning_effort = True
+    reasoning_effort_values = ("low", "medium", "high", "xhigh", "max")
 
     # Tools the agent is allowed to use (mirrors SREGym's whitelist).
     # Using --allowedTools instead of --dangerously-skip-permissions
@@ -89,7 +89,7 @@ class ClaudeCodeBackend(AgenticBackend):
             "stream-json",
             "--verbose",
             "--effort",
-            self.reasoning_effort or "max",
+            self.reasoning_effort if self.reasoning_effort is not None else "max",
             "--model",
             self.model,
             "--allowedTools",

--- a/src/evaluator/backends/claude_code.py
+++ b/src/evaluator/backends/claude_code.py
@@ -36,6 +36,7 @@ class ClaudeCodeBackend(AgenticBackend):
         "ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION",
         "DISABLE_PROMPT_CACHING",
     ]
+    supports_reasoning_effort = True
 
     # Tools the agent is allowed to use (mirrors SREGym's whitelist).
     # Using --allowedTools instead of --dangerously-skip-permissions
@@ -88,7 +89,7 @@ class ClaudeCodeBackend(AgenticBackend):
             "stream-json",
             "--verbose",
             "--effort",
-            "max",
+            self.reasoning_effort or "max",
             "--model",
             self.model,
             "--allowedTools",

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -48,7 +48,7 @@ class CodexBackend(AgenticBackend):
         "AWS_PROFILE",
     ]
     credential_mounts = ["codex"]
-    supports_reasoning_effort = True
+    reasoning_effort_values = ("none", "low", "medium", "high", "xhigh", "max", "ultra")
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -48,6 +48,7 @@ class CodexBackend(AgenticBackend):
         "AWS_PROFILE",
     ]
     credential_mounts = ["codex"]
+    supports_reasoning_effort = True
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL
@@ -71,6 +72,8 @@ class CodexBackend(AgenticBackend):
             "-o",
             last_msg_path,
         ]
+        if self.reasoning_effort is not None:
+            cmd.extend(["-c", f"model_reasoning_effort={self.reasoning_effort}"])
         if self._uses_bedrock():
             cmd.extend(["-c", 'model_provider="amazon-bedrock"'])
         return cmd

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -48,7 +48,7 @@ class CodexBackend(AgenticBackend):
         "AWS_PROFILE",
     ]
     credential_mounts = ["codex"]
-    reasoning_effort_values = ("none", "low", "medium", "high", "xhigh", "max", "ultra")
+    reasoning_effort_values = ("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra")
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL

--- a/src/evaluator/backends/copilot.py
+++ b/src/evaluator/backends/copilot.py
@@ -25,7 +25,7 @@ class CopilotBackend(AgenticBackend):
         "COPILOT_PROVIDER_TYPE",
         "COPILOT_MODEL",
     ]
-    supports_reasoning_effort = True
+    reasoning_effort_values = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL
@@ -55,7 +55,7 @@ class CopilotBackend(AgenticBackend):
             "--model",
             self.model,
             "--effort",
-            self.reasoning_effort or "max",
+            self.reasoning_effort if self.reasoning_effort is not None else "max",
             "--log-level",
             "none",
             "--no-color",

--- a/src/evaluator/backends/copilot.py
+++ b/src/evaluator/backends/copilot.py
@@ -25,6 +25,7 @@ class CopilotBackend(AgenticBackend):
         "COPILOT_PROVIDER_TYPE",
         "COPILOT_MODEL",
     ]
+    supports_reasoning_effort = True
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL
@@ -43,8 +44,7 @@ class CopilotBackend(AgenticBackend):
         # release check, so the *only* host it needs is the Copilot
         # inference API (no GitHub repo/web access — anti-cheating parity
         # with the firewalled codex/claude runs).
-        # --effort max mirrors the highest reasoning budget used for the
-        # other backends so the comparison is apples-to-apples.
+        # The existing max effort remains the default unless explicitly overridden.
         return [
             "copilot",
             "--allow-all",
@@ -55,7 +55,7 @@ class CopilotBackend(AgenticBackend):
             "--model",
             self.model,
             "--effort",
-            "max",
+            self.reasoning_effort or "max",
             "--log-level",
             "none",
             "--no-color",

--- a/src/evaluator/backends/copilot_oneshot.py
+++ b/src/evaluator/backends/copilot_oneshot.py
@@ -16,6 +16,7 @@ class CopilotOneShotBackend(OneShotBackend):
     install_script = "install-copilot-sdk.sh"
     session_state_dir = None
     env_keys = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
+    supports_reasoning_effort = True
     capabilities = replace(
         OneShotBackend.capabilities,
         cooperative_deadline=True,

--- a/src/evaluator/backends/copilot_oneshot.py
+++ b/src/evaluator/backends/copilot_oneshot.py
@@ -16,7 +16,7 @@ class CopilotOneShotBackend(OneShotBackend):
     install_script = "install-copilot-sdk.sh"
     session_state_dir = None
     env_keys = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
-    supports_reasoning_effort = True
+    reasoning_effort_values = ("low", "medium", "high", "xhigh")
     capabilities = replace(
         OneShotBackend.capabilities,
         cooperative_deadline=True,

--- a/src/evaluator/backends/litellm.py
+++ b/src/evaluator/backends/litellm.py
@@ -13,6 +13,7 @@ class LiteLLMBackend(AgenticBackend):
     name = "litellm"
     install_script = "install-litellm.sh"
     env_keys = ENV_KEYS
+    supports_reasoning_effort = True
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL
@@ -24,7 +25,7 @@ class LiteLLMBackend(AgenticBackend):
         return uses_bedrock(self.model)
 
     def build_command(self, workspace: str, result_dir: str) -> list[str]:
-        return [
+        command = [
             "python3",
             "/opt/litellm_agent.py",
             "--workspace",
@@ -32,6 +33,9 @@ class LiteLLMBackend(AgenticBackend):
             "--model",
             self.model,
         ]
+        if self.reasoning_effort is not None:
+            command.extend(["--reasoning-effort", self.reasoning_effort])
+        return command
 
     def firewall_hosts(self) -> list[str]:
         return detect_firewall_hosts(self.model)

--- a/src/evaluator/backends/litellm.py
+++ b/src/evaluator/backends/litellm.py
@@ -6,14 +6,21 @@ import json
 
 from .agentic import AgenticBackend
 from .base import detect_firewall_hosts
-from .litellm_common import DEFAULT_MODEL, ENV_KEYS, check_auth, credential_mounts, uses_bedrock
+from .litellm_common import (
+    DEFAULT_MODEL,
+    ENV_KEYS,
+    REASONING_EFFORT_VALUES,
+    check_auth,
+    credential_mounts,
+    uses_bedrock,
+)
 
 
 class LiteLLMBackend(AgenticBackend):
     name = "litellm"
     install_script = "install-litellm.sh"
     env_keys = ENV_KEYS
-    supports_reasoning_effort = True
+    reasoning_effort_values = REASONING_EFFORT_VALUES
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL

--- a/src/evaluator/backends/litellm_agent.py
+++ b/src/evaluator/backends/litellm_agent.py
@@ -100,6 +100,7 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--workspace", required=True)
     parser.add_argument("--model", required=True)
+    parser.add_argument("--reasoning-effort", default=None)
     parser.add_argument("--max-iterations", type=int, default=0)
     args = parser.parse_args()
 
@@ -116,13 +117,16 @@ def main() -> None:
     while args.max_iterations == 0 or i < args.max_iterations:
         i += 1
         try:
-            response = litellm.completion(
+            completion_options = dict(
                 model=args.model,
                 messages=messages,
                 tools=TOOLS,
                 temperature=0.0,
                 max_tokens=16384,
             )
+            if args.reasoning_effort is not None:
+                completion_options["reasoning_effort"] = args.reasoning_effort
+            response = litellm.completion(**completion_options)
         except Exception as e:
             print(json.dumps({"type": "error", "message": str(e), "iteration": i}))
             break

--- a/src/evaluator/backends/litellm_agent.py
+++ b/src/evaluator/backends/litellm_agent.py
@@ -96,7 +96,7 @@ def exec_tool(name: str, args: dict, workspace: str) -> str:
         return f"ERROR: {e}"
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--workspace", required=True)
     parser.add_argument("--model", required=True)
@@ -113,6 +113,7 @@ def main() -> None:
     total_in = 0
     total_out = 0
     i = 0
+    failed = False
 
     while args.max_iterations == 0 or i < args.max_iterations:
         i += 1
@@ -121,7 +122,6 @@ def main() -> None:
                 model=args.model,
                 messages=messages,
                 tools=TOOLS,
-                temperature=0.0,
                 max_tokens=16384,
             )
             if args.reasoning_effort is not None:
@@ -129,6 +129,7 @@ def main() -> None:
             response = litellm.completion(**completion_options)
         except Exception as e:
             print(json.dumps({"type": "error", "message": str(e), "iteration": i}))
+            failed = True
             break
 
         usage = response.usage
@@ -170,7 +171,8 @@ def main() -> None:
             )
 
     print(json.dumps({"type": "usage", "input_tokens": total_in, "output_tokens": total_out}))
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/evaluator/backends/litellm_common.py
+++ b/src/evaluator/backends/litellm_common.py
@@ -12,7 +12,7 @@ from .base import (
 )
 
 DEFAULT_MODEL = "claude-sonnet-4-6"
-REASONING_EFFORT_VALUES = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+REASONING_EFFORT_VALUES = ("none", "minimal", "low", "medium", "high", "xhigh", "max", "default")
 
 ENV_KEYS = [
     "OPENAI_API_KEY",

--- a/src/evaluator/backends/litellm_common.py
+++ b/src/evaluator/backends/litellm_common.py
@@ -12,6 +12,7 @@ from .base import (
 )
 
 DEFAULT_MODEL = "claude-sonnet-4-6"
+REASONING_EFFORT_VALUES = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
 ENV_KEYS = [
     "OPENAI_API_KEY",

--- a/src/evaluator/backends/litellm_oneshot.py
+++ b/src/evaluator/backends/litellm_oneshot.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .base import detect_firewall_hosts
-from .litellm_common import DEFAULT_MODEL, ENV_KEYS, check_auth, credential_mounts
+from .litellm_common import DEFAULT_MODEL, ENV_KEYS, REASONING_EFFORT_VALUES, check_auth, credential_mounts
 from .oneshot import OneShotBackend
 
 
@@ -12,7 +12,7 @@ class LiteLLMOneShotBackend(OneShotBackend):
     provider = "litellm"
     install_script = "install-litellm-oneshot.sh"
     env_keys = ENV_KEYS
-    supports_reasoning_effort = True
+    reasoning_effort_values = REASONING_EFFORT_VALUES
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL

--- a/src/evaluator/backends/litellm_oneshot.py
+++ b/src/evaluator/backends/litellm_oneshot.py
@@ -12,6 +12,7 @@ class LiteLLMOneShotBackend(OneShotBackend):
     provider = "litellm"
     install_script = "install-litellm-oneshot.sh"
     env_keys = ENV_KEYS
+    supports_reasoning_effort = True
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL

--- a/src/evaluator/backends/oneshot.py
+++ b/src/evaluator/backends/oneshot.py
@@ -106,7 +106,7 @@ class OneShotBackend(Backend):
             if workspace == "/workspace"
             else [sys.executable, "-m", "evaluator.backends.oneshot_runner"]
         )
-        return [
+        command = [
             *runner,
             "--provider",
             self.provider,
@@ -117,6 +117,9 @@ class OneShotBackend(Backend):
             "--model",
             self.model,
         ]
+        if self.reasoning_effort is not None:
+            command.extend(["--reasoning-effort", self.reasoning_effort])
+        return command
 
     def build_run_command(self, workspace: str, result_dir: str, deadline: float | None) -> list[str]:
         command = self.build_command(workspace, result_dir)

--- a/src/evaluator/backends/oneshot_runner.py
+++ b/src/evaluator/backends/oneshot_runner.py
@@ -233,9 +233,15 @@ def _rewrite_inference_payload(endpoint: str, payload: object, prompt: str) -> d
 class StrictCopilotRequestHandler(_CopilotRequestHandler):
     """Rewrite the sole Copilot inference request and block every later attempt."""
 
-    def __init__(self, prompt: str, model: str | None = None) -> None:
+    def __init__(
+        self,
+        prompt: str,
+        model: str | None = None,
+        reasoning_effort: str | None = None,
+    ) -> None:
         self._prompt = prompt
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self._expected_session_id: str | None = None
         self._deadline: float | None = None
         self._frozen = False
@@ -386,6 +392,8 @@ class StrictCopilotRequestHandler(_CopilotRequestHandler):
         }
         if self.model is not None:
             audit["model"] = self.model
+        if self.reasoning_effort is not None:
+            audit["reasoning_effort"] = self.reasoning_effort
         if self.endpoint is not None:
             audit["endpoint"] = self.endpoint
         if self.request_sha256 is not None:
@@ -461,9 +469,16 @@ def _litellm_max_tokens(litellm: object, model: str) -> int:
     return 32_768
 
 
-def _litellm_audit(prompt: str, model: str, max_tokens: int = 32_768) -> dict[str, object]:
-    request = {"model": model, "messages": [{"role": "user", "content": prompt}]}
-    return {
+def _litellm_audit(
+    prompt: str,
+    model: str,
+    max_tokens: int = 32_768,
+    reasoning_effort: str | None = None,
+) -> dict[str, object]:
+    request: dict[str, object] = {"model": model, "messages": [{"role": "user", "content": prompt}]}
+    if reasoning_effort is not None:
+        request["reasoning_effort"] = reasoning_effort
+    audit: dict[str, object] = {
         "provider": "litellm",
         "model": model,
         "model_requests": 0,
@@ -484,11 +499,16 @@ def _litellm_audit(prompt: str, model: str, max_tokens: int = 32_768) -> dict[st
         "tools_supplied": False,
         "max_tokens": max_tokens,
     }
+    if reasoning_effort is not None:
+        audit["reasoning_effort"] = reasoning_effort
+    return audit
 
 
-def run_litellm(prompt: str, model: str) -> ProviderResult:
-    request = {"model": model, "messages": [{"role": "user", "content": prompt}]}
-    audit = _litellm_audit(prompt, model)
+def run_litellm(prompt: str, model: str, reasoning_effort: str | None = None) -> ProviderResult:
+    request: dict[str, object] = {"model": model, "messages": [{"role": "user", "content": prompt}]}
+    if reasoning_effort is not None:
+        request["reasoning_effort"] = reasoning_effort
+    audit = _litellm_audit(prompt, model, reasoning_effort=reasoning_effort)
     try:
         import litellm
     except ImportError as exc:
@@ -507,8 +527,7 @@ def run_litellm(prompt: str, model: str) -> ProviderResult:
         audit["model_requests"] = 1
         audit["request_attempts"] = 1
         response = litellm.completion(
-            model=model,
-            messages=request["messages"],
+            **request,
             stream=False,
             max_tokens=max_tokens,
             num_retries=0,
@@ -616,9 +635,11 @@ async def run_copilot(
     deadline: float | None,
     handler: StrictCopilotRequestHandler | None = None,
     on_timeout: Callable[[ProviderTimeoutError], None] | None = None,
+    reasoning_effort: str | None = None,
 ) -> ProviderResult:
     guard = handler or StrictCopilotRequestHandler(prompt)
     guard.model = model
+    guard.reasoning_effort = reasoning_effort
     guard.set_deadline(deadline)
     events: list[object] = []
     usage_data_type: type | None = None
@@ -687,6 +708,7 @@ async def run_copilot(
         CopilotClient, AssistantMessageData, AssistantUsageData = _load_copilot_sdk()
         usage_data_type = AssistantUsageData
         token = _copilot_token()
+        reasoning_options = {"reasoning_effort": reasoning_effort} if reasoning_effort is not None else {}
 
         with tempfile.TemporaryDirectory(prefix="tlaps-bench-copilot-") as base_directory:
             async with CopilotClient(
@@ -723,6 +745,7 @@ async def run_copilot(
                     infinite_sessions={"enabled": False},
                     memory={"enabled": False},
                     on_event=events.append,
+                    **reasoning_options,
                 )
                 if deadline_reported:
                     schedule_abort()
@@ -771,35 +794,56 @@ class OneShotProvider(Protocol):
     def invoke(self, on_timeout: Callable[[ProviderTimeoutError], None]) -> ProviderResult: ...
 
 
-ProviderFactory = Callable[[str, str, str, float | None], OneShotProvider]
+ProviderFactory = Callable[..., OneShotProvider]
 
 
 class _LiteLLMProvider:
-    def __init__(self, prompt: str, model: str, _workspace: str, _deadline: float | None) -> None:
+    def __init__(
+        self,
+        prompt: str,
+        model: str,
+        _workspace: str,
+        _deadline: float | None,
+        reasoning_effort: str | None = None,
+    ) -> None:
         self.prompt = prompt
         self.model = model
+        self.reasoning_effort = reasoning_effort
 
     @property
     def audit(self) -> dict[str, object]:
-        return _litellm_audit(self.prompt, self.model)
+        return _litellm_audit(self.prompt, self.model, reasoning_effort=self.reasoning_effort)
 
     def invoke(self, _on_timeout: Callable[[ProviderTimeoutError], None]) -> ProviderResult:
-        return run_litellm(self.prompt, self.model)
+        if self.reasoning_effort is None:
+            return run_litellm(self.prompt, self.model)
+        return run_litellm(self.prompt, self.model, self.reasoning_effort)
 
 
 class _CopilotProvider:
-    def __init__(self, prompt: str, model: str, workspace: str, deadline: float | None) -> None:
+    def __init__(
+        self,
+        prompt: str,
+        model: str,
+        workspace: str,
+        deadline: float | None,
+        reasoning_effort: str | None = None,
+    ) -> None:
         self.prompt = prompt
         self.model = model
         self.workspace = workspace
         self.deadline = deadline
-        self.guard = StrictCopilotRequestHandler(prompt, model)
+        self.reasoning_effort = reasoning_effort
+        self.guard = StrictCopilotRequestHandler(prompt, model, reasoning_effort)
 
     @property
     def audit(self) -> dict[str, object]:
         return self.guard.audit()
 
     def invoke(self, on_timeout: Callable[[ProviderTimeoutError], None]) -> ProviderResult:
+        reasoning_options = (
+            {"reasoning_effort": self.reasoning_effort} if self.reasoning_effort is not None else {}
+        )
         return asyncio.run(
             run_copilot(
                 self.prompt,
@@ -808,6 +852,7 @@ class _CopilotProvider:
                 self.deadline,
                 handler=self.guard,
                 on_timeout=on_timeout,
+                **reasoning_options,
             )
         )
 
@@ -832,6 +877,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--workspace", required=True)
     parser.add_argument("--result-dir", required=True)
     parser.add_argument("--model", required=True)
+    parser.add_argument("--reasoning-effort", default=None)
     parser.add_argument("--deadline", type=float, default=0.0)
     return parser.parse_args(argv)
 
@@ -844,7 +890,11 @@ def main(argv: list[str] | None = None) -> int:
         _emit("result", status="error", model_requests=0)
         return 1
     deadline = args.deadline if args.deadline > 0 else None
-    provider = _PROVIDER_REGISTRY[args.provider](prompt, args.model, args.workspace, deadline)
+    factory = _PROVIDER_REGISTRY[args.provider]
+    if args.reasoning_effort is None:
+        provider = factory(prompt, args.model, args.workspace, deadline)
+    else:
+        provider = factory(prompt, args.model, args.workspace, deadline, args.reasoning_effort)
     terminal_emitted = False
 
     def emit_failure(exc: Exception) -> None:

--- a/src/evaluator/backends/oneshot_runner.py
+++ b/src/evaluator/backends/oneshot_runner.py
@@ -841,9 +841,7 @@ class _CopilotProvider:
         return self.guard.audit()
 
     def invoke(self, on_timeout: Callable[[ProviderTimeoutError], None]) -> ProviderResult:
-        reasoning_options = (
-            {"reasoning_effort": self.reasoning_effort} if self.reasoning_effort is not None else {}
-        )
+        reasoning_options = {"reasoning_effort": self.reasoning_effort} if self.reasoning_effort is not None else {}
         return asyncio.run(
             run_copilot(
                 self.prompt,

--- a/src/evaluator/backends/pi.py
+++ b/src/evaluator/backends/pi.py
@@ -48,6 +48,7 @@ class PiBackend(AgenticBackend):
         "OPENROUTER_API_KEY",
         "XAI_API_KEY",
     ]
+    reasoning_effort_values = ("off", "minimal", "low", "medium", "high", "xhigh", "max")
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL
@@ -62,6 +63,9 @@ class PiBackend(AgenticBackend):
 
     def build_command(self, workspace: str, result_dir: str) -> list[str]:
         provider, model = self._provider_model()
+        thinking_option = (
+            f"--thinking {shlex.quote(self.reasoning_effort)} " if self.reasoning_effort is not None else ""
+        )
         return [
             "bash",
             "-lc",
@@ -69,6 +73,7 @@ class PiBackend(AgenticBackend):
                 "prompt=$(cat); "
                 f"cd {shlex.quote(workspace)}; "
                 "pi --mode json --no-session "
+                f"{thinking_option}"
                 f"--provider {shlex.quote(provider)} --model {shlex.quote(model)} "
                 '"$prompt"'
             ),

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -9,7 +9,7 @@ For each benchmark:
 
 Usage:
     python3 runner.py [--backend codex|claude_code|copilot|litellm|pi] [--mode proof-completion|proof-from-scratch] \\
-                      [--model NAME] [--jobs N] [--filter PATTERN] \\
+                      [--model NAME] [--reasoning-effort VALUE] [--jobs N] [--filter PATTERN] \\
                       [--timeout SECS] [--check-timeout SECS] [--output-dir DIR]
 """
 
@@ -1409,6 +1409,11 @@ def main():
         "--mode", default="proof-completion", choices=list_modes(), help="Benchmark mode (default: proof-completion)"
     )
     parser.add_argument("--model", default=None, help="Override the backend default model")
+    parser.add_argument(
+        "--reasoning-effort",
+        default=None,
+        help="Pass a backend/model-specific reasoning effort (default: preserve existing backend behavior)",
+    )
     parser.add_argument("--jobs", type=int, default=1, help="Parallel backend runs")
     parser.add_argument("--filter", default=None, help="Only run benchmarks matching pattern")
     parser.add_argument(
@@ -1543,6 +1548,7 @@ def main():
     # preserves the useful fail-fast behavior for a misspelled --filter: no
     # backend validation, auth probe, image build, or model request happens.
     try:
+        backend.set_reasoning_effort(args.reasoning_effort)
         args.infra_retries = backend.validate_options(args.infra_retries, args.max_continuations)
     except ValueError as exc:
         parser.error(str(exc))
@@ -1605,6 +1611,8 @@ def main():
     os.makedirs(output_dir, exist_ok=True)
 
     print(f"Backend: {backend.name}" + (f" (model={args.model})" if args.model else ""))
+    if backend.reasoning_effort is not None:
+        print(f"Effort:  {backend.reasoning_effort}")
     print(f"Mode:   {mode.name} — {mode.description}")
     print(f"Output:  {output_dir}")
 

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -1412,7 +1412,8 @@ def main():
     parser.add_argument(
         "--reasoning-effort",
         default=None,
-        help="Pass a backend/model-specific reasoning effort (default: preserve existing backend behavior)",
+        help="Override backend/model reasoning effort; accepted values depend on --backend "
+        "(default: preserve existing backend behavior)",
     )
     parser.add_argument("--jobs", type=int, default=1, help="Parallel backend runs")
     parser.add_argument("--filter", default=None, help="Only run benchmarks matching pattern")

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -15,8 +15,8 @@ never INFRA_ERROR), then runs a registry of INFRA RULES (criteria). Each rule
 inspects a ``TerminationContext`` and returns a reason if it fires, else
 ``None``; the first that fires wins. There is one rule per backend
 (:func:`codex_turn_failed`, :func:`claude_code_result_error`,
-:func:`copilot_session_error`), each branching on ``ctx.backend`` to read its
-own event vocabulary, plus one backend-independent startup rule
+:func:`copilot_session_error`, :func:`litellm_completion_error`), each branching
+on ``ctx.backend`` to read its own event vocabulary, plus one backend-independent startup rule
 (:func:`agent_startup_failure`) for the CLI dying before emitting a single
 event. The one-shot rule may also return TIMEOUT for a strictly audited
 provider deadline. Add more by appending to :data:`INFRA_RULES`.
@@ -241,6 +241,28 @@ def copilot_session_error(ctx: TerminationContext) -> str | None:
     return TerminationReason.INFRA_ERROR
 
 
+def litellm_completion_error(ctx: TerminationContext) -> str | None:
+    """LiteLLM rule: the agent stopped on a completion error.
+
+    The LiteLLM agent emits an ``error`` event and stops its loop when a
+    provider rejects the request or inference otherwise fails. A later
+    ``response`` would indicate recovery, so only the last response/error
+    outcome determines whether the run was cut short.
+    """
+    if ctx.backend != "litellm":
+        return None
+    last_outcome = None
+    for event in ctx.events():
+        event_type = event.get("type")
+        if event_type == "response":
+            last_outcome = "response"
+        elif event_type == "error":
+            last_outcome = "error"
+    if last_outcome == "error":
+        return TerminationReason.INFRA_ERROR
+    return None
+
+
 def one_shot_result_error(ctx: TerminationContext) -> str | None:
     """One-shot rule: require an audited terminal result and one clean response.
 
@@ -323,6 +345,7 @@ INFRA_RULES: list[Rule] = [
     codex_turn_failed,
     claude_code_result_error,
     copilot_session_error,
+    litellm_completion_error,
     one_shot_result_error,
     agent_startup_failure,
 ]

--- a/tests/evaluator/test_oneshot_runner.py
+++ b/tests/evaluator/test_oneshot_runner.py
@@ -396,6 +396,10 @@ def test_litellm_makes_one_call_with_no_tools_system_or_retries(monkeypatch):
     assert result.audit["litellm_completion_invocations"] == 1
     assert result.audit["wire_audited"] is False
     assert result.audit["litellm_retries_disabled"] is True
+
+    reasoned_result = oneshot_runner.run_litellm("EXACT PROMPT", "provider/model", "low")
+    assert calls[-1]["reasoning_effort"] == "low"
+    assert reasoned_result.audit["reasoning_effort"] == "low"
     assert result.audit["system_supplied"] is False
     assert result.audit["tools_supplied"] is False
     assert result.audit["finish_reason"] == "stop"
@@ -706,6 +710,7 @@ def test_copilot_runner_uses_empty_mode_and_strict_session_options(monkeypatch, 
             str(tmp_path),
             time.time() + 123.0,
             handler=handler,
+            reasoning_effort="medium",
         )
     )
 
@@ -720,6 +725,7 @@ def test_copilot_runner_uses_empty_mode_and_strict_session_options(monkeypatch, 
     assert session_options["capi"] == {"enable_web_socket_responses": False}
     assert session_options["infinite_sessions"] == {"enabled": False}
     assert session_options["memory"] == {"enabled": False}
+    assert session_options["reasoning_effort"] == "medium"
     assert captured["send"] == {
         "prompt": "EXACT PROMPT",
         "agent_mode": "interactive",
@@ -728,6 +734,7 @@ def test_copilot_runner_uses_empty_mode_and_strict_session_options(monkeypatch, 
     assert result.text == "MODEL RESPONSE"
     assert (result.input_tokens, result.output_tokens) == (20, 8)
     assert result.audit["inference_requests"] == 1
+    assert result.audit["reasoning_effort"] == "medium"
     assert result.audit["wire_audited"] is True
     assert result.audit["finish_reason"] == "stop"
     assert json.loads(handler.forwarded[0].content)["input"][0]["content"][0]["text"] == "EXACT PROMPT"

--- a/tests/evaluator/test_reasoning_effort.py
+++ b/tests/evaluator/test_reasoning_effort.py
@@ -1,20 +1,23 @@
 """Reasoning-effort CLI plumbing across evaluator backends."""
 
+import io
+import json
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from evaluator import runner
-from evaluator.backends import get_backend
+from evaluator.backends import get_backend, litellm_agent
 
 EXPECTED_EFFORT_VALUES = {
-    "codex": ("none", "low", "medium", "high", "xhigh", "max", "ultra"),
+    "codex": ("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"),
     "claude_code": ("low", "medium", "high", "xhigh", "max"),
     "copilot": ("none", "minimal", "low", "medium", "high", "xhigh", "max"),
     "copilot_oneshot": ("low", "medium", "high", "xhigh"),
-    "litellm": ("none", "minimal", "low", "medium", "high", "xhigh", "max"),
-    "litellm_oneshot": ("none", "minimal", "low", "medium", "high", "xhigh", "max"),
+    "litellm": ("none", "minimal", "low", "medium", "high", "xhigh", "max", "default"),
+    "litellm_oneshot": ("none", "minimal", "low", "medium", "high", "xhigh", "max", "default"),
     "pi": ("off", "minimal", "low", "medium", "high", "xhigh", "max"),
 }
 
@@ -85,6 +88,87 @@ def test_backend_rejects_empty_reasoning_effort(backend_name):
 
     with pytest.raises(ValueError, match="--reasoning-effort cannot be empty"):
         backend.set_reasoning_effort("")
+
+
+@pytest.mark.parametrize(
+    ("backend_name", "reasoning_effort"),
+    [
+        ("codex", "minimal"),
+        ("litellm", "default"),
+        ("litellm_oneshot", "default"),
+    ],
+)
+def test_backend_accepts_supported_edge_reasoning_effort(backend_name, reasoning_effort):
+    backend = get_backend(backend_name)
+
+    backend.set_reasoning_effort(reasoning_effort)
+
+    assert backend.reasoning_effort == reasoning_effort
+
+
+def test_litellm_agent_completion_error_exits_nonzero(monkeypatch, capsys, tmp_path):
+    completion_options = {}
+
+    def reject_completion(**kwargs):
+        completion_options.update(kwargs)
+        raise RuntimeError("reasoning effort is unsupported for this model")
+
+    monkeypatch.setattr(litellm_agent.litellm, "completion", reject_completion)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("Return a short answer."))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "litellm_agent",
+            "--workspace",
+            str(tmp_path),
+            "--model",
+            "gpt-5.5",
+            "--reasoning-effort",
+            "minimal",
+            "--max-iterations",
+            "1",
+        ],
+    )
+
+    assert litellm_agent.main() == 1
+    assert completion_options["reasoning_effort"] == "minimal"
+    assert "temperature" not in completion_options
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [event["type"] for event in events] == ["error", "usage"]
+    assert events[-1] == {"type": "usage", "input_tokens": 0, "output_tokens": 0}
+
+
+def test_litellm_agent_success_exits_zero(monkeypatch, capsys, tmp_path):
+    message = SimpleNamespace(
+        content="ok",
+        tool_calls=None,
+        model_dump=lambda: {"role": "assistant", "content": "ok"},
+    )
+    response = SimpleNamespace(
+        usage=SimpleNamespace(prompt_tokens=4, completion_tokens=1),
+        choices=[SimpleNamespace(message=message)],
+    )
+    monkeypatch.setattr(litellm_agent.litellm, "completion", lambda **_kwargs: response)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("Return a short answer."))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "litellm_agent",
+            "--workspace",
+            str(tmp_path),
+            "--model",
+            "gpt-5.5",
+            "--max-iterations",
+            "1",
+        ],
+    )
+
+    assert litellm_agent.main() == 0
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [event["type"] for event in events] == ["response", "usage"]
+    assert events[-1] == {"type": "usage", "input_tokens": 4, "output_tokens": 1}
 
 
 def test_omitted_reasoning_effort_preserves_existing_defaults():

--- a/tests/evaluator/test_reasoning_effort.py
+++ b/tests/evaluator/test_reasoning_effort.py
@@ -1,8 +1,29 @@
 """Reasoning-effort CLI plumbing across evaluator backends."""
 
+import sys
+from unittest.mock import MagicMock
+
 import pytest
 
+from evaluator import runner
 from evaluator.backends import get_backend
+
+EXPECTED_EFFORT_VALUES = {
+    "codex": ("none", "low", "medium", "high", "xhigh", "max", "ultra"),
+    "claude_code": ("low", "medium", "high", "xhigh", "max"),
+    "copilot": ("none", "minimal", "low", "medium", "high", "xhigh", "max"),
+    "copilot_oneshot": ("low", "medium", "high", "xhigh"),
+    "litellm": ("none", "minimal", "low", "medium", "high", "xhigh", "max"),
+    "litellm_oneshot": ("none", "minimal", "low", "medium", "high", "xhigh", "max"),
+    "pi": ("off", "minimal", "low", "medium", "high", "xhigh", "max"),
+}
+
+
+class NonEmptyMode:
+    name = "proof-completion"
+
+    def get_benchmark_files(self, filter_pattern=None):
+        return ["/benchmarks/proof-completion/GCD/GCD_GCD3.tla"]
 
 
 def _has_option(command: list[str], option: str, value: str) -> bool:
@@ -30,21 +51,92 @@ def test_explicit_reasoning_effort_reaches_backend_command(backend_name, option,
     assert backend.initial_result_metadata()["reasoning_effort"] == "low"
 
 
+def test_explicit_reasoning_effort_reaches_pi_command():
+    backend = get_backend("pi", model="anthropic/claude-sonnet-4-6")
+    backend.set_reasoning_effort("low")
+
+    command = backend.build_command("/workspace", "/results")
+
+    assert "--thinking low" in command[2]
+    assert backend.initial_result_metadata()["reasoning_effort"] == "low"
+
+
+@pytest.mark.parametrize(("backend_name", "values"), EXPECTED_EFFORT_VALUES.items())
+def test_backend_reasoning_effort_contract(backend_name, values):
+    backend = get_backend(backend_name)
+
+    assert backend.reasoning_effort_values == values
+    for value in values:
+        backend.set_reasoning_effort(value)
+        assert backend.reasoning_effort == value
+
+
+@pytest.mark.parametrize("backend_name", EXPECTED_EFFORT_VALUES)
+def test_backend_rejects_unknown_reasoning_effort(backend_name):
+    backend = get_backend(backend_name)
+
+    with pytest.raises(ValueError, match="invalid --reasoning-effort 'definitely-invalid'"):
+        backend.set_reasoning_effort("definitely-invalid")
+
+
+@pytest.mark.parametrize("backend_name", EXPECTED_EFFORT_VALUES)
+def test_backend_rejects_empty_reasoning_effort(backend_name):
+    backend = get_backend(backend_name)
+
+    with pytest.raises(ValueError, match="--reasoning-effort cannot be empty"):
+        backend.set_reasoning_effort("")
+
+
 def test_omitted_reasoning_effort_preserves_existing_defaults():
     codex = get_backend("codex")
     claude = get_backend("claude_code")
     copilot = get_backend("copilot")
     litellm = get_backend("litellm")
+    copilot_oneshot = get_backend("copilot_oneshot")
     litellm_oneshot = get_backend("litellm_oneshot")
+    pi = get_backend("pi")
 
     assert not any(value.startswith("model_reasoning_effort=") for value in codex.build_command("/w", "/r"))
     assert _has_option(claude.build_command("/w", "/r"), "--effort", "max")
     assert _has_option(copilot.build_command("/w", "/r"), "--effort", "max")
     assert "--reasoning-effort" not in litellm.build_command("/w", "/r")
+    assert "--reasoning-effort" not in copilot_oneshot.build_command("/w", "/r")
     assert "--reasoning-effort" not in litellm_oneshot.build_command("/w", "/r")
-    assert "reasoning_effort" not in codex.initial_result_metadata()
+    assert "--thinking" not in pi.build_command("/w", "/r")[2]
+    for backend in (codex, claude, copilot, litellm, copilot_oneshot, litellm_oneshot, pi):
+        assert "reasoning_effort" not in backend.initial_result_metadata()
 
 
-def test_backend_specific_reasoning_effort_validation():
-    with pytest.raises(ValueError, match="does not support --reasoning-effort"):
-        get_backend("pi").set_reasoning_effort("low")
+@pytest.mark.parametrize(
+    ("backend_name", "effort_args", "expected_error"),
+    [
+        ("litellm", ["--reasoning-effort", "definitely-invalid"], "invalid --reasoning-effort"),
+        ("claude_code", ["--reasoning-effort="], "--reasoning-effort cannot be empty"),
+    ],
+)
+def test_invalid_cli_effort_fails_before_auth_image_or_preflight(
+    monkeypatch, capsys, backend_name, effort_args, expected_error
+):
+    backend = get_backend(backend_name)
+    check_auth = MagicMock()
+    ensure_image = MagicMock()
+    preflight = MagicMock()
+    monkeypatch.setattr(backend, "check_auth", check_auth)
+    monkeypatch.setattr(runner, "get_backend", lambda *args, **kwargs: backend)
+    monkeypatch.setattr(runner, "get_mode", lambda *args, **kwargs: NonEmptyMode())
+    monkeypatch.setattr(runner, "ensure_image", ensure_image)
+    monkeypatch.setattr(runner, "_run_preflight", preflight)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["tlaps-bench run", "--backend", backend_name, *effort_args, "--filter", "GCD_GCD3"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.main()
+
+    assert exc_info.value.code == 2
+    assert expected_error in capsys.readouterr().err
+    check_auth.assert_not_called()
+    ensure_image.assert_not_called()
+    preflight.assert_not_called()

--- a/tests/evaluator/test_reasoning_effort.py
+++ b/tests/evaluator/test_reasoning_effort.py
@@ -1,0 +1,50 @@
+"""Reasoning-effort CLI plumbing across evaluator backends."""
+
+import pytest
+
+from evaluator.backends import get_backend
+
+
+def _has_option(command: list[str], option: str, value: str) -> bool:
+    return any(command[index : index + 2] == [option, value] for index in range(len(command) - 1))
+
+
+@pytest.mark.parametrize(
+    ("backend_name", "option", "value"),
+    [
+        ("codex", "-c", "model_reasoning_effort=low"),
+        ("claude_code", "--effort", "low"),
+        ("copilot", "--effort", "low"),
+        ("litellm", "--reasoning-effort", "low"),
+        ("copilot_oneshot", "--reasoning-effort", "low"),
+        ("litellm_oneshot", "--reasoning-effort", "low"),
+    ],
+)
+def test_explicit_reasoning_effort_reaches_backend_command(backend_name, option, value):
+    backend = get_backend(backend_name, model="test-model")
+    backend.set_reasoning_effort("low")
+
+    command = backend.build_command("/workspace", "/results")
+
+    assert _has_option(command, option, value)
+    assert backend.initial_result_metadata()["reasoning_effort"] == "low"
+
+
+def test_omitted_reasoning_effort_preserves_existing_defaults():
+    codex = get_backend("codex")
+    claude = get_backend("claude_code")
+    copilot = get_backend("copilot")
+    litellm = get_backend("litellm")
+    litellm_oneshot = get_backend("litellm_oneshot")
+
+    assert not any(value.startswith("model_reasoning_effort=") for value in codex.build_command("/w", "/r"))
+    assert _has_option(claude.build_command("/w", "/r"), "--effort", "max")
+    assert _has_option(copilot.build_command("/w", "/r"), "--effort", "max")
+    assert "--reasoning-effort" not in litellm.build_command("/w", "/r")
+    assert "--reasoning-effort" not in litellm_oneshot.build_command("/w", "/r")
+    assert "reasoning_effort" not in codex.initial_result_metadata()
+
+
+def test_backend_specific_reasoning_effort_validation():
+    with pytest.raises(ValueError, match="does not support --reasoning-effort"):
+        get_backend("pi").set_reasoning_effort("low")

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -27,6 +27,7 @@ from evaluator.termination import (
     codex_turn_failed,
     copilot_session_error,
     is_wall_clock_timeout,
+    litellm_completion_error,
     one_shot_result_error,
     startup_error_snippet,
 )
@@ -147,7 +148,33 @@ def test_rule_only_applies_to_its_backend(tmp_path):
     # other backend; a backend with no rule of its own classifies OK.
     p = _write_jsonl(tmp_path / "infra.jsonl", INFRA_STREAM)
     assert codex_turn_failed(_ctx(p, backend="claude_code")) is None
-    assert classify(_ctx(p, backend="litellm")) == TerminationReason.OK
+    assert classify(_ctx(p, backend="custom")) == TerminationReason.OK
+
+
+def test_litellm_completion_error_is_infra(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "litellm-error.jsonl",
+        [
+            {"type": "error", "message": "reasoning effort is unsupported for this model", "iteration": 1},
+            {"type": "usage", "input_tokens": 0, "output_tokens": 0},
+        ],
+    )
+
+    assert classify(_ctx(path, backend="litellm", agent_exit=0)) == TerminationReason.INFRA_ERROR
+
+
+def test_litellm_response_after_error_is_ok(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "litellm-recovered.jsonl",
+        [
+            {"type": "error", "message": "transient provider error", "iteration": 1},
+            {"type": "response", "text": "recovered", "iteration": 2},
+            {"type": "usage", "input_tokens": 10, "output_tokens": 2},
+        ],
+    )
+
+    assert litellm_completion_error(_ctx(path, backend="litellm")) is None
+    assert classify(_ctx(path, backend="litellm")) == TerminationReason.OK
 
 
 def test_missing_stream_is_ok(tmp_path):
@@ -207,6 +234,7 @@ def test_registry_is_the_extension_point():
     assert codex_turn_failed in INFRA_RULES
     assert claude_code_result_error in INFRA_RULES
     assert copilot_session_error in INFRA_RULES
+    assert litellm_completion_error in INFRA_RULES
     assert one_shot_result_error in INFRA_RULES
     assert agent_startup_failure in INFRA_RULES
 


### PR DESCRIPTION
## Summary

- Add optional `--reasoning-effort` support across compatible backends.
- Preserve existing backend defaults when omitted.
- Forward the selected effort directly to the backend.
- Record the requested effort in result metadata.

## Validation

- Live Codex runs passed at `low` and `medium`.
- Live Copilot + Claude Haiku 4.5 passed at `medium`.
