### PR TITLE
Refresh GermanProtocol benchmarks from upstream

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -31,10 +31,11 @@ tlaplus/Examples  —  MIT, except where noted below  —  https://github.com/tl
       - tlaplus_examples_BlockingQueue — MIT: from
         https://github.com/lemmy/BlockingQueue; Copyright (c) 2020
         Markus A. Kuppe.
-      - tlaplus_examples_GermanProtocol — MIT: the benchmark model corresponds
-        to GermanCoherence.tla at commit aba0cef20ce694f97612ad36a873734a1314534a:
-        https://github.com/tlaplus/Examples/blob/aba0cef20ce694f97612ad36a873734a1314534a/specifications/GermanProtocol/GermanCoherence.tla
-        It is adapted from the German cache-coherence protocol Murphi models in
+      - tlaplus_examples_GermanProtocol — MIT: the benchmark models correspond
+        to GermanControl.tla and GermanData.tla at commit
+        91c22ea537853196ed1e03e9ad91693ec37642de:
+        https://github.com/tlaplus/Examples/tree/91c22ea537853196ed1e03e9ad91693ec37642de/specifications/GermanProtocol
+        They are adapted from the German cache-coherence protocol Murphi models in
         https://github.com/dsethi/ProtocolDeadlockFiles, published as
         supplementary material for Divjyot Sethi, Muralidhar Talupur, and
         Sharad Malik, "Using Flow Specifications of Parameterized Cache

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ can be derived.
 
 | Source | Examples | Proof completion | Proof from scratch | Total |
 |---|--:|--:|--:|--:|
