### PR TITLE
Allow custom OpenAI-compatible endpoint through firewall

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -59,6 +59,22 @@ uv run tlaps-bench run --backend litellm --model claude-sonnet-4-6
 uv run tlaps-bench run --backend litellm_oneshot --model claude-sonnet-4-6
 ```
 
+### OpenAI-compatible endpoints
+
+To target any OpenAI-compatible endpoint (a self-hosted gateway, a vendor's
+inference API, etc.), use the LiteLLM backend with an `openai/<model>` model id
+and point `OPENAI_API_BASE` (or `OPENAI_BASE_URL`) at the endpoint. The host is
+forwarded into the container and automatically added to the firewall allow-list:
+
+```bash
+export OPENAI_API_KEY=...
+export OPENAI_API_BASE=https://inference-api.somecompany.com/v1
+uv run tlaps-bench run --backend litellm --model openai/somecompany/some-model
+```
+
+The leading `openai/` selects LiteLLM's OpenAI-compatible transport; everything
+after it is sent to the endpoint as the wire model id.
+
 ### Reasoning effort
 
 Use the optional `--reasoning-effort` flag to override a model's reasoning budget:

--- a/src/evaluator/backends/base.py
+++ b/src/evaluator/backends/base.py
@@ -81,14 +81,15 @@ ALL_API_HOSTS = (
 )
 
 
-def _azure_openai_hosts() -> list[str]:
-    """Extract Azure OpenAI endpoint host(s) from environment variables.
+def _hosts_from_env(*env_vars: str) -> list[str]:
+    """Extract deduplicated hostnames from endpoint URLs in the given env vars.
 
-    Azure OpenAI uses customer-specific hostnames (e.g.
-    my-resource.openai.azure.com) that cannot be statically enumerated.
+    Used for endpoints with customer/provider-specific hostnames that cannot be
+    statically enumerated (Azure OpenAI, OpenAI-compatible base URLs, etc.). The
+    ``//`` prefix lets ``urlparse`` extract a host even from a scheme-less value.
     """
     hosts: list[str] = []
-    for var in ("AZURE_OPENAI_HOST", "AZURE_API_BASE", "AZURE_OPENAI_ENDPOINT"):
+    for var in env_vars:
         val = os.environ.get(var, "").strip()
         if not val:
             continue
@@ -100,7 +101,16 @@ def _azure_openai_hosts() -> list[str]:
 
 def detect_firewall_hosts(model: str) -> list[str]:
     """All known LLM API hosts. Blocks general internet, allows any provider."""
-    return ALL_API_HOSTS + _azure_openai_hosts()
+    # Azure OpenAI and custom OpenAI-compatible endpoints use non-enumerable
+    # hostnames supplied through env, so derive them at run time.
+    dynamic_hosts = _hosts_from_env(
+        "AZURE_OPENAI_HOST",
+        "AZURE_API_BASE",
+        "AZURE_OPENAI_ENDPOINT",
+        "OPENAI_API_BASE",
+        "OPENAI_BASE_URL",
+    )
+    return ALL_API_HOSTS + dynamic_hosts
 
 
 def has_aws_env_credentials() -> bool:

--- a/src/evaluator/backends/litellm_agent.py
+++ b/src/evaluator/backends/litellm_agent.py
@@ -10,6 +10,12 @@ import os
 import subprocess
 import sys
 
+# Use LiteLLM's bundled model-cost map instead of fetching it at runtime: the
+# container firewall blocks the remote fetch, and a failed fetch both emits a
+# warning the runner misreads as a transient infra failure and changes provider
+# param handling. Must be set before importing litellm.
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
 try:
     import litellm
 except ImportError:

--- a/src/evaluator/backends/litellm_agent.py
+++ b/src/evaluator/backends/litellm_agent.py
@@ -22,6 +22,10 @@ except ImportError:
     print(json.dumps({"type": "error", "message": "litellm not installed"}))
     sys.exit(1)
 
+# Drop provider-unsupported params (e.g. temperature for gpt-5 reasoning models)
+# rather than raising, so one agent loop works across model families.
+litellm.drop_params = True
+
 TOOLS = [
     {
         "type": "function",


### PR DESCRIPTION
The agent container firewall only whitelisted a fixed list of known LLM provider hosts, so OpenAI-compatible endpoints reached via a custom base URL (e.g. SomeCompany's inference API) were blocked despite OPENAI_API_BASE / OPENAI_BASE_URL already being forwarded into the container.

Derive the host from OPENAI_API_BASE / OPENAI_BASE_URL and add it to the firewall allow-list, mirroring the existing Azure OpenAI handling. This lets `litellm --model openai/<model>` target any OpenAI-compatible endpoint via env alone. Document the workflow in the LiteLLM section of docs/USAGE.md.