### PR TITLE
Add Cursor CLI backend

### DIFF
--- a/docker/install-scripts/install-cursor.sh
+++ b/docker/install-scripts/install-cursor.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+# Cursor Agent CLI ships as a self-contained binary installed under
+# $HOME/.local/bin. Symlink it onto the default PATH so the (non-login) agent
+# shell can find `cursor-agent`. This runs before the firewall is applied, so
+# the installer's downloads reach the internet freely.
+curl https://cursor.com/install -fsS | bash
+cursor_agent="$HOME/.local/bin/cursor-agent"
+if [[ ! -x "$cursor_agent" ]]; then
+    echo "Cursor installer did not create executable: $cursor_agent" >&2
+    exit 1
+fi
+ln -sf "$cursor_agent" /usr/local/bin/cursor-agent

--- a/src/common/container.py
+++ b/src/common/container.py
@@ -9,6 +9,7 @@ import shlex
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import time
 import tomllib
@@ -153,6 +154,9 @@ class CredentialMount:
 
     mount_path: str
     copy: Callable[[Path, Path], bool]
+    # Host source directory. Defaults to ``~/.<name>``; set explicitly for
+    # backends whose credentials live elsewhere or vary by host platform.
+    source_dir: Callable[[], Path] | None = None
 
 
 def _copy_all_credentials(src: Path, dst: Path) -> bool:
@@ -193,6 +197,21 @@ def _copy_pi_credentials(src: Path, dst: Path) -> bool:
     auth_dst.mkdir(parents=True, exist_ok=True)
     shutil.copy2(auth_src, auth_dst / "auth.json")
     return True
+
+
+def _copy_cursor_credentials(src: Path, dst: Path) -> bool:
+    """Copy only the Cursor CLI's OAuth credential file (accessToken/refreshToken)."""
+    return _copy_named_credential_file(src, dst, "auth.json")
+
+
+def _cursor_credential_dir() -> Path:
+    """Return the host-specific Cursor CLI credential directory."""
+    if sys.platform == "darwin":
+        return Path.home() / ".cursor"
+
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    config_home = Path(xdg_config_home).expanduser() if xdg_config_home else Path.home() / ".config"
+    return config_home / "cursor"
 
 
 def _copy_codex_credentials(src: Path, dst: Path) -> bool:
@@ -244,6 +263,11 @@ class ContainerRunner:
         "aws": CredentialMount("/root/.aws", _copy_all_credentials),
         "claude": CredentialMount("/root/.claude", _copy_claude_credentials),
         "codex": CredentialMount("/root/.codex", _copy_codex_credentials),
+        "cursor": CredentialMount(
+            "/root/.config/cursor",
+            _copy_cursor_credentials,
+            source_dir=_cursor_credential_dir,
+        ),
         "pi": CredentialMount("/root/.pi", _copy_pi_credentials),
     }
 
@@ -297,7 +321,7 @@ class ContainerRunner:
             mount = self._CREDENTIAL_MOUNTS.get(name)
             if mount is None:
                 raise ValueError(f"unknown credential mount: {name}")
-            src = Path.home() / f".{name}"
+            src = mount.source_dir() if mount.source_dir else (Path.home() / f".{name}")
             if not src.is_dir():
                 continue
             # Session dir targets this path: copy credentials into it (not a
@@ -322,7 +346,7 @@ class ContainerRunner:
         for key, value in config.env.items():
             args.extend(["-e", f"{key}={value}"])
 
-        # Firewall hosts as env var (read by firewall.sh inside container)
+        # Firewall config as env vars (read by firewall.sh inside container)
         if config.firewall_hosts:
             args.extend(["-e", f"FIREWALL_HOSTS={','.join(config.firewall_hosts)}"])
         else:

--- a/src/evaluator/backends/__init__.py
+++ b/src/evaluator/backends/__init__.py
@@ -7,6 +7,7 @@ from .claude_code import ClaudeCodeBackend
 from .codex import CodexBackend
 from .copilot import CopilotBackend
 from .copilot_oneshot import CopilotOneShotBackend