-| [tlaplus/Examples](https://github.com/tlaplus/Examples) | 45 | 369 | 126 | 495 |
+| [tlaplus/Examples](https://github.com/tlaplus/Examples) | 45 | 369 | 132 | 501 |
 | [TLAPS distribution examples](https://github.com/tlaplus/tlapm) | 14 | 103 | 57 | 160 |
-| **Subtotal** | **59** | **472** | **183** | **655** |
+| **Subtotal** | **59** | **472** | **189** | **661** |
 
 **Systems specifications**
 
@@ -52,7 +52,7 @@ can be derived.
 | [two_thread_mutex (Anvil)](https://github.com/anvil-verifier/anvil/blob/main/src/tla_demo.rs) | 1 | – | 1 | 1 |
 | **Subtotal** | **11** | **1** | **44** | **45** |
 
-**70 examples, 700 tasks in total.** A per-example breakdown is in
+**70 examples, 706 tasks in total.** A per-example breakdown is in
 [`docs/DATASET.md`](docs/DATASET.md).
 
 ## Running

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanCoherence_Coherence.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanCoherence_Coherence.tla
@@ -1,6 +1,0 @@
----------------------- MODULE GermanCoherence_Coherence ----------------------
-EXTENDS GermanCoherence
-
-THEOREM Coherent == Spec => []Coherence
-PROOF OBVIOUS
-=============================================================================

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanControl.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanControl.tla
@@ -1,0 +1,128 @@
+----------------------------- MODULE GermanControl -----------------------------
+CONSTANTS
+    NODE,
+    NoNode
+
+ASSUME NoNodeNotInNODE == NoNode \notin NODE
+
+CacheState == {"I", "S", "E"}
+
+VARIABLES
+    cache,
+    chan1,
+    chan2,
+    chan3,
+    invSet,
+    shrSet,
+    exGntd,
+    curCmd,
+    curPtr
+
+vars == <<cache, chan1, chan2, chan3, invSet, shrSet, exGntd, curCmd, curPtr>>
+
+-------------------------------------------------------------------------------
+
+TypeOK ==
+    /\ cache  \in [NODE -> CacheState]
+    /\ chan1  \in [NODE -> {"Empty", "ReqS", "ReqE"}]
+    /\ chan2  \in [NODE -> {"Empty", "Inv", "GntS", "GntE"}]
+    /\ chan3  \in [NODE -> {"Empty", "InvAck"}]
+    /\ invSet \subseteq NODE
+    /\ shrSet \subseteq NODE
+    /\ exGntd \in BOOLEAN
+    /\ curCmd \in {"Empty", "ReqS", "ReqE"}
+    /\ curPtr \in NODE \cup {NoNode}
+
+Init ==
+    /\ cache  = [i \in NODE |-> "I"]
+    /\ chan1  = [i \in NODE |-> "Empty"]
+    /\ chan2  = [i \in NODE |-> "Empty"]
+    /\ chan3  = [i \in NODE |-> "Empty"]
+    /\ invSet = {}
+    /\ shrSet = {}
+    /\ exGntd = FALSE
+    /\ curCmd = "Empty"
+    /\ curPtr = NoNode
+
+-------------------------------------------------------------------------------
+
+SendReq(i) ==
+    /\ chan1[i] = "Empty"
+    /\ \E c \in {"ReqS", "ReqE"} :
+         /\ cache[i] \in (IF c = "ReqS" THEN {"I"} ELSE {"I", "S"})
+         /\ chan1' = [chan1 EXCEPT ![i] = c]
+    /\ UNCHANGED <<cache, chan2, chan3, invSet, shrSet, exGntd, curCmd, curPtr>>
+
+RecvReq(i) ==
+    /\ curCmd = "Empty"
+    /\ chan1[i] \in {"ReqS", "ReqE"}
+    /\ curCmd' = chan1[i]
+    /\ curPtr' = i
+    /\ chan1' = [chan1 EXCEPT ![i] = "Empty"]
+    /\ invSet' = shrSet
+    /\ UNCHANGED <<cache, chan2, chan3, shrSet, exGntd>>
+
+SendInv(i) ==
+    /\ chan2[i] = "Empty"
+    /\ i \in invSet
+    /\ (curCmd = "ReqE" \/ (curCmd = "ReqS" /\ exGntd = TRUE))
+    /\ chan2' = [chan2 EXCEPT ![i] = "Inv"]
+    /\ invSet' = invSet \ {i}
+    /\ UNCHANGED <<cache, chan1, chan3, shrSet, exGntd, curCmd, curPtr>>
+
+SendInvAck(i) ==
+    /\ chan2[i] = "Inv"
+    /\ chan3[i] = "Empty"
+    /\ chan2' = [chan2 EXCEPT ![i] = "Empty"]
+    /\ chan3' = [chan3 EXCEPT ![i] = "InvAck"]
+    /\ cache' = [cache EXCEPT ![i] = "I"]
+    /\ UNCHANGED <<chan1, invSet, shrSet, exGntd, curCmd, curPtr>>
+
+RecvInvAck(i) ==
+    /\ chan3[i] = "InvAck"
+    /\ curCmd # "Empty"
+    /\ chan3' = [chan3 EXCEPT ![i] = "Empty"]
+    /\ shrSet' = shrSet \ {i}
+    /\ exGntd' = IF exGntd = TRUE THEN FALSE ELSE exGntd
+    /\ UNCHANGED <<cache, chan1, chan2, invSet, curCmd, curPtr>>
+
+SendGnt(i) ==
+    /\ curCmd \in {"ReqS", "ReqE"}
+    /\ curPtr = i
+    /\ chan2[i] = "Empty"
+    /\ exGntd = FALSE
+    /\ curCmd = "ReqE" => shrSet = {}
+    /\ chan2' = [chan2 EXCEPT ![i] = IF curCmd = "ReqS" THEN "GntS" ELSE "GntE"]
+    /\ shrSet' = shrSet \cup {i}
+    /\ exGntd' = (curCmd = "ReqE")
+    /\ curCmd' = "Empty"
+    /\ curPtr' = NoNode
+    /\ UNCHANGED <<cache, chan1, chan3, invSet>>
+
+RecvGnt(i) ==
+    /\ chan2[i] \in {"GntS", "GntE"}
+    /\ cache' = [cache EXCEPT ![i] = IF chan2[i] = "GntS" THEN "S" ELSE "E"]
+    /\ chan2' = [chan2 EXCEPT ![i] = "Empty"]
+    /\ UNCHANGED <<chan1, chan3, invSet, shrSet, exGntd, curCmd, curPtr>>
+
+-------------------------------------------------------------------------------
+
+Next ==
+    \E i \in NODE :
+        \/ SendReq(i)
+        \/ RecvReq(i)
+        \/ SendInv(i)     \/ SendInvAck(i)   \/ RecvInvAck(i)
+        \/ SendGnt(i)
+        \/ RecvGnt(i)
+
+Spec == Init /\ [][Next]_vars
+
+-------------------------------------------------------------------------------
+
+Coherence ==
+    \A i, j \in NODE :
+        i # j =>
+            /\ (cache[i] = "E" => cache[j] = "I")
+            /\ (cache[i] = "S" => cache[j] \in {"I", "S"})
+
+=============================================================================

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanControlBenchmarks_Coherence.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanControlBenchmarks_Coherence.tla
@@ -1,0 +1,7 @@
+----------------------- MODULE GermanControlBenchmarks_Coherence ------------------------
+EXTENDS GermanControl
+
+THEOREM Spec => []Coherence
+PROOF OBVIOUS
+
+=============================================================================

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData.tla
@@ -1,0 +1,134 @@
+------------------------------ MODULE GermanData ------------------------------
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    NODE,
+    DATA,
+    NoData,
+    NoNode
+
+ASSUME NoDataNotInDATA == NoData \notin DATA
+ASSUME NoNodeNotInNODE == NoNode \notin NODE
+
+VARIABLES
+    cache,
+    chan1,
+    chan2,
+    chan3,
+    invSet,
+    shrSet,
+    exGntd,
+    curCmd,
+    curPtr,
+    memData,
+    auxData
+
+vars == <<cache, chan1, chan2, chan3, invSet, shrSet,
+          exGntd, curCmd, curPtr, memData, auxData>>
+
+Init ==
+    \E d \in DATA :
+        /\ cache  = [i \in NODE |-> [state |-> "I", data |-> NoData]]
+        /\ chan1  = [i \in NODE |-> [cmd |-> "Empty", data |-> NoData]]
+        /\ chan2  = [i \in NODE |-> [cmd |-> "Empty", data |-> NoData]]
+        /\ chan3  = [i \in NODE |-> [cmd |-> "Empty", data |-> NoData]]
+        /\ invSet = {}
+        /\ shrSet = {}
+        /\ exGntd = FALSE
+        /\ curCmd = "Empty"
+        /\ curPtr = NoNode
+        /\ memData = d
+        /\ auxData = d
+
+Store(i, d) ==
+    /\ cache[i].state = "E"
+    /\ cache' = [cache EXCEPT ![i].data = d]
+    /\ auxData' = d
+    /\ UNCHANGED <<chan1, chan2, chan3, invSet, shrSet,
+                   exGntd, curCmd, curPtr, memData>>
+
+SendReq(i) ==
+    /\ chan1[i].cmd = "Empty"
+    /\ \E c \in {"ReqS", "ReqE"} :
+         /\ cache[i].state \in (IF c = "ReqS" THEN {"I"} ELSE {"I", "S"})
+         /\ chan1' = [chan1 EXCEPT ![i].cmd = c]
+    /\ UNCHANGED <<cache, chan2, chan3, invSet, shrSet,
+                   exGntd, curCmd, curPtr, memData, auxData>>
+
+RecvGnt(i) ==
+    /\ chan2[i].cmd \in {"GntS", "GntE"}
+    /\ cache' = [cache EXCEPT ![i].state = IF chan2[i].cmd = "GntS" THEN "S" ELSE "E",
+                              ![i].data  = chan2[i].data]
+    /\ chan2' = [chan2 EXCEPT ![i].cmd = "Empty", ![i].data = NoData]
+    /\ UNCHANGED <<chan1, chan3, invSet, shrSet,
+                   exGntd, curCmd, curPtr, memData, auxData>>
+
+SendInvAck(i) ==
+    /\ chan2[i].cmd = "Inv"
+    /\ chan3[i].cmd = "Empty"
+    /\ chan2' = [chan2 EXCEPT ![i].cmd = "Empty", ![i].data = NoData]
+    /\ chan3' = [chan3 EXCEPT ![i].cmd = "InvAck",
+                              ![i].data = IF cache[i].state = "E"
+                                          THEN cache[i].data
+                                          ELSE NoData]
+    /\ cache' = [cache EXCEPT ![i].state = "I", ![i].data = NoData]
+    /\ UNCHANGED <<chan1, invSet, shrSet,
+                   exGntd, curCmd, curPtr, memData, auxData>>
+
+RecvReq(i) ==
+    /\ curCmd = "Empty"
+    /\ chan1[i].cmd \in {"ReqS", "ReqE"}
+    /\ curCmd' = chan1[i].cmd
+    /\ curPtr' = i
+    /\ chan1' = [chan1 EXCEPT ![i].cmd = "Empty"]
+    /\ invSet' = shrSet
+    /\ UNCHANGED <<cache, chan2, chan3, shrSet,
+                   exGntd, memData, auxData>>
+
+SendInv(i) ==
+    /\ chan2[i].cmd = "Empty"
+    /\ i \in invSet
+    /\ (curCmd = "ReqE" \/ (curCmd = "ReqS" /\ exGntd = TRUE))
+    /\ chan2' = [chan2 EXCEPT ![i].cmd = "Inv"]
+    /\ invSet' = invSet \ {i}
+    /\ UNCHANGED <<cache, chan1, chan3, shrSet,
+                   exGntd, curCmd, curPtr, memData, auxData>>
+
+RecvInvAck(i) ==
+    /\ chan3[i].cmd = "InvAck"
+    /\ curCmd # "Empty"
+    /\ shrSet' = shrSet \ {i}
+    /\ IF exGntd = TRUE
+         THEN /\ exGntd'  = FALSE
+              /\ memData' = chan3[i].data
+              /\ chan3'   = [chan3 EXCEPT ![i].cmd = "Empty", ![i].data = NoData]
+         ELSE /\ chan3'   = [chan3 EXCEPT ![i].cmd = "Empty"]
+              /\ UNCHANGED <<exGntd, memData>>
+    /\ UNCHANGED <<cache, chan1, chan2, invSet, curCmd, curPtr, auxData>>
+
+SendGnt(i) ==
+    /\ curCmd \in {"ReqS", "ReqE"}
+    /\ curPtr = i
+    /\ chan2[i].cmd = "Empty"
+    /\ exGntd = FALSE
+    /\ curCmd = "ReqE" => shrSet = {}
+    /\ chan2' = [chan2 EXCEPT ![i].cmd  = IF curCmd = "ReqS" THEN "GntS" ELSE "GntE",
+                              ![i].data = memData]
+    /\ shrSet' = shrSet \cup {i}
+    /\ exGntd' = (curCmd = "ReqE")
+    /\ curCmd' = "Empty"
+    /\ curPtr' = NoNode
+    /\ UNCHANGED <<cache, chan1, chan3, invSet, memData, auxData>>
+
+Next ==
+    \/ \E i \in NODE, d \in DATA : Store(i, d)
+    \/ \E i \in NODE :
+         \/ SendReq(i)
+         \/ RecvReq(i)
+         \/ SendInv(i)     \/ SendInvAck(i)   \/ RecvInvAck(i)
+         \/ SendGnt(i)
+         \/ RecvGnt(i)
+
+Spec == Init /\ [][Next]_vars
+
+=============================================================================

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_DataProp.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_DataProp.tla
@@ -1,0 +1,11 @@
+------------------------------ MODULE GermanData_DataProp ------------------------------
+EXTENDS GermanData
+
+DataProp ==
+    /\ (exGntd = FALSE => memData = auxData)
+    /\ \A i \in NODE : cache[i].state # "I" => cache[i].data = auxData
+
+THEOREM Spec => []DataProp
+PROOF OBVIOUS
+
+=============================================================================

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_DirectoryAccurate.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_DirectoryAccurate.tla
@@ -1,0 +1,10 @@
+------------------------------ MODULE GermanData_DirectoryAccurate ------------------------------
+EXTENDS GermanData
+
+DirectoryAccurate ==
+    \A i \in NODE : cache[i].state \in {"S", "E"} => i \in shrSet
+
+THEOREM Spec => []DirectoryAccurate
+PROOF OBVIOUS
+
+=============================================================================

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_ExclusiveIsolation.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_ExclusiveIsolation.tla
@@ -1,0 +1,16 @@
+------------------------------ MODULE GermanData_ExclusiveIsolation ------------------------------
+EXTENDS GermanData
+
+ExclusiveIsolation ==
+    \A i \in NODE :
+        cache[i].state = "E" =>
+            /\ exGntd = TRUE
+            /\ \A j \in NODE \ {i} :
+                /\ cache[j].state = "I"
+                /\ chan2[j].cmd \notin {"GntS", "GntE"}
+                /\ chan3[j].cmd # "InvAck"
+
+THEOREM Spec => []ExclusiveIsolation
+PROOF OBVIOUS
+
+=============================================================================

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_Refinement.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_Refinement.tla
@@ -1,0 +1,15 @@
+------------------------------ MODULE GermanData_Refinement ------------------------------
+EXTENDS GermanData
+
+Abstract == INSTANCE GermanControl WITH
+    cache <- [i \in NODE |-> cache[i].state],
+    chan1 <- [i \in NODE |-> chan1[i].cmd],
+    chan2 <- [i \in NODE |-> chan2[i].cmd],
+    chan3 <- [i \in NODE |-> chan3[i].cmd]
+
+Refinement == Abstract!Spec
+
+THEOREM Spec => Refinement
+PROOF OBVIOUS
+
+=============================================================================

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_TransactionConsistency.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_TransactionConsistency.tla
@@ -1,0 +1,10 @@
+------------------------------ MODULE GermanData_TransactionConsistency ------------------------------
+EXTENDS GermanData
+
+TransactionConsistency ==
+    (curCmd = "Empty") <=> (curPtr = NoNode)
+
+THEOREM Spec => []TransactionConsistency
+PROOF OBVIOUS
+
+=============================================================================

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_WritebackCarriesLatest.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_WritebackCarriesLatest.tla
@@ -1,0 +1,16 @@
+------------------------------ MODULE GermanData_WritebackCarriesLatest ------------------------------
+EXTENDS GermanData
+
+WritebackCarriesLatest ==
+    \A i \in NODE :
+        (chan3[i].cmd = "InvAck" /\ curCmd # "Empty" /\ exGntd = TRUE) =>
+            /\ chan3[i].data = auxData
+            /\ \A j \in NODE \ {i} :
+                /\ cache[j].state # "E"
+                /\ chan2[j].cmd # "GntE"
+                /\ chan3[j].cmd # "InvAck"
+
+THEOREM Spec => []WritebackCarriesLatest
+PROOF OBVIOUS
+
+=============================================================================

--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -65,6 +65,7 @@ This file is generated; regenerate it with `python3 scripts/dataset_table.py`.
 | [Majority](https://github.com/tlaplus/Examples/tree/master/specifications/Majority) | tlaplus/Examples | 9 | – | 9 |
 | [ewd687a](https://github.com/tlaplus/Examples/tree/91c22ea537853196ed1e03e9ad91693ec37642de/specifications/ewd687a) | tlaplus/Examples | 6 | 3 | 9 |
 | [glowingRaccoon](https://github.com/tlaplus/Examples/tree/master/specifications/glowingRaccoon) | tlaplus/Examples | 6 | 3 | 9 |
+| [GermanProtocol](https://github.com/tlaplus/Examples/tree/91c22ea537853196ed1e03e9ad91693ec37642de/specifications/GermanProtocol) | tlaplus/Examples | – | 7 | 7 |
 | [Paxos](https://github.com/tlaplus/Examples/tree/master/specifications/Paxos) | tlaplus/Examples | 3 | 4 | 7 |
 | [Bakery-Boulangerie](https://github.com/tlaplus/Examples/tree/master/specifications/Bakery-Boulangerie) | tlaplus/Examples | 2 | 4 | 6 |
 | [ReadersWriters](https://github.com/tlaplus/Examples/tree/master/specifications/ReadersWriters) | tlaplus/Examples | 3 | 2 | 5 |
@@ -85,8 +86,7 @@ This file is generated; regenerate it with `python3 scripts/dataset_table.py`.
 | [SpanningTree](https://github.com/tlaplus/Examples/tree/master/specifications/SpanningTree) | tlaplus/Examples | 1 | 1 | 2 |
 | [SpecifyingSystems_TLC](https://github.com/tlaplus/Examples/tree/master/specifications/SpecifyingSystems/TLC) | tlaplus/Examples | 1 | 1 | 2 |
 | [byihive](https://github.com/tlaplus/Examples/tree/master/specifications/byihive) | tlaplus/Examples | 1 | 1 | 2 |
-| [GermanProtocol](https://github.com/tlaplus/Examples/blob/aba0cef20ce694f97612ad36a873734a1314534a/specifications/GermanProtocol/GermanCoherence.tla) | tlaplus/Examples | – | 1 | 1 |
 | [SpecifyingSystems_HourClock](https://github.com/tlaplus/Examples/tree/master/specifications/SpecifyingSystems/HourClock) | tlaplus/Examples | 1 | – | 1 |
 | [two_thread_mutex](https://github.com/anvil-verifier/anvil/blob/main/src/tla_demo.rs) | two_thread_mutex (Anvil) | – | 1 | 1 |
 
-**Total: 70 examples — 473 proof-completion + 227 proof-from-scratch = 700 tasks.**
+**Total: 70 examples — 473 proof-completion + 233 proof-from-scratch = 706 tasks.**

--- a/scripts/dataset_table.py
+++ b/scripts/dataset_table.py
@@ -95,9 +95,9 @@ _GROUP_URL = {
     "ZooKeeper_LowLevel": "https://github.com/Disalg-ICS-NJU/zookeeper-tla-spec/tree/main/low-level-spec/zk-3.7",
     "tlaplus_examples_BlockingQueue": "https://github.com/lemmy/BlockingQueue",
     "tlaplus_examples_GermanProtocol": (
-        "https://github.com/tlaplus/Examples/blob/"
-        "aba0cef20ce694f97612ad36a873734a1314534a/"
-        "specifications/GermanProtocol/GermanCoherence.tla"
+        "https://github.com/tlaplus/Examples/tree/"
+        "91c22ea537853196ed1e03e9ad91693ec37642de/"
+        "specifications/GermanProtocol"
     ),
     "tlaplus_examples_ewd687a": (
         "https://github.com/tlaplus/Examples/tree/91c22ea537853196ed1e03e9ad91693ec37642de/specifications/ewd687a"

--- a/source/tlaplus_examples_GermanProtocol/GermanControl.tla
+++ b/source/tlaplus_examples_GermanProtocol/GermanControl.tla
@@ -1,5 +1,4 @@
----------------------------- MODULE GermanCoherence ----------------------------
-
+----------------------------- MODULE GermanControl -----------------------------
 CONSTANTS
     NODE,
     NoNode
@@ -7,7 +6,6 @@ CONSTANTS
 ASSUME NoNodeNotInNODE == NoNode \notin NODE
 
 CacheState == {"I", "S", "E"}
-MsgCmd     == {"Empty", "ReqS", "ReqE", "Inv", "InvAck", "GntS", "GntE"}
 
 VARIABLES
     cache,
@@ -26,13 +24,13 @@ vars == <<cache, chan1, chan2, chan3, invSet, shrSet, exGntd, curCmd, curPtr>>
 
 TypeOK ==
     /\ cache  \in [NODE -> CacheState]
-    /\ chan1  \in [NODE -> MsgCmd]
-    /\ chan2  \in [NODE -> MsgCmd]
-    /\ chan3  \in [NODE -> MsgCmd]
-    /\ invSet \in [NODE -> BOOLEAN]
-    /\ shrSet \in [NODE -> BOOLEAN]
+    /\ chan1  \in [NODE -> {"Empty", "ReqS", "ReqE"}]
+    /\ chan2  \in [NODE -> {"Empty", "Inv", "GntS", "GntE"}]
+    /\ chan3  \in [NODE -> {"Empty", "InvAck"}]
+    /\ invSet \subseteq NODE
+    /\ shrSet \subseteq NODE
     /\ exGntd \in BOOLEAN
-    /\ curCmd \in MsgCmd
+    /\ curCmd \in {"Empty", "ReqS", "ReqE"}
     /\ curPtr \in NODE \cup {NoNode}
 
 Init ==
@@ -40,39 +38,25 @@ Init ==
     /\ chan1  = [i \in NODE |-> "Empty"]
     /\ chan2  = [i \in NODE |-> "Empty"]
     /\ chan3  = [i \in NODE |-> "Empty"]
-    /\ invSet = [i \in NODE |-> FALSE]
-    /\ shrSet = [i \in NODE |-> FALSE]
+    /\ invSet = {}
+    /\ shrSet = {}
     /\ exGntd = FALSE
     /\ curCmd = "Empty"
     /\ curPtr = NoNode
 
 -------------------------------------------------------------------------------
 
-SendReqS(i) ==
+SendReq(i) ==
     /\ chan1[i] = "Empty"
-    /\ cache[i] = "I"
-    /\ chan1' = [chan1 EXCEPT ![i] = "ReqS"]
+    /\ \E c \in {"ReqS", "ReqE"} :
+         /\ cache[i] \in (IF c = "ReqS" THEN {"I"} ELSE {"I", "S"})
+         /\ chan1' = [chan1 EXCEPT ![i] = c]
     /\ UNCHANGED <<cache, chan2, chan3, invSet, shrSet, exGntd, curCmd, curPtr>>
 
-SendReqE(i) ==
-    /\ chan1[i] = "Empty"
-    /\ cache[i] \in {"I", "S"}
-    /\ chan1' = [chan1 EXCEPT ![i] = "ReqE"]
-    /\ UNCHANGED <<cache, chan2, chan3, invSet, shrSet, exGntd, curCmd, curPtr>>
-
-RecvReqS(i) ==
+RecvReq(i) ==
     /\ curCmd = "Empty"
-    /\ chan1[i] = "ReqS"
-    /\ curCmd' = "ReqS"
-    /\ curPtr' = i
-    /\ chan1' = [chan1 EXCEPT ![i] = "Empty"]
-    /\ invSet' = shrSet
-    /\ UNCHANGED <<cache, chan2, chan3, shrSet, exGntd>>
-
-RecvReqE(i) ==
-    /\ curCmd = "Empty"
-    /\ chan1[i] = "ReqE"
-    /\ curCmd' = "ReqE"
+    /\ chan1[i] \in {"ReqS", "ReqE"}
+    /\ curCmd' = chan1[i]
     /\ curPtr' = i
     /\ chan1' = [chan1 EXCEPT ![i] = "Empty"]
     /\ invSet' = shrSet
@@ -80,10 +64,10 @@ RecvReqE(i) ==
 
 SendInv(i) ==
     /\ chan2[i] = "Empty"
-    /\ invSet[i] = TRUE
+    /\ i \in invSet
     /\ (curCmd = "ReqE" \/ (curCmd = "ReqS" /\ exGntd = TRUE))
     /\ chan2' = [chan2 EXCEPT ![i] = "Inv"]
-    /\ invSet' = [invSet EXCEPT ![i] = FALSE]
+    /\ invSet' = invSet \ {i}
     /\ UNCHANGED <<cache, chan1, chan3, shrSet, exGntd, curCmd, curPtr>>
 
 SendInvAck(i) ==
@@ -98,43 +82,26 @@ RecvInvAck(i) ==
     /\ chan3[i] = "InvAck"
     /\ curCmd # "Empty"
     /\ chan3' = [chan3 EXCEPT ![i] = "Empty"]
-    /\ shrSet' = [shrSet EXCEPT ![i] = FALSE]
+    /\ shrSet' = shrSet \ {i}
     /\ exGntd' = IF exGntd = TRUE THEN FALSE ELSE exGntd
     /\ UNCHANGED <<cache, chan1, chan2, invSet, curCmd, curPtr>>
 
-SendGntS(i) ==
-    /\ curCmd = "ReqS"
+SendGnt(i) ==
+    /\ curCmd \in {"ReqS", "ReqE"}
     /\ curPtr = i
     /\ chan2[i] = "Empty"
     /\ exGntd = FALSE
-    /\ chan2' = [chan2 EXCEPT ![i] = "GntS"]
-    /\ shrSet' = [shrSet EXCEPT ![i] = TRUE]
-    /\ curCmd' = "Empty"
-    /\ curPtr' = NoNode
-    /\ UNCHANGED <<cache, chan1, chan3, invSet, exGntd>>
-
-SendGntE(i) ==
-    /\ curCmd = "ReqE"
-    /\ curPtr = i
-    /\ chan2[i] = "Empty"
-    /\ exGntd = FALSE
-    /\ \A j \in NODE : shrSet[j] = FALSE
-    /\ chan2' = [chan2 EXCEPT ![i] = "GntE"]
-    /\ shrSet' = [shrSet EXCEPT ![i] = TRUE]
-    /\ exGntd' = TRUE
+    /\ curCmd = "ReqE" => shrSet = {}
+    /\ chan2' = [chan2 EXCEPT ![i] = IF curCmd = "ReqS" THEN "GntS" ELSE "GntE"]
+    /\ shrSet' = shrSet \cup {i}
+    /\ exGntd' = (curCmd = "ReqE")
     /\ curCmd' = "Empty"
     /\ curPtr' = NoNode
     /\ UNCHANGED <<cache, chan1, chan3, invSet>>
 
-RecvGntS(i) ==
-    /\ chan2[i] = "GntS"
-    /\ cache' = [cache EXCEPT ![i] = "S"]
-    /\ chan2' = [chan2 EXCEPT ![i] = "Empty"]
-    /\ UNCHANGED <<chan1, chan3, invSet, shrSet, exGntd, curCmd, curPtr>>
-
-RecvGntE(i) ==
-    /\ chan2[i] = "GntE"
-    /\ cache' = [cache EXCEPT ![i] = "E"]
+RecvGnt(i) ==
+    /\ chan2[i] \in {"GntS", "GntE"}
+    /\ cache' = [cache EXCEPT ![i] = IF chan2[i] = "GntS" THEN "S" ELSE "E"]
     /\ chan2' = [chan2 EXCEPT ![i] = "Empty"]
     /\ UNCHANGED <<chan1, chan3, invSet, shrSet, exGntd, curCmd, curPtr>>
 
@@ -142,11 +109,11 @@ RecvGntE(i) ==
 
 Next ==
     \E i \in NODE :
-        \/ SendReqS(i)    \/ SendReqE(i)
-        \/ RecvReqS(i)    \/ RecvReqE(i)
+        \/ SendReq(i)
+        \/ RecvReq(i)
         \/ SendInv(i)     \/ SendInvAck(i)   \/ RecvInvAck(i)
-        \/ SendGntS(i)    \/ SendGntE(i)
-        \/ RecvGntS(i)    \/ RecvGntE(i)
+        \/ SendGnt(i)
+        \/ RecvGnt(i)
 
 Spec == Init /\ [][Next]_vars
 

--- a/source/tlaplus_examples_GermanProtocol/GermanControlBenchmarks.tla
+++ b/source/tlaplus_examples_GermanProtocol/GermanControlBenchmarks.tla
@@ -1,0 +1,7 @@
+----------------------- MODULE GermanControlBenchmarks ------------------------
+EXTENDS GermanControl
+
+THEOREM Spec => []Coherence
+PROOF OMITTED
+
+=============================================================================

--- a/source/tlaplus_examples_GermanProtocol/GermanData.tla
+++ b/source/tlaplus_examples_GermanProtocol/GermanData.tla
@@ -1,0 +1,253 @@
+------------------------------ MODULE GermanData ------------------------------
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    NODE,
+    DATA,
+    NoData,
+    NoNode
+
+ASSUME NoDataNotInDATA == NoData \notin DATA
+ASSUME NoNodeNotInNODE == NoNode \notin NODE
+
+CacheState == {"I", "S", "E"}
+
+Payload == DATA \cup {NoData}
+
+VARIABLES
+    cache,
+    chan1,
+    chan2,
+    chan3,
+    invSet,
+    shrSet,
+    exGntd,
+    curCmd,
+    curPtr,
+    memData,
+    auxData
+
+vars == <<cache, chan1, chan2, chan3, invSet, shrSet,
+          exGntd, curCmd, curPtr, memData, auxData>>
+
+-------------------------------------------------------------------------------
+
+TypeOK ==
+    /\ cache  \in [NODE -> [state : CacheState, data : Payload]]
+    /\ chan1  \in [NODE -> [cmd : {"Empty", "ReqS", "ReqE"}, data : Payload]]
+    /\ chan2  \in [NODE -> [cmd : {"Empty", "Inv", "GntS", "GntE"}, data : Payload]]
+    /\ chan3  \in [NODE -> [cmd : {"Empty", "InvAck"}, data : Payload]]
+    /\ invSet \subseteq NODE
+    /\ shrSet \subseteq NODE
+    /\ exGntd \in BOOLEAN
+    /\ curCmd \in {"Empty", "ReqS", "ReqE"}
+    /\ curPtr \in NODE \cup {NoNode}
+    /\ memData \in DATA
+    /\ auxData \in DATA
+
+Init ==
+    \E d \in DATA :
+        /\ cache  = [i \in NODE |-> [state |-> "I", data |-> NoData]]
+        /\ chan1  = [i \in NODE |-> [cmd |-> "Empty", data |-> NoData]]
+        /\ chan2  = [i \in NODE |-> [cmd |-> "Empty", data |-> NoData]]
+        /\ chan3  = [i \in NODE |-> [cmd |-> "Empty", data |-> NoData]]
+        /\ invSet = {}
+        /\ shrSet = {}
+        /\ exGntd = FALSE
+        /\ curCmd = "Empty"
+        /\ curPtr = NoNode
+        /\ memData = d
+        /\ auxData = d
+
+-------------------------------------------------------------------------------
+
+Store(i, d) ==
+    /\ cache[i].state = "E"
+    /\ cache' = [cache EXCEPT ![i].data = d]
+    /\ auxData' = d
+    /\ UNCHANGED <<chan1, chan2, chan3, invSet, shrSet,
+                   exGntd, curCmd, curPtr, memData>>
+
+SendReq(i) ==
+    /\ chan1[i].cmd = "Empty"
+    /\ \E c \in {"ReqS", "ReqE"} :
+         /\ cache[i].state \in (IF c = "ReqS" THEN {"I"} ELSE {"I", "S"})
+         /\ chan1' = [chan1 EXCEPT ![i].cmd = c]
+    /\ UNCHANGED <<cache, chan2, chan3, invSet, shrSet,
+                   exGntd, curCmd, curPtr, memData, auxData>>
+
+RecvGnt(i) ==
+    /\ chan2[i].cmd \in {"GntS", "GntE"}
+    /\ cache' = [cache EXCEPT ![i].state = IF chan2[i].cmd = "GntS" THEN "S" ELSE "E",
+                              ![i].data  = chan2[i].data]
+    /\ chan2' = [chan2 EXCEPT ![i].cmd = "Empty", ![i].data = NoData]
+    /\ UNCHANGED <<chan1, chan3, invSet, shrSet,
+                   exGntd, curCmd, curPtr, memData, auxData>>
+
+SendInvAck(i) ==
+    /\ chan2[i].cmd = "Inv"
+    /\ chan3[i].cmd = "Empty"
+    /\ chan2' = [chan2 EXCEPT ![i].cmd = "Empty", ![i].data = NoData]
+    /\ chan3' = [chan3 EXCEPT ![i].cmd = "InvAck",
+                              ![i].data = IF cache[i].state = "E"
+                                          THEN cache[i].data
+                                          ELSE NoData]
+    /\ cache' = [cache EXCEPT ![i].state = "I", ![i].data = NoData]
+    /\ UNCHANGED <<chan1, invSet, shrSet,
+                   exGntd, curCmd, curPtr, memData, auxData>>
+
+-------------------------------------------------------------------------------
+
+RecvReq(i) ==
+    /\ curCmd = "Empty"
+    /\ chan1[i].cmd \in {"ReqS", "ReqE"}
+    /\ curCmd' = chan1[i].cmd
+    /\ curPtr' = i
+    /\ chan1' = [chan1 EXCEPT ![i].cmd = "Empty"]
+    /\ invSet' = shrSet
+    /\ UNCHANGED <<cache, chan2, chan3, shrSet,
+                   exGntd, memData, auxData>>
+
+SendInv(i) ==
+    /\ chan2[i].cmd = "Empty"
+    /\ i \in invSet
+    /\ (curCmd = "ReqE" \/ (curCmd = "ReqS" /\ exGntd = TRUE))
+    /\ chan2' = [chan2 EXCEPT ![i].cmd = "Inv"]
+    /\ invSet' = invSet \ {i}
+    /\ UNCHANGED <<cache, chan1, chan3, shrSet,
+                   exGntd, curCmd, curPtr, memData, auxData>>
+
+RecvInvAck(i) ==
+    /\ chan3[i].cmd = "InvAck"
+    /\ curCmd # "Empty"
+    /\ shrSet' = shrSet \ {i}
+    /\ IF exGntd = TRUE
+         THEN /\ exGntd'  = FALSE
+              /\ memData' = chan3[i].data
+              /\ chan3'   = [chan3 EXCEPT ![i].cmd = "Empty", ![i].data = NoData]
+         ELSE /\ chan3'   = [chan3 EXCEPT ![i].cmd = "Empty"]
+              /\ UNCHANGED <<exGntd, memData>>
+    /\ UNCHANGED <<cache, chan1, chan2, invSet, curCmd, curPtr, auxData>>
+
+SendGnt(i) ==
+    /\ curCmd \in {"ReqS", "ReqE"}
+    /\ curPtr = i
+    /\ chan2[i].cmd = "Empty"
+    /\ exGntd = FALSE
+    /\ curCmd = "ReqE" => shrSet = {}
+    /\ chan2' = [chan2 EXCEPT ![i].cmd  = IF curCmd = "ReqS" THEN "GntS" ELSE "GntE",
+                              ![i].data = memData]
+    /\ shrSet' = shrSet \cup {i}
+    /\ exGntd' = (curCmd = "ReqE")
+    /\ curCmd' = "Empty"
+    /\ curPtr' = NoNode
+    /\ UNCHANGED <<cache, chan1, chan3, invSet, memData, auxData>>
+
+-------------------------------------------------------------------------------
+
+Next ==
+    \/ \E i \in NODE, d \in DATA : Store(i, d)
+    \/ \E i \in NODE :
+         \/ SendReq(i)
+         \/ RecvReq(i)
+         \/ SendInv(i)     \/ SendInvAck(i)   \/ RecvInvAck(i)
+         \/ SendGnt(i)
+         \/ RecvGnt(i)
+
+Spec == Init /\ [][Next]_vars
+
+-------------------------------------------------------------------------------
+
+Abstract == INSTANCE GermanControl WITH
+    cache <- [i \in NODE |-> cache[i].state],
+    chan1 <- [i \in NODE |-> chan1[i].cmd],
+    chan2 <- [i \in NODE |-> chan2[i].cmd],
+    chan3 <- [i \in NODE |-> chan3[i].cmd]
+
+Refinement == Abstract!Spec
+
+-------------------------------------------------------------------------------
+
+Coherence ==
+    \A i, j \in NODE :
+        i # j =>
+            /\ (cache[i].state = "E" => cache[j].state = "I")
+            /\ (cache[i].state = "S" => cache[j].state \in {"I", "S"})
+
+DataProp ==
+    /\ (exGntd = FALSE => memData = auxData)
+    /\ \A i \in NODE : cache[i].state # "I" => cache[i].data = auxData
+
+TransactionConsistency ==
+    (curCmd = "Empty") <=> (curPtr = NoNode)
+
+DirectoryAccurate ==
+    \A i \in NODE : cache[i].state \in {"S", "E"} => i \in shrSet
+
+ExclusiveIsolation ==
+    \A i \in NODE :
+        cache[i].state = "E" =>
+            /\ exGntd = TRUE
+            /\ \A j \in NODE \ {i} :
+                /\ cache[j].state = "I"
+                /\ chan2[j].cmd \notin {"GntS", "GntE"}
+                /\ chan3[j].cmd # "InvAck"
+
+WritebackCarriesLatest ==
+    \A i \in NODE :
+        (chan3[i].cmd = "InvAck" /\ curCmd # "Empty" /\ exGntd = TRUE) =>
+            /\ chan3[i].data = auxData
+            /\ \A j \in NODE \ {i} :
+                /\ cache[j].state # "E"
+                /\ chan2[j].cmd # "GntE"
+                /\ chan3[j].cmd # "InvAck"
+
+-------------------------------------------------------------------------------
+
+Fairness ==
+    \A i \in NODE :
+        /\ SF_vars(RecvReq(i))
+        /\ WF_vars(SendInv(i))
+        /\ WF_vars(SendInvAck(i))
+        /\ WF_vars(RecvInvAck(i))
+        /\ WF_vars(SendGnt(i))
+        /\ WF_vars(RecvGnt(i))
+
+FairSpec == Spec /\ Fairness
+
+RequestEventuallyServed ==
+    \A i \in NODE :
+        (chan1[i].cmd \in {"ReqS", "ReqE"}) ~> (chan1[i].cmd = "Empty")
+
+SharedRequestEventuallyGranted ==
+    \A i \in NODE :
+        (chan1[i].cmd = "ReqS") ~> (cache[i].state # "I")
+
+ExclusiveRequestEventuallyGranted ==
+    \A i \in NODE :
+        (chan1[i].cmd = "ReqE") ~> (cache[i].state = "E")
+
+-------------------------------------------------------------------------------
+\* Benchmark targets. These are local wrappers around properties checked by
+\* the upstream TLC configuration; the model and property definitions above
+\* are otherwise identical to tlaplus/Examples at the pinned commit.
+
+THEOREM Spec => []DataProp
+PROOF OMITTED
+
+THEOREM Spec => []TransactionConsistency
+PROOF OMITTED
+
+THEOREM Spec => []DirectoryAccurate
+PROOF OMITTED
+
+THEOREM Spec => []ExclusiveIsolation
+PROOF OMITTED
+
+THEOREM Spec => []WritebackCarriesLatest
+PROOF OMITTED
+
+THEOREM Spec => Refinement
+PROOF OMITTED
+
+=============================================================================


### PR DESCRIPTION
## What changed

- Refresh `GermanProtocol` from the old `GermanCoherence.tla` snapshot to
  `GermanControl.tla` and `GermanData.tla` from
  [`tlaplus/Examples@91c22ea`](https://github.com/tlaplus/Examples/tree/91c22ea537853196ed1e03e9ad91693ec37642de/specifications/GermanProtocol).
- Add regenerable source files and replace the old task with seven focused
  proof-from-scratch tasks covering control coherence, five data invariants,
  and the `GermanData => GermanControl` refinement.
- Update provenance, source links, and dataset totals from 700 to 706 tasks.

The group remains proof-from-scratch only because upstream does not provide
human-written TLAPS proofs.

## Testing

- Upstream TLC configurations pass for `GermanControl` and `GermanData`.
- All seven generated tasks pass SANY and the non-degeneracy gate.
- Dataset integrity passes for all 925 benchmark files.
