### PR TITLE
Document German Protocol provenance

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -31,6 +31,19 @@ tlaplus/Examples  —  MIT, except where noted below  —  https://github.com/tl
       - tlaplus_examples_BlockingQueue — MIT: from
         https://github.com/lemmy/BlockingQueue; Copyright (c) 2020
         Markus A. Kuppe.
+      - tlaplus_examples_GermanProtocol — MIT: the benchmark model corresponds
+        to GermanCoherence.tla at commit aba0cef20ce694f97612ad36a873734a1314534a:
+        https://github.com/tlaplus/Examples/blob/aba0cef20ce694f97612ad36a873734a1314534a/specifications/GermanProtocol/GermanCoherence.tla
+        It is adapted from the German cache-coherence protocol Murphi models in
+        https://github.com/dsethi/ProtocolDeadlockFiles, published as
+        supplementary material for Divjyot Sethi, Muralidhar Talupur, and
+        Sharad Malik, "Using Flow Specifications of Parameterized Cache
+        Coherence Protocols for Verifying Deadlock Freedom" (ATVA 2014). Those
+        models build on Ching-Tsun Chou, Phanindra K. Mannava, and Seungjoon
+        Park, "A Simple Method for Parameterized Verification of Cache
+        Coherence Protocols" (FMCAD 2004); the protocol is attributed to Steven
+        M. German. The upstream example asks redistributors to review the
+        external artifact's licensing and attribution requirements.
 
 OpenAddressing  —  MIT  —  benchmark group OpenAddressing
     By Markus A. Kuppe, from the mku-OA branch of https://github.com/lemmy/Examples

--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -7,7 +7,7 @@ per-source summary.
 Each row is a benchmark **example** — one directory under `benchmark/<mode>/`,
 i.e. one coherent protocol or example. A protocol whose proof is split across
 several TLA+ modules stays a single row. The example name links to its upstream
-location; the upstream location of `GermanProtocol` could not be found.
+location.
 
 `–` marks a mode with no task for that example: a source with no human proofs
 yields no proof-completion task, and an example whose only proven theorems are
@@ -85,7 +85,7 @@ This file is generated; regenerate it with `python3 scripts/dataset_table.py`.
 | [SpanningTree](https://github.com/tlaplus/Examples/tree/master/specifications/SpanningTree) | tlaplus/Examples | 1 | 1 | 2 |
 | [SpecifyingSystems_TLC](https://github.com/tlaplus/Examples/tree/master/specifications/SpecifyingSystems/TLC) | tlaplus/Examples | 1 | 1 | 2 |
 | [byihive](https://github.com/tlaplus/Examples/tree/master/specifications/byihive) | tlaplus/Examples | 1 | 1 | 2 |
-| GermanProtocol | tlaplus/Examples | – | 1 | 1 |
+| [GermanProtocol](https://github.com/tlaplus/Examples/blob/aba0cef20ce694f97612ad36a873734a1314534a/specifications/GermanProtocol/GermanCoherence.tla) | tlaplus/Examples | – | 1 | 1 |
 | [SpecifyingSystems_HourClock](https://github.com/tlaplus/Examples/tree/master/specifications/SpecifyingSystems/HourClock) | tlaplus/Examples | 1 | – | 1 |
 | [two_thread_mutex](https://github.com/anvil-verifier/anvil/blob/main/src/tla_demo.rs) | two_thread_mutex (Anvil) | – | 1 | 1 |
 

--- a/scripts/dataset_table.py
+++ b/scripts/dataset_table.py
@@ -94,8 +94,12 @@ _GROUP_URL = {
     "ZooKeeper": "https://github.com/Disalg-ICS-NJU/zookeeper-tla-spec/blob/main/high-level-spec/Zab.tla",
     "ZooKeeper_LowLevel": "https://github.com/Disalg-ICS-NJU/zookeeper-tla-spec/tree/main/low-level-spec/zk-3.7",
     "tlaplus_examples_BlockingQueue": "https://github.com/lemmy/BlockingQueue",
+    "tlaplus_examples_GermanProtocol": (
+        "https://github.com/tlaplus/Examples/blob/"
+        "aba0cef20ce694f97612ad36a873734a1314534a/"
+        "specifications/GermanProtocol/GermanCoherence.tla"
+    ),
     "two_thread_mutex": "https://github.com/anvil-verifier/anvil/blob/main/src/tla_demo.rs",
-    # The upstream location of tlaplus_examples_GermanProtocol could not be found.
 }
 
 
@@ -108,8 +112,6 @@ def group_url(group):
         return f"https://github.com/kenmcmil/ivy/blob/master/examples/liveness/{name}.ivy"
     if group.startswith("tlaplus_examples_"):
         x = group[len("tlaplus_examples_") :]
-        if x == "GermanProtocol":
-            return None
         if x.startswith("SpecifyingSystems_"):
             chapter = x[len("SpecifyingSystems_") :]
             return f"{_EX}/SpecifyingSystems/{chapter}"


### PR DESCRIPTION
## Summary
- link the existing GermanProtocol benchmark to its exact upstream snapshot
- document the protocol's provenance and attribution in `NOTICE`
- update the generated dataset row without changing tasks or counts