+from .cursor import CursorBackend
 from .litellm import LiteLLMBackend
 from .litellm_oneshot import LiteLLMOneShotBackend
 from .oneshot import OneShotBackend as OneShotBackend
@@ -15,6 +16,7 @@ from .pi import PiBackend
 _REGISTRY = {
     CodexBackend.name: CodexBackend,
     ClaudeCodeBackend.name: ClaudeCodeBackend,
+    CursorBackend.name: CursorBackend,
     CopilotBackend.name: CopilotBackend,
     CopilotOneShotBackend.name: CopilotOneShotBackend,
     LiteLLMBackend.name: LiteLLMBackend,

--- a/src/evaluator/backends/cursor.py
+++ b/src/evaluator/backends/cursor.py
@@ -1,0 +1,215 @@
+"""Cursor CLI (`cursor-agent`) backend."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from ipaddress import ip_address
+from urllib.parse import urlparse
+
+from .agentic import AgenticBackend
+
+DEFAULT_MODEL = "sonnet-4.5"
+DEFAULT_API_ENDPOINT = "https://api2.cursor.sh"
+_DNS_LABEL = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+
+
+class CursorBackend(AgenticBackend):
+    name = "cursor"
+    install_script = "install-cursor.sh"
+    session_state_dir = None
+    # CURSOR_API_KEY / endpoint let users route via an API key instead of the
+    # mounted `cursor-agent login` credentials.
+    env_keys = [
+        "CURSOR_API_KEY",
+        "CURSOR_API_ENDPOINT",
+    ]
+
+    def __init__(self, model: str | None = None):
+        self.model = model or DEFAULT_MODEL
+
+    def build_command(self, workspace: str, result_dir: str) -> list[str]:
+        # --force: run non-interactively with full tool access (implies workspace
+        #   trust), since the Docker container is the isolation boundary.
+        # --sandbox disabled: don't nest Cursor's own sandbox inside the container
+        #   (avoids the unprivileged-userns/bwrap failure seen with other CLIs).
+        return [
+            "cursor-agent",
+            "--print",
+            "--output-format",
+            "stream-json",
+            "--force",
+            "--sandbox",
+            "disabled",
+            "--workspace",
+            workspace,
+            "--model",
+            self.model,
+        ]
+
+    def get_credential_mounts(self) -> list[str]:
+        # API-key auth needs no mounted login credentials.
+        if os.environ.get("CURSOR_API_KEY"):
+            return []
+        return ["cursor"]
+
+    def check_auth(self) -> str | None:
+        # Fast path: an API key is set.
+        if os.environ.get("CURSOR_API_KEY"):
+            return None
+        # Slow path: ask the CLI whether it's logged in (local read of
+        # ~/.config/cursor state; no session pollution).
+        try:
+            r = subprocess.run(
+                ["cursor-agent", "status"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if r.returncode == 0 and "Logged in" in (r.stdout + r.stderr):
+                return None
+        except FileNotFoundError:
+            return "cursor: `cursor-agent` CLI not found on PATH"
+        except Exception:
+            pass
+        return "cursor: no auth detected. Set CURSOR_API_KEY or run `cursor-agent login`."
+
+    def firewall_hosts(self) -> list[str]:
+        """Allow only the configured Cursor API endpoint.
+
+        The container firewall supports HTTPS on port 443 only, so reject
+        endpoint values that it cannot enforce instead of silently widening
+        egress or letting the run fail later inside Cursor.
+        """
+        endpoint = os.environ.get("CURSOR_API_ENDPOINT", DEFAULT_API_ENDPOINT).strip()
+        try:
+            parsed = urlparse(endpoint)
+            port = parsed.port
+        except ValueError as exc:
+            raise ValueError(f"invalid CURSOR_API_ENDPOINT: {endpoint!r}") from exc
+
+        if (
+            parsed.scheme.lower() != "https"
+            or not parsed.netloc
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or port not in (None, 443)
+        ):
+            raise ValueError(
+                f"CURSOR_API_ENDPOINT must be an absolute HTTPS URL on port 443 with a valid hostname, got {endpoint!r}"
+            )
+
+        try:
+            hostname = parsed.hostname.encode("idna").decode("ascii").lower().rstrip(".")
+            ip_address(hostname)
+        except ValueError:
+            labels = hostname.split(".")
+            if not hostname or len(hostname) > 253 or not all(_DNS_LABEL.fullmatch(label) for label in labels):
+                raise ValueError(
+                    "CURSOR_API_ENDPOINT must be an absolute HTTPS URL on port 443 "
+                    f"with a valid hostname, got {endpoint!r}"
+                ) from None
+        except UnicodeError as exc:
+            raise ValueError(f"invalid CURSOR_API_ENDPOINT hostname: {parsed.hostname!r}") from exc
+        else:
+            raise ValueError(f"CURSOR_API_ENDPOINT must use a DNS hostname, got {endpoint!r}")
+
+        return [hostname]
+
+    def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
+        lines: list[str] = []
+        in_tok = 0
+        out_tok = 0
+
+        try:
+            with open(jsonl_path) as f:
+                for raw in f:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        event = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+
+                    etype = event.get("type", "")
+
+                    if etype == "assistant":
+                        message = event.get("message", {})
+                        content = message.get("content", [])
+                        if isinstance(content, list):
+                            for block in content:
+                                if not isinstance(block, dict):
+                                    continue
+                                if block.get("type") == "text":
+                                    text = block.get("text", "")
+                                    if text:
+                                        lines.append(f"[AGENT] {text}")
+                                        lines.append("")
+
+                    elif etype == "tool_call":
+                        subtype = event.get("subtype", "")
+                        tc = event.get("tool_call", {})
+                        if not isinstance(tc, dict) or not tc:
+                            continue
+                        kind = next(iter(tc))
+                        body = tc.get(kind) if isinstance(tc.get(kind), dict) else {}
+                        args = body.get("args", {}) if isinstance(body, dict) else {}
+                        if subtype == "started":
+                            lines.append(f"[TOOL] {kind} {self._summarize_args(kind, args)}")
+                            lines.append("")
+                        elif subtype == "completed":
+                            result = body.get("result") if isinstance(body, dict) else None
+                            if result is not None:
+                                lines.append(f"[TOOL_RESULT] {self._summarize_result(result)}")
+                                lines.append("")
+
+                    elif etype == "result":
+                        subtype = event.get("subtype", "")
+                        result_text = event.get("result", "")
+                        if result_text:
+                            lines.append(f"[RESULT/{subtype}] {result_text}")
+                            lines.append("")
+                        usage = event.get("usage", {})
+                        if isinstance(usage, dict):
+                            in_tok = (
+                                usage.get("inputTokens", 0)
+                                + usage.get("cacheReadTokens", 0)
+                                + usage.get("cacheWriteTokens", 0)
+                            )
+                            out_tok = usage.get("outputTokens", 0)
+
+                    elif etype == "error":
+                        lines.append(f"[ERROR] {event.get('message', '')}")
+                        lines.append("")
+        except FileNotFoundError:
+            pass
+
+        return "\n".join(lines), in_tok, out_tok
+
+    @staticmethod
+    def _summarize_args(kind: str, args: dict) -> str:
+        if not isinstance(args, dict):
+            return ""
+        for key in ("command", "path", "filePath", "query", "pattern"):
+            val = args.get(key)
+            if isinstance(val, str) and val:
+                return val
+        try:
+            s = json.dumps(args, ensure_ascii=False)
+        except (TypeError, ValueError):
+            s = str(args)
+        return s[:300]
+
+    @staticmethod
+    def _summarize_result(result: object) -> str:
+        try:
+            s = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
+        except (TypeError, ValueError):
+            s = str(result)
+        if len(s) > 3000:
+            s = s[:1500] + "\n... (truncated) ...\n" + s[-1500:]
+        return s.rstrip()

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -15,11 +15,12 @@ never INFRA_ERROR), then runs a registry of INFRA RULES (criteria). Each rule
 inspects a ``TerminationContext`` and returns a reason if it fires, else
 ``None``; the first that fires wins. There is one rule per backend
 (:func:`codex_turn_failed`, :func:`claude_code_result_error`,
-:func:`copilot_session_error`, :func:`litellm_completion_error`), each branching
-on ``ctx.backend`` to read its own event vocabulary, plus one backend-independent startup rule
-(:func:`agent_startup_failure`) for the CLI dying before emitting a single
-event. The one-shot rule may also return TIMEOUT for a strictly audited
-provider deadline. Add more by appending to :data:`INFRA_RULES`.
+:func:`copilot_session_error`, :func:`cursor_result_error`,
+:func:`litellm_completion_error`), each branching on ``ctx.backend`` to read its
+own event vocabulary, plus one backend-independent startup rule
+(:func:`agent_startup_failure`) for the CLI dying before emitting a single event.
+The one-shot rule may also return TIMEOUT for a strictly audited provider
+deadline. Add more by appending to :data:`INFRA_RULES`.
 
 This module only CLASSIFIES. Acting on the classification (the runner auto-
 retries an INFRA_ERROR run whose model did no work) is left to the caller.
@@ -241,6 +242,33 @@ def copilot_session_error(ctx: TerminationContext) -> str | None:
     return TerminationReason.INFRA_ERROR
 
 
+def cursor_result_error(ctx: TerminationContext) -> str | None:
+    """Cursor rule: require one clean terminal ``result`` event.
+
+    Cursor's ``stream-json`` contract ends every successful run with exactly one
+    terminal ``result`` whose ``subtype`` is ``success`` and ``is_error`` is
+    false. On failure, the CLI may exit nonzero after emitting only a partial
+    stream, with the error itself written to stderr. A non-empty stream that is
+    malformed, lacks that terminal, or ends in an explicit error is therefore
+    not a trustworthy model attempt.
+
+    An empty or wholly malformed stream is also infrastructure failure: a clean
+    Cursor run cannot exit without the terminal success event.
+    """
+    if ctx.backend != "cursor":
+        return None
+    events = ctx.events()
+    if not events or not ctx.event_stream_valid():
+        return TerminationReason.INFRA_ERROR
+    results = [event for event in events if event.get("type") == "result"]
+    if len(results) != 1 or events[-1] is not results[0]:
+        return TerminationReason.INFRA_ERROR
+    terminal = results[0]
+    if terminal.get("subtype") != "success" or terminal.get("is_error") is not False:
+        return TerminationReason.INFRA_ERROR
+    return None
+
+
 def litellm_completion_error(ctx: TerminationContext) -> str | None:
     """LiteLLM rule: the agent stopped on a completion error.
 
@@ -348,6 +376,7 @@ INFRA_RULES: list[Rule] = [
     codex_turn_failed,
     claude_code_result_error,
     copilot_session_error,
+    cursor_result_error,
     litellm_completion_error,
     one_shot_result_error,
     agent_startup_failure,

--- a/tests/common/test_firewall_dns.py
+++ b/tests/common/test_firewall_dns.py
@@ -24,41 +24,52 @@ def _stub(bindir, name, body):
 
 def _run_firewall(tmp_path, fail_digs):
     """Run firewall.sh with stubbed tools: dig answers nothing for the first
-    `fail_digs` calls, then resolves. Returns (proc, dig call count)."""
+    `fail_digs` calls, then resolves. Returns (proc, dig call count, iptables calls)."""
     bindir = tmp_path / "bin"
     bindir.mkdir()
     counter = tmp_path / "dig_calls"
     counter.write_text("0")
+    iptables_calls = tmp_path / "iptables_calls"
+    iptables_calls.write_text("")
     _stub(
         bindir,
         "dig",
         f'n=$(cat "{counter}"); n=$((n + 1)); echo "$n" > "{counter}"; '
         f'if [ "$n" -gt {fail_digs} ]; then echo 1.2.3.4; fi',
     )
-    _stub(bindir, "iptables", "exit 0")
+    _stub(bindir, "iptables", f'printf "%s\\n" "$*" >> "{iptables_calls}"')
     _stub(bindir, "ip6tables", "exit 0")
     _stub(bindir, "sleep", "exit 0")  # keep the retry backoff instant
     env = {**os.environ, "PATH": f"{bindir}:{os.environ['PATH']}", "FIREWALL_HOSTS": "api.example.com"}
     proc = subprocess.run(["bash", FIREWALL_SH], capture_output=True, text=True, env=env, timeout=30)
-    return proc, int(counter.read_text())
+    return proc, int(counter.read_text()), iptables_calls.read_text().splitlines()
 
 
 def test_first_try_resolution_needs_no_retry(tmp_path):
-    proc, dig_calls = _run_firewall(tmp_path, fail_digs=0)
+    proc, dig_calls, _ = _run_firewall(tmp_path, fail_digs=0)
     assert proc.returncode == 0, proc.stderr
     assert dig_calls == 1
     assert "Allowed: api.example.com -> 1.2.3.4" in proc.stdout
 
 
 def test_transient_dns_miss_is_retried(tmp_path):
-    proc, dig_calls = _run_firewall(tmp_path, fail_digs=2)
+    proc, dig_calls, _ = _run_firewall(tmp_path, fail_digs=2)
     assert proc.returncode == 0, proc.stderr
     assert dig_calls == 3
     assert "Allowed: api.example.com -> 1.2.3.4" in proc.stdout
 
 
 def test_persistent_dns_failure_still_fails_after_retries(tmp_path):
-    proc, dig_calls = _run_firewall(tmp_path, fail_digs=99)
+    proc, dig_calls, _ = _run_firewall(tmp_path, fail_digs=99)
     assert proc.returncode == 1
     assert dig_calls == 3  # all retries spent before giving up
     assert "no IPs resolved for host 'api.example.com'" in proc.stderr
+
+
+def test_https_accept_rule_is_scoped_to_resolved_ip(tmp_path):
+    proc, _, iptables_calls = _run_firewall(tmp_path, fail_digs=0)
+
+    assert proc.returncode == 0, proc.stderr
+    https_accepts = [call for call in iptables_calls if "--dport 443" in call and "-j ACCEPT" in call]
+    assert https_accepts == ["-A OUTPUT -d 1.2.3.4 -p tcp --dport 443 -j ACCEPT"]
+    assert "-A OUTPUT -j DROP" in iptables_calls

--- a/tests/evaluator/test_container.py
+++ b/tests/evaluator/test_container.py
@@ -8,7 +8,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
-from common.container import ContainerConfig, ContainerRunner, forward_env
+from common.container import ContainerConfig, ContainerRunner, _cursor_credential_dir, forward_env
 from evaluator.backends.claude_code import ClaudeCodeBackend
 from evaluator.backends.codex import CodexBackend
 from evaluator.backends.copilot import CopilotBackend
@@ -137,6 +137,7 @@ class TestBuildDockerArgs:
         assert "--cap-add=NET_ADMIN" in args
         env_args = [args[i + 1] for i, a in enumerate(args) if a == "-e"]
         assert "FIREWALL_HOSTS=api.openai.com,api.anthropic.com" in env_args
+        assert not any("ALLOW_ALL_HTTPS" in value for value in env_args)
 
     def test_no_firewall_when_empty(self):
         runner = ContainerRunner()
@@ -233,6 +234,59 @@ class TestBuildDockerArgs:
             assert not os.path.exists(os.path.join(copied_home, "sessions"))
         finally:
             runner.cleanup_credential_tmps()
+
+    def test_cursor_mount_uses_macos_credential_dir(self, tmp_path):
+        cursor_home = tmp_path / ".cursor"
+        cursor_home.mkdir()
+        (cursor_home / "auth.json").write_text('{"accessToken": "secret"}\n')
+
+        runner = ContainerRunner()
+        config = ContainerConfig(credential_mounts=["cursor"])
+        try:
+            with (
+                patch("common.container.sys.platform", "darwin"),
+                patch("common.container.Path.home", return_value=tmp_path),
+                patch.dict(os.environ, {}, clear=True),
+            ):
+                args, _ = runner.build_docker_args(config)
+
+            mount_args = [args[i + 1] for i, arg in enumerate(args) if arg == "-v"]
+            cursor_mount = next(m for m in mount_args if m.endswith(":/root/.config/cursor:rw"))
+            copied_home = cursor_mount.split(":", 1)[0]
+            assert os.path.exists(os.path.join(copied_home, "auth.json"))
+        finally:
+            runner.cleanup_credential_tmps()
+
+    def test_cursor_mount_uses_linux_xdg_config_home(self, tmp_path):
+        xdg_config_home = tmp_path / "xdg"
+        cursor_home = xdg_config_home / "cursor"
+        cursor_home.mkdir(parents=True)
+        (cursor_home / "auth.json").write_text('{"accessToken": "secret"}\n')
+
+        runner = ContainerRunner()
+        config = ContainerConfig(credential_mounts=["cursor"])
+        try:
+            with (
+                patch("common.container.sys.platform", "linux"),
+                patch("common.container.Path.home", return_value=tmp_path / "unused-home"),
+                patch.dict(os.environ, {"XDG_CONFIG_HOME": str(xdg_config_home)}, clear=True),
+            ):
+                args, _ = runner.build_docker_args(config)
+
+            mount_args = [args[i + 1] for i, arg in enumerate(args) if arg == "-v"]
+            cursor_mount = next(m for m in mount_args if m.endswith(":/root/.config/cursor:rw"))
+            copied_home = cursor_mount.split(":", 1)[0]
+            assert os.path.exists(os.path.join(copied_home, "auth.json"))
+        finally:
+            runner.cleanup_credential_tmps()
+
+    def test_cursor_credential_dir_uses_linux_default_config_home(self, tmp_path):
+        with (
+            patch("common.container.sys.platform", "linux"),
+            patch("common.container.Path.home", return_value=tmp_path),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            assert _cursor_credential_dir() == tmp_path / ".config" / "cursor"
 
     def test_codex_mount_copies_only_minimal_bedrock_config(self, tmp_path):
         codex_home = tmp_path / ".codex"

--- a/tests/evaluator/test_cursor_backend.py
+++ b/tests/evaluator/test_cursor_backend.py
@@ -1,0 +1,53 @@
+"""Focused tests for the Cursor backend's network boundary."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from evaluator.backends.cursor import CursorBackend
+
+
+def test_cursor_firewall_uses_exact_default_api_host(monkeypatch):
+    monkeypatch.delenv("CURSOR_API_ENDPOINT", raising=False)
+
+    assert CursorBackend().firewall_hosts() == ["api2.cursor.sh"]
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "hostname"),
+    [
+        ("https://cursor-gateway.example.com", "cursor-gateway.example.com"),
+        ("https://CURSOR-GATEWAY.EXAMPLE.COM:443/v1", "cursor-gateway.example.com"),
+        ("https://bücher.example/v1", "xn--bcher-kva.example"),
+        ("https://cursor-gateway.example.com./v1", "cursor-gateway.example.com"),
+    ],
+)
+def test_cursor_firewall_uses_configured_https_endpoint(monkeypatch, endpoint, hostname):
+    monkeypatch.setenv("CURSOR_API_ENDPOINT", endpoint)
+
+    assert CursorBackend().firewall_hosts() == [hostname]
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "",
+        "api2.cursor.sh",
+        "http://api2.cursor.sh",
+        "https:///missing-host",
+        "https://api2.cursor.sh:8443",
+        "https://api2.cursor.sh:not-a-port",
+        "https://user@example.com",
+        "https://bad_host.example.com",
+        "https://127.0.0.1",
+        "https://[::1]",
+    ],
+)
+def test_cursor_firewall_rejects_endpoint_it_cannot_enforce(monkeypatch, endpoint):
+    monkeypatch.setenv("CURSOR_API_ENDPOINT", endpoint)
+
+    with pytest.raises(ValueError, match="CURSOR_API_ENDPOINT"):
+        CursorBackend().firewall_hosts()

