### PR TITLE
Use dynamic IP sets for Cursor egress

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -35,7 +35,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     curl ca-certificates git python3 python3-pip \
     libstdc++6 libgmp10 make \
     default-jdk-headless \
-    iptables iproute2 dnsutils libcap2-bin
+    iptables iproute2 dnsutils libcap2-bin \
+    dnsmasq-base ipset \
+    && groupadd --system tlaps-dnsmasq \
+    && useradd --system --gid tlaps-dnsmasq --home-dir /nonexistent \
+        --no-create-home --shell /usr/sbin/nologin tlaps-dnsmasq
 
 # Layer 2: Node.js (rarely changes)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/docker/firewall.sh
+++ b/docker/firewall.sh
@@ -10,7 +10,126 @@ if [ "${DISABLE_FIREWALL:-0}" = "1" ]; then
 fi
 
 if [ -z "${FIREWALL_HOSTS:-}" ]; then
+    if [ "${DYNAMIC_FIREWALL:-0}" = "1" ]; then
+        echo "[firewall] ERROR: dynamic firewall requires FIREWALL_HOSTS" >&2
+        exit 1
+    fi
     echo "[firewall] No FIREWALL_HOSTS set, skipping firewall"
+    exit 0
+fi
+
+if [ "${DYNAMIC_FIREWALL:-0}" = "1" ]; then
+    DNSMASQ_USER="tlaps-dnsmasq"
+    DNSMASQ_UID=$(id -u "$DNSMASQ_USER")
+    DNSMASQ_IPSET="tlaps-egress-v4"
+    RESOLV_CONF="${RESOLV_CONF:-/etc/resolv.conf}"
+
+    is_ipv4() {
+        local address="$1"
+        local octet
+        local -a octets
+        [[ "$address" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] || return 1
+        IFS='.' read -ra octets <<< "$address"
+        for octet in "${octets[@]}"; do
+            ((10#"$octet" <= 255)) || return 1
+        done
+        return 0
+    }
+
+    DOCKER_DNS_SERVERS=()
+    while read -r directive resolver _ || [ -n "${directive:-}" ]; do
+        if [ "$directive" != "nameserver" ] || ! is_ipv4 "$resolver" || [ "$resolver" = "127.0.0.1" ]; then
+            continue
+        fi
+        if [[ ! " ${DOCKER_DNS_SERVERS[*]} " =~ " ${resolver} " ]]; then
+            DOCKER_DNS_SERVERS+=("$resolver")
+        fi
+    done < "$RESOLV_CONF"
+
+    if [ "${#DOCKER_DNS_SERVERS[@]}" -eq 0 ]; then
+        echo "[firewall] ERROR: no usable IPv4 DNS resolver in $RESOLV_CONF" >&2
+        exit 1
+    fi
+
+    DNSMASQ_ARGS=(
+        --conf-file=
+        --no-resolv
+        --no-hosts
+        --bind-interfaces
+        --listen-address=127.0.0.1
+        --port=53
+        --user="$DNSMASQ_USER"
+        --group="$DNSMASQ_USER"
+        --pid-file=/run/tlaps-dnsmasq.pid
+        --stop-dns-rebind
+        --filter-AAAA
+        --address=/#/
+    )
+
+    IFS=',' read -ra HOSTS <<< "$FIREWALL_HOSTS"
+    for host in "${HOSTS[@]}"; do
+        host=$(echo "$host" | xargs)
+        host="${host,,}"
+        if [[ "$host" == \*.* ]]; then
+            host="${host#*.}"
+        fi
+        if [ "${#host}" -gt 253 ] || [[ ! "$host" =~ ^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]]; then
+            echo "[firewall] ERROR: invalid dynamic firewall hostname '$host'" >&2
+            exit 1
+        fi
+        for resolver in "${DOCKER_DNS_SERVERS[@]}"; do
+            DNSMASQ_ARGS+=("--server=/${host}/${resolver}")
+        done
+        DNSMASQ_ARGS+=("--ipset=/${host}/${DNSMASQ_IPSET}")
+    done
+
+    ipset -exist create "$DNSMASQ_IPSET" hash:ip family inet maxelem 65536
+
+    # Only the dedicated dnsmasq UID may reach the upstream resolvers.
+    # Agent DNS is restricted to the local dnsmasq listener; these DNS-specific
+    # rules precede the general loopback allow rule so upstream DNS is not exposed.
+    for resolver in "${DOCKER_DNS_SERVERS[@]}"; do
+        iptables -A OUTPUT -p udp -d "$resolver" --dport 53 \
+            -m owner --uid-owner "$DNSMASQ_UID" -j ACCEPT
+        iptables -A OUTPUT -p tcp -d "$resolver" --dport 53 \
+            -m owner --uid-owner "$DNSMASQ_UID" -j ACCEPT
+    done
+    iptables -A OUTPUT -p udp -d 127.0.0.1 --dport 53 -j ACCEPT
+    iptables -A OUTPUT -p tcp -d 127.0.0.1 --dport 53 -j ACCEPT
+    iptables -A OUTPUT -p udp --dport 53 -j DROP
+    iptables -A OUTPUT -p tcp --dport 53 -j DROP
+
+    # Never trust an ipset entry for a private, shared, link-local, benchmark,
+    # multicast, or reserved destination. These rules also protect against a
+    # resolver regression or an address inserted before rebinding checks.
+    for blocked_net in \
+        0.0.0.0/8 \
+        10.0.0.0/8 \
+        100.64.0.0/10 \
+        169.254.0.0/16 \
+        172.16.0.0/12 \
+        192.0.0.0/24 \
+        192.0.2.0/24 \
+        192.88.99.0/24 \
+        192.168.0.0/16 \
+        198.18.0.0/15 \
+        198.51.100.0/24 \
+        203.0.113.0/24 \
+        224.0.0.0/4 \
+        240.0.0.0/4
+    do
+        iptables -A OUTPUT -d "$blocked_net" -j DROP
+    done
+
+    iptables -A OUTPUT -o lo -j ACCEPT
+    iptables -A OUTPUT -m set --match-set "$DNSMASQ_IPSET" dst \
+        -p tcp --dport 443 -j ACCEPT
+    iptables -A OUTPUT -j DROP
+    ip6tables -P OUTPUT DROP
+
+    dnsmasq "${DNSMASQ_ARGS[@]}"
+    printf 'nameserver 127.0.0.1\noptions ndots:0\n' > "$RESOLV_CONF"
+    echo "[firewall] Dynamic mode active: only ${FIREWALL_HOSTS} allowed"
     exit 0
 fi
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -326,6 +326,12 @@ The first-attempt verdict stays in `check_verdict`. Continuation rounds are save
 
 Each run spins up an isolated container that installs the agent CLI, applies a network firewall (only LLM API hosts are reachable), and mounts benchmarks read-only to prevent tampering.
 
+Cursor uses a DNS-backed IP set so newly discovered or rotated Cursor endpoints
+become reachable without adding one firewall rule per resolved address. Other
+DNS names, non-HTTPS traffic, and IPv6 remain blocked. Default Cursor entries
+act as DNS suffixes and last for the container lifetime; a custom
+`CURSOR_API_ENDPOINT` keeps the existing exact-host firewall behavior.
+
 The runner fingerprints the Docker inputs and automatically rebuilds when the
 embedded source or checker changes. Use `--force-build` only when you need to
 rebuild the current fingerprint explicitly:

--- a/src/common/container.py
+++ b/src/common/container.py
@@ -125,6 +125,7 @@ class ContainerConfig:
     benchmark_dir: str = ""  # host path, mounted to /benchmark (ro) for tamper-proof baseline
     env: dict[str, str] = field(default_factory=dict)
     firewall_hosts: list[str] = field(default_factory=list)
+    dynamic_firewall: bool = False
     install_script: str | None = None  # run at container start before agent cmd
     cap_net_admin: bool = True
     memory: str = ""
@@ -259,6 +260,27 @@ def _copy_codex_bedrock_config(src: Path, dst: Path) -> bool:
 class ContainerRunner:
     """Programmatic interface to Docker for running evaluator backends in isolation."""
 
+    _DYNAMIC_FIREWALL_CAPS = (
+        "NET_ADMIN",
+        "NET_BIND_SERVICE",
+        "NET_RAW",
+        "SETPCAP",
+        "SETUID",
+        "SETGID",
+        "CHOWN",
+        "FOWNER",
+        "DAC_OVERRIDE",
+    )
+    _DYNAMIC_AGENT_DROP_CAPS = (
+        "cap_net_admin",
+        "cap_net_bind_service",
+        "cap_net_raw",
+        "cap_setpcap",
+        "cap_setuid",
+        "cap_setgid",
+        "cap_chown",
+        "cap_fowner",
+    )
     _CREDENTIAL_MOUNTS = {
         "aws": CredentialMount("/root/.aws", _copy_all_credentials),
         "claude": CredentialMount("/root/.claude", _copy_claude_credentials),
@@ -273,6 +295,9 @@ class ContainerRunner:
 
     def build_docker_args(self, config: ContainerConfig) -> tuple[list[str], str]:
         """Build the `docker run` argument list from config."""
+        if config.dynamic_firewall and not config.firewall_hosts:
+            raise ValueError("dynamic_firewall requires at least one firewall host")
+
         cid_file = f"/tmp/tlaps-bench-{uuid.uuid4().hex[:8]}.cid"
 
         args = [
@@ -299,7 +324,11 @@ class ContainerRunner:
         if config.memory:
             args.append(f"--memory={config.memory}")
 
-        if config.cap_net_admin and config.firewall_hosts:
+        if config.dynamic_firewall:
+            args.append("--cap-drop=ALL")
+            args.extend(f"--cap-add={capability}" for capability in self._DYNAMIC_FIREWALL_CAPS)
+            args.append("--security-opt=no-new-privileges:true")
+        elif config.cap_net_admin and config.firewall_hosts:
             args.append("--cap-add=NET_ADMIN")
 
         # Workspace and result mounts
@@ -349,26 +378,42 @@ class ContainerRunner:
         # Firewall config as env vars (read by firewall.sh inside container)
         if config.firewall_hosts:
             args.extend(["-e", f"FIREWALL_HOSTS={','.join(config.firewall_hosts)}"])
+            if config.dynamic_firewall:
+                args.extend(["-e", "DYNAMIC_FIREWALL=1"])
         else:
             args.extend(["-e", "DISABLE_FIREWALL=1"])
 
         args.append(config.image)
         return args, cid_file
 
-    def build_composite_command(self, cmd: list[str], install_script: str | None = None) -> str:
+    def build_composite_command(
+        self,
+        cmd: list[str],
+        install_script: str | None = None,
+        *,
+        dynamic_firewall: bool = False,
+    ) -> str:
         """Build shell command: install script → firewall → agent command."""
         agent_cmd = " ".join(shlex.quote(c) for c in cmd)
         parts = []
         if install_script:
             parts.append(f"/opt/install-scripts/{install_script} >&2")
         parts.append("/opt/firewall.sh >&2")
-        parts.append(f"exec capsh --drop=cap_net_admin -- -c {shlex.quote(agent_cmd)}")
+        if dynamic_firewall:
+            drop_caps = ",".join(self._DYNAMIC_AGENT_DROP_CAPS)
+            parts.append(f"exec capsh --drop={drop_caps} --caps=cap_dac_override+eip -- -c {shlex.quote(agent_cmd)}")
+        else:
+            parts.append(f"exec capsh --drop=cap_net_admin -- -c {shlex.quote(agent_cmd)}")
         return " && ".join(parts)
 
     def run(self, config: ContainerConfig, cmd: list[str], stdin_data: str | None = None) -> ContainerRun:
         """Launch a container with the given command. Returns handle."""
         docker_args, cid_file = self.build_docker_args(config)
-        composite = self.build_composite_command(cmd, config.install_script)
+        composite = self.build_composite_command(
+            cmd,
+            config.install_script,
+            dynamic_firewall=config.dynamic_firewall,
+        )
         full_cmd = docker_args + ["bash", "-c", composite]
 
         proc = subprocess.Popen(
@@ -394,7 +439,11 @@ class ContainerRunner:
     ) -> tuple[int, str, str]:
         """Run container to completion. Returns (exit_code, stdout, stderr)."""
         docker_args, cid_file = self.build_docker_args(config)
-        composite = self.build_composite_command(cmd, config.install_script)
+        composite = self.build_composite_command(
+            cmd,
+            config.install_script,
+            dynamic_firewall=config.dynamic_firewall,
+        )
         full_cmd = docker_args + ["bash", "-c", composite]
 
         try:
@@ -427,7 +476,11 @@ class ContainerRunner:
         so could not have caught an auth-host block.)
         """
         docker_args, cid_file = self.build_docker_args(config)
-        composite = self.build_composite_command(cmd, config.install_script)
+        composite = self.build_composite_command(
+            cmd,
+            config.install_script,
+            dynamic_firewall=config.dynamic_firewall,
+        )
         full_cmd = docker_args + ["bash", "-c", composite]
         try:
             result = subprocess.run(full_cmd, input=stdin_data, capture_output=True, text=True, timeout=timeout)

--- a/src/evaluator/backends/base.py
+++ b/src/evaluator/backends/base.py
@@ -185,6 +185,7 @@ class Backend(ABC):
     approach: str = "agentic"
     provider: str | None = None
     install_script: str | None = None  # run at container start (e.g. "install-codex.sh")
+    dynamic_firewall: bool = False  # resolve allowed DNS suffixes throughout the run
     env_keys: list[str] = []  # host env vars to forward into container
     credential_mounts: list[str] = []  # host credential dirs to copy into agent containers
     # Container path holding this backend's session state; --session-dir mounts
@@ -377,7 +378,11 @@ class Backend(ABC):
         return None
 
     def firewall_hosts(self) -> list[str]:
-        """API hosts that must be reachable."""
+        """API hosts that must be reachable.
+
+        When ``dynamic_firewall`` is enabled, each entry also covers its
+        subdomains so newly discovered service endpoints can be admitted.
+        """
         return []
 
     def detect_quota_block(self, jsonl_path: str) -> int | None:

--- a/src/evaluator/backends/cursor.py
+++ b/src/evaluator/backends/cursor.py
@@ -12,7 +12,15 @@ from urllib.parse import urlparse
 from .agentic import AgenticBackend
 
 DEFAULT_MODEL = "sonnet-4.5"
-DEFAULT_API_ENDPOINT = "https://api2.cursor.sh"
+DEFAULT_RUNTIME_HOSTS = [
+    "api2.cursor.sh",
+    "api2direct.cursor.sh",
+    "api5.cursor.sh",
+    "authenticate.cursor.sh",
+    "authenticator.cursor.sh",
+    "authentication.cursor.sh",
+    "repo42.cursor.sh",
+]
 _DNS_LABEL = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
 
 
@@ -76,14 +84,23 @@ class CursorBackend(AgenticBackend):
             pass
         return "cursor: no auth detected. Set CURSOR_API_KEY or run `cursor-agent login`."
 
-    def firewall_hosts(self) -> list[str]:
-        """Allow only the configured Cursor API endpoint.
+    @property
+    def dynamic_firewall(self) -> bool:
+        """Use dynamic DNS only for Cursor's public service endpoints."""
+        return "CURSOR_API_ENDPOINT" not in os.environ
 
-        The container firewall supports HTTPS on port 443 only, so reject
-        endpoint values that it cannot enforce instead of silently widening
-        egress or letting the run fail later inside Cursor.
+    def firewall_hosts(self) -> list[str]:
+        """Return the Cursor hosts that must be reachable during a run.
+
+        Default Cursor domains use dynamic DNS suffix matching. A custom
+        endpoint keeps the legacy exact-host firewall behavior so private
+        enterprise gateways remain supported.
         """
-        endpoint = os.environ.get("CURSOR_API_ENDPOINT", DEFAULT_API_ENDPOINT).strip()
+        configured_endpoint = os.environ.get("CURSOR_API_ENDPOINT")
+        if configured_endpoint is None:
+            return list(DEFAULT_RUNTIME_HOSTS)
+
+        endpoint = configured_endpoint.strip()
         try:
             parsed = urlparse(endpoint)
             port = parsed.port

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -1069,6 +1069,7 @@ def _run_backend_container(
         benchmark_dir=canonical_dir or "",
         env=backend_env,
         firewall_hosts=backend.firewall_hosts(),
+        dynamic_firewall=backend.dynamic_firewall,
         install_script=backend.install_script,
         credential_mounts=backend.get_credential_mounts(),
         keep_container=item.keep_container,
@@ -1476,6 +1477,7 @@ def _run_preflight(backend, container_image: str) -> None:
             result_dir=result_dir,
             env=forward_env(backend.env_keys, model=getattr(backend, "model", None)),
             firewall_hosts=backend.firewall_hosts(),
+            dynamic_firewall=backend.dynamic_firewall,
             install_script=backend.install_script,
             credential_mounts=backend.get_credential_mounts(),
         )

--- a/tests/common/test_dynamic_firewall.py
+++ b/tests/common/test_dynamic_firewall.py
@@ -1,0 +1,179 @@
+"""Focused tests for the dnsmasq/ipset firewall mode."""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "docker" / "base.Dockerfile"
+FIREWALL_SH = REPO_ROOT / "docker" / "firewall.sh"
+
+
+def _stub(bindir, name, body):
+    path = bindir / name
+    path.write_text(f"#!/bin/bash\nset -e\n{body}\n")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def _run_dynamic_firewall(
+    tmp_path,
+    hosts="api2.cursor.sh, *.api5.cursor.sh",
+    resolvers="nameserver 127.0.0.11\noptions ndots:0\n",
+):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    logs = {}
+    for tool in ("iptables", "ip6tables", "ipset", "dnsmasq"):
+        log = tmp_path / f"{tool}.log"
+        log.write_text("")
+        logs[tool] = log
+        _stub(bindir, tool, f'printf "%s\\n" "$*" >> "{log}"')
+    _stub(
+        bindir,
+        "id",
+        'if [ "$1" = "-u" ] && [ "$2" = "tlaps-dnsmasq" ]; then echo 4242; else exec /usr/bin/id "$@"; fi',
+    )
+
+    resolv_conf = tmp_path / "resolv.conf"
+    resolv_conf.write_text(resolvers)
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "DYNAMIC_FIREWALL": "1",
+        "FIREWALL_HOSTS": hosts,
+        "RESOLV_CONF": str(resolv_conf),
+    }
+    result = subprocess.run(
+        ["bash", str(FIREWALL_SH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    calls = {tool: path.read_text().splitlines() for tool, path in logs.items()}
+    return result, calls, resolv_conf.read_text()
+
+
+def test_image_installs_dynamic_firewall_tools_and_dedicated_user():
+    contents = DOCKERFILE.read_text()
+
+    assert "dnsmasq-base ipset" in contents
+    assert "groupadd --system tlaps-dnsmasq" in contents
+    assert "--gid tlaps-dnsmasq" in contents
+    assert "--shell /usr/sbin/nologin tlaps-dnsmasq" in contents
+
+
+def test_dynamic_mode_configures_allowlisted_dns_and_ipset(tmp_path):
+    result, calls, resolv_conf = _run_dynamic_firewall(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert calls["ipset"] == ["-exist create tlaps-egress-v4 hash:ip family inet maxelem 65536"]
+    dnsmasq = calls["dnsmasq"][0]
+    for required in (
+        "--conf-file=",
+        "--no-resolv",
+        "--no-hosts",
+        "--bind-interfaces",
+        "--listen-address=127.0.0.1",
+        "--user=tlaps-dnsmasq",
+        "--group=tlaps-dnsmasq",
+        "--stop-dns-rebind",
+        "--filter-AAAA",
+        "--address=/#/",
+        "--server=/api2.cursor.sh/127.0.0.11",
+        "--ipset=/api2.cursor.sh/tlaps-egress-v4",
+        "--server=/api5.cursor.sh/127.0.0.11",
+        "--ipset=/api5.cursor.sh/tlaps-egress-v4",
+    ):
+        assert required in dnsmasq
+    assert resolv_conf == "nameserver 127.0.0.1\noptions ndots:0\n"
+
+
+def test_dynamic_mode_uses_all_ipv4_resolvers(tmp_path):
+    result, calls, _ = _run_dynamic_firewall(
+        tmp_path,
+        hosts="api2.cursor.sh",
+        resolvers=(
+            "nameserver 2001:db8::53\n"
+            "nameserver 999.0.0.1\n"
+            "nameserver 127.0.0.11\n"
+            "nameserver 127.0.0.11\n"
+            "nameserver 10.0.0.53"
+        ),
+    )
+
+    assert result.returncode == 0, result.stderr
+    dnsmasq = calls["dnsmasq"][0]
+    assert dnsmasq.count("--server=/api2.cursor.sh/127.0.0.11") == 1
+    assert dnsmasq.count("--server=/api2.cursor.sh/10.0.0.53") == 1
+    assert "2001:db8::53" not in dnsmasq
+    assert "999.0.0.1" not in dnsmasq
+    for resolver in ("127.0.0.11", "10.0.0.53"):
+        udp_rule = f"-A OUTPUT -p udp -d {resolver} --dport 53 -m owner --uid-owner 4242 -j ACCEPT"
+        tcp_rule = f"-A OUTPUT -p tcp -d {resolver} --dport 53 -m owner --uid-owner 4242 -j ACCEPT"
+        assert calls["iptables"].count(udp_rule) == 1
+        assert calls["iptables"].count(tcp_rule) == 1
+
+
+def test_dynamic_mode_seals_direct_dns_and_blocks_private_before_ipset(tmp_path):
+    result, calls, _ = _run_dynamic_firewall(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    rules = calls["iptables"]
+    udp_upstream = "-A OUTPUT -p udp -d 127.0.0.11 --dport 53 -m owner --uid-owner 4242 -j ACCEPT"
+    tcp_upstream = "-A OUTPUT -p tcp -d 127.0.0.11 --dport 53 -m owner --uid-owner 4242 -j ACCEPT"
+    assert udp_upstream in rules
+    assert tcp_upstream in rules
+    assert "-A OUTPUT -p udp -d 127.0.0.1 --dport 53 -j ACCEPT" in rules
+    assert "-A OUTPUT -p tcp -d 127.0.0.1 --dport 53 -j ACCEPT" in rules
+
+    udp_dns_drop = rules.index("-A OUTPUT -p udp --dport 53 -j DROP")
+    tcp_dns_drop = rules.index("-A OUTPUT -p tcp --dport 53 -j DROP")
+    loopback_allow = rules.index("-A OUTPUT -o lo -j ACCEPT")
+    assert rules.index(udp_upstream) < udp_dns_drop < loopback_allow
+    assert rules.index(tcp_upstream) < tcp_dns_drop < loopback_allow
+
+    ipset_allow = rules.index("-A OUTPUT -m set --match-set tlaps-egress-v4 dst -p tcp --dport 443 -j ACCEPT")
+    for network in (
+        "10.0.0.0/8",
+        "100.64.0.0/10",
+        "169.254.0.0/16",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+    ):
+        assert rules.index(f"-A OUTPUT -d {network} -j DROP") < ipset_allow
+    assert rules[-1] == "-A OUTPUT -j DROP"
+    assert calls["ip6tables"] == ["-P OUTPUT DROP"]
+
+
+def test_dynamic_mode_rejects_malformed_allowlist_entries(tmp_path):
+    result, calls, resolv_conf = _run_dynamic_firewall(
+        tmp_path,
+        hosts="api2.cursor.sh/../../etc/passwd",
+    )
+
+    assert result.returncode == 1
+    assert "invalid dynamic firewall hostname" in result.stderr
+    assert calls["dnsmasq"] == []
+    assert resolv_conf == "nameserver 127.0.0.11\noptions ndots:0\n"
+
+
+def test_dynamic_mode_fails_closed_without_allowlist(tmp_path):
+    result, calls, _ = _run_dynamic_firewall(tmp_path, hosts="")
+
+    assert result.returncode == 1
+    assert "requires FIREWALL_HOSTS" in result.stderr
+    assert calls["dnsmasq"] == []
+
+
+def test_dynamic_mode_fails_closed_without_ipv4_resolver(tmp_path):
+    result, calls, resolv_conf = _run_dynamic_firewall(
+        tmp_path,
+        resolvers="nameserver 2001:db8::53\n",
+    )
+
+    assert result.returncode == 1
+    assert "no usable IPv4 DNS resolver" in result.stderr
+    assert calls["dnsmasq"] == []
+    assert resolv_conf == "nameserver 2001:db8::53\n"

--- a/tests/evaluator/test_container.py
+++ b/tests/evaluator/test_container.py
@@ -135,9 +135,46 @@ class TestBuildDockerArgs:
         args, _ = runner.build_docker_args(config)
 
         assert "--cap-add=NET_ADMIN" in args
+        assert "--cap-drop=ALL" not in args
+        assert "--security-opt=no-new-privileges:true" not in args
         env_args = [args[i + 1] for i, a in enumerate(args) if a == "-e"]
         assert "FIREWALL_HOSTS=api.openai.com,api.anthropic.com" in env_args
+        assert "DYNAMIC_FIREWALL=1" not in env_args
         assert not any("ALLOW_ALL_HTTPS" in value for value in env_args)
+
+    def test_dynamic_firewall_uses_only_initialization_capabilities(self):
+        runner = ContainerRunner()
+        config = ContainerConfig(
+            firewall_hosts=["api2.cursor.sh"],
+            dynamic_firewall=True,
+            cap_net_admin=False,
+        )
+        args, _ = runner.build_docker_args(config)
+
+        cap_adds = {argument.removeprefix("--cap-add=") for argument in args if argument.startswith("--cap-add=")}
+        assert cap_adds == {
+            "NET_ADMIN",
+            "NET_BIND_SERVICE",
+            "NET_RAW",
+            "SETPCAP",
+            "SETUID",
+            "SETGID",
+            "CHOWN",
+            "FOWNER",
+            "DAC_OVERRIDE",
+        }
+        assert "--cap-drop=ALL" in args
+        assert "--security-opt=no-new-privileges:true" in args
+        env_args = [args[i + 1] for i, argument in enumerate(args) if argument == "-e"]
+        assert "FIREWALL_HOSTS=api2.cursor.sh" in env_args
+        assert "DYNAMIC_FIREWALL=1" in env_args
+
+    def test_dynamic_firewall_requires_hosts(self):
+        runner = ContainerRunner()
+        config = ContainerConfig(dynamic_firewall=True)
+
+        with pytest.raises(ValueError, match="requires at least one firewall host"):
+            runner.build_docker_args(config)
 
     def test_no_firewall_when_empty(self):
         runner = ContainerRunner()
@@ -342,6 +379,23 @@ class TestBuildCompositeCommand:
         assert "/opt/firewall.sh" in result
         assert "capsh --drop=cap_net_admin" in result
         assert "codex exec --model gpt-5.5" in result
+
+    def test_dynamic_firewall_drops_initialization_caps_but_keeps_dac_override(self):
+        runner = ContainerRunner()
+        result = runner.build_composite_command(
+            ["cursor-agent", "--print"],
+            dynamic_firewall=True,
+        )
+
+        assert "/opt/firewall.sh" in result
+        assert (
+            "--drop=cap_net_admin,cap_net_bind_service,cap_net_raw,cap_setpcap,"
+            "cap_setuid,cap_setgid,cap_chown,cap_fowner"
+        ) in result
+        assert "--caps=cap_dac_override+eip" in result
+        drop_arg = result.split("--drop=", 1)[1].split(" ", 1)[0]
+        assert "cap_dac_override" not in drop_arg
+        assert result.endswith("-c 'cursor-agent --print'")
 
     def test_command_quoting(self):
         runner = ContainerRunner()

--- a/tests/evaluator/test_cursor_backend.py
+++ b/tests/evaluator/test_cursor_backend.py
@@ -10,10 +10,20 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 from evaluator.backends.cursor import CursorBackend
 
 
-def test_cursor_firewall_uses_exact_default_api_host(monkeypatch):
+def test_cursor_uses_dynamic_firewall_with_default_runtime_hosts(monkeypatch):
     monkeypatch.delenv("CURSOR_API_ENDPOINT", raising=False)
+    backend = CursorBackend()
 
-    assert CursorBackend().firewall_hosts() == ["api2.cursor.sh"]
+    assert backend.dynamic_firewall is True
+    assert backend.firewall_hosts() == [
+        "api2.cursor.sh",
+        "api2direct.cursor.sh",
+        "api5.cursor.sh",
+        "authenticate.cursor.sh",
+        "authenticator.cursor.sh",
+        "authentication.cursor.sh",
+        "repo42.cursor.sh",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -27,8 +37,10 @@ def test_cursor_firewall_uses_exact_default_api_host(monkeypatch):
 )
 def test_cursor_firewall_uses_configured_https_endpoint(monkeypatch, endpoint, hostname):
     monkeypatch.setenv("CURSOR_API_ENDPOINT", endpoint)
+    backend = CursorBackend()
 
-    assert CursorBackend().firewall_hosts() == [hostname]
+    assert backend.dynamic_firewall is False
+    assert backend.firewall_hosts() == [hostname]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- populate a per-container IP set from allowed Cursor DNS suffixes with dnsmasq
- allow HTTPS only to addresses in that set while blocking other DNS and IPv6
- include Cursor's default indexing endpoint and preserve all valid IPv4 DNS resolvers
- keep custom `CURSOR_API_ENDPOINT` values on the existing exact/static firewall path

This follows up on #77 and keeps its IP-level firewall model while supporting Cursor's rotating endpoints without one iptables rule per address.