--- a/tests/evaluator/test_cursor_installer.py
+++ b/tests/evaluator/test_cursor_installer.py
@@ -1,0 +1,54 @@
+"""Regression tests for the Cursor CLI install script."""
+
+import os
+import subprocess
+from pathlib import Path
+
+INSTALL_SCRIPT = Path("docker/install-scripts/install-cursor.sh").resolve()
+
+
+def _run_installer(tmp_path, curl_script):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(curl_script)
+    fake_curl.chmod(0o755)
+
+    home = tmp_path / "home"
+    home.mkdir()
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{env['PATH']}",
+        }
+    )
+    return subprocess.run(
+        ["bash", str(INSTALL_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_cursor_installer_propagates_curl_failure(tmp_path):
+    result = _run_installer(
+        tmp_path,
+        """#!/bin/bash
+exit 22
+""",
+    )
+
+    assert result.returncode == 22
+
+
+def test_cursor_installer_rejects_missing_executable(tmp_path):
+    result = _run_installer(
+        tmp_path,
+        """#!/bin/bash
+printf '#!/bin/bash\\nexit 0\\n'
+""",
+    )
+
+    assert result.returncode != 0
+    assert "Cursor installer did not create executable" in result.stderr

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -26,6 +26,7 @@ from evaluator.termination import (
     claude_code_result_error,
     codex_turn_failed,
     copilot_session_error,
+    cursor_result_error,
     is_wall_clock_timeout,
     litellm_completion_error,
     one_shot_result_error,
@@ -214,6 +215,7 @@ TRUNCATED_BY_BACKEND = {
     "codex": [{"type": "thread.started"}, {"type": "turn.started"}],
     "claude_code": [{"type": "system", "subtype": "init"}, {"type": "assistant", "message": {}}],
     "copilot": [{"type": "assistant.message", "data": {"content": "working"}}],
+    "cursor": [{"type": "system", "subtype": "init"}, {"type": "assistant", "message": {}}],
 }
 
 
@@ -246,6 +248,7 @@ def test_same_truncation_without_timeout_is_still_infra(tmp_path):
         "codex": TerminationReason.OK,
         "claude_code": TerminationReason.INFRA_ERROR,
         "copilot": TerminationReason.INFRA_ERROR,
+        "cursor": TerminationReason.INFRA_ERROR,
     }
     for backend, stream in TRUNCATED_BY_BACKEND.items():
         p = _write_jsonl(tmp_path / f"{backend}.jsonl", stream)
@@ -257,6 +260,7 @@ def test_registry_is_the_extension_point():
     assert codex_turn_failed in INFRA_RULES
     assert claude_code_result_error in INFRA_RULES
     assert copilot_session_error in INFRA_RULES
+    assert cursor_result_error in INFRA_RULES
     assert litellm_completion_error in INFRA_RULES
     assert one_shot_result_error in INFRA_RULES
     assert agent_startup_failure in INFRA_RULES
@@ -796,6 +800,98 @@ def test_cc_rule_only_applies_to_claude_code(tmp_path):
     # codex stream through the claude rule must abstain.
     p = _write_jsonl(tmp_path / "infra.jsonl", INFRA_STREAM)
     assert claude_code_result_error(_ctx(p, backend="codex")) is None
+
+
+# --- cursor rule (stream-json contract ends in one clean result) -------------
+
+CURSOR_SUCCESS = [
+    {"type": "system", "subtype": "init", "session_id": "s1"},
+    {
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": "done"}]},
+        "session_id": "s1",
+    },
+    {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "result": "done",
+        "session_id": "s1",
+    },
+]
+CURSOR_TRUNCATED = [
+    {"type": "system", "subtype": "init", "session_id": "s1"},
+    {"type": "assistant", "message": {"role": "assistant", "content": []}, "session_id": "s1"},
+]
+CURSOR_ERROR = [
+    {"type": "system", "subtype": "init", "session_id": "s1"},
+    {"type": "error", "message": "stream disconnected", "session_id": "s1"},
+]
+
+
+def test_cursor_clean_terminal_success_is_ok(tmp_path):
+    path = _write_jsonl(tmp_path / "cursor-success.jsonl", CURSOR_SUCCESS)
+    assert classify(_ctx(path, backend="cursor", agent_exit=0)) == TerminationReason.OK
+
+
+@pytest.mark.parametrize("stream", [CURSOR_TRUNCATED, CURSOR_ERROR])
+def test_cursor_nonempty_stream_without_terminal_result_is_infra(tmp_path, stream):
+    path = _write_jsonl(tmp_path / "cursor-incomplete.jsonl", stream)
+    assert classify(_ctx(path, backend="cursor", agent_exit=1)) == TerminationReason.INFRA_ERROR
+
+
+@pytest.mark.parametrize(
+    "terminal",
+    [
+        {"type": "result", "subtype": "error_during_execution", "is_error": True},
+        {"type": "result", "subtype": "success", "is_error": True},
+        {"type": "result", "subtype": "success"},
+    ],
+)
+def test_cursor_error_or_malformed_terminal_result_is_infra(tmp_path, terminal):
+    path = _write_jsonl(
+        tmp_path / "cursor-bad-result.jsonl",
+        [{"type": "system", "subtype": "init"}, terminal],
+    )
+    assert classify(_ctx(path, backend="cursor", agent_exit=1)) == TerminationReason.INFRA_ERROR
+
+
+@pytest.mark.parametrize(
+    "stream",
+    [
+        [*CURSOR_SUCCESS, {"type": "assistant", "message": {"content": []}}],
+        [*CURSOR_SUCCESS, CURSOR_SUCCESS[-1]],
+    ],
+)
+def test_cursor_result_must_be_unique_and_terminal(tmp_path, stream):
+    path = _write_jsonl(tmp_path / "cursor-malformed-terminal.jsonl", stream)
+    assert classify(_ctx(path, backend="cursor")) == TerminationReason.INFRA_ERROR
+
+
+def test_cursor_malformed_event_stream_is_infra(tmp_path):
+    path = tmp_path / "cursor-malformed-stream.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "system", "subtype": "init"}),
+                "not json",
+                json.dumps(CURSOR_SUCCESS[-1]),
+            ]
+        )
+    )
+    assert classify(_ctx(str(path), backend="cursor")) == TerminationReason.INFRA_ERROR
+
+
+@pytest.mark.parametrize("contents", ["", "not json\n"])
+def test_cursor_empty_or_wholly_malformed_stream_is_infra_even_after_zero_exit(tmp_path, contents):
+    path = tmp_path / "cursor-empty-or-malformed.jsonl"
+    path.write_text(contents)
+    assert classify(_ctx(str(path), backend="cursor", agent_exit=0)) == TerminationReason.INFRA_ERROR
+
+
+def test_cursor_rule_only_applies_to_cursor(tmp_path):
+    path = _write_jsonl(tmp_path / "cursor-truncated.jsonl", CURSOR_TRUNCATED)
+    assert cursor_result_error(_ctx(path, backend="codex")) is None
 
 
 # --- copilot rule (event vocabulary per Copilot SDK streaming-events docs) ---


### PR DESCRIPTION
Add a `cursor` backend running `cursor-agent` non-interactively (--print, stream-json, --force, --sandbox disabled). Auth uses the mounted `cursor-agent login` token (~/.config/cursor/auth.json) or CURSOR_API_KEY.

Cursor's API/agent endpoints resolve to large, rotating AWS IP pools that the pin-at-start firewall cannot track, so add an opt-in `unrestricted_https_egress` backend flag that switches the container firewall to allow all outbound HTTPS (443) while still blocking other egress. Also generalize credential mounts with a `source_dir` since Cursor's token lives outside ~/.<name>.