### PR TITLE
Add inductive invariance checking (Apalache + TLC) for proof-from-scratch

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -83,6 +83,23 @@ RUN --mount=type=cache,target=/tmp/downloads \
     && test -f /opt/community/GraphTheorems.tla \
     && rm -rf /tmp/CommunityModules-${COMMUNITY_TAG}
 
+# Layer 5b: Apalache model checker (downloaded inside Docker — no host
+# dependency). Kept in sync with scripts/install_deps.sh (host → ~/.apalache).
+# The tgz unpacks to apalache-${APALACHE_VERSION}/ with bin/apalache-mc + lib/;
+# symlinked onto PATH so agents can invoke `apalache-mc` directly.
+ARG APALACHE_TAG=v0.58.3
+ARG APALACHE_VERSION=0.58.3
+ARG APALACHE_ASSET=apalache-${APALACHE_VERSION}.tgz
+ARG APALACHE_URL=https://github.com/apalache-mc/apalache/releases/download/${APALACHE_TAG}/${APALACHE_ASSET}
+RUN --mount=type=cache,target=/tmp/downloads \
+    if [ ! -f /tmp/downloads/${APALACHE_ASSET} ]; then \
+      curl -fsSL -o /tmp/downloads/${APALACHE_ASSET} "${APALACHE_URL}"; \
+    fi \
+    && tar -xzf /tmp/downloads/${APALACHE_ASSET} -C /opt/ \
+    && mv /opt/apalache-${APALACHE_VERSION} /opt/apalache \
+    && test -x /opt/apalache/bin/apalache-mc \
+    && ln -s /opt/apalache/bin/apalache-mc /usr/local/bin/apalache-mc
+
 # Layer 6: SANY DumpSemantics compilation (needs tla2tools.jar + JDK)
 COPY src/dataset/sany-dump /opt/sany/src/dataset/sany-dump
 RUN cp -r /opt/community /opt/sany/lib/community \

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Install host-side dependencies for tlaps-bench:
 #   - tlapm 1.6 pre-release  -> ~/.tlapm
-#   - Apalache 0.57.0        -> ~/.apalache
+#   - Apalache 0.58.3        -> ~/.apalache
 #   - tla2tools.jar (SANY)   -> <repo>/lib/tla2tools.jar
 #
 # Idempotent: skips downloads when the target is already present.
@@ -32,7 +32,7 @@ case "${HOST_OS} ${HOST_ARCH}" in
 esac
 TLAPM_URL="https://github.com/tlaplus/tlapm/releases/download/${TLAPM_TAG}/${TLAPM_ASSET}"
 
-APALACHE_TAG="v0.57.0"
+APALACHE_TAG="v0.58.3"
 APALACHE_VERSION="${APALACHE_TAG#v}"
 APALACHE_ASSET="apalache-${APALACHE_VERSION}.tgz"
 APALACHE_URL="https://github.com/apalache-mc/apalache/releases/download/${APALACHE_TAG}/${APALACHE_ASSET}"

--- a/src/evaluator/prompts/proof-from-scratch.txt
+++ b/src/evaluator/prompts/proof-from-scratch.txt
@@ -21,9 +21,9 @@ Your solution must also parse under the standard TLA+ parser (SANY): the checker
 
 Two model checkers are installed: Apalache as `apalache-mc`, and TLC in `/opt/sany/lib/tla2tools.jar`. Use one to test an inductive invariant candidate in seconds, before investing in a TLAPS proof of it. Prefer Apalache; fall back to TLC when the spec cannot be made to typecheck.
 For a candidate `IndInv` (typically a type invariant conjoined with the extra state constraints you need) and the safety predicate `Safety` that the target theorem is about, three checks together say "IndInv is inductive and strong enough" — run them against the typed wrapper module described below, `APFoo.tla` here:
-`apalache-mc check --init=Init --inv=IndInv --length=0 APFoo.tla` — the initial states satisfy the candidate (`Init => IndInv`).
-`apalache-mc check --init=IndInv --inv=IndInv --length=1 APFoo.tla` — one step cannot leave the candidate (`IndInv /\ Next => IndInv'`); this is the same obligation as your TLAPS inductive step.
-`apalache-mc check --init=IndInv --inv=Safety --length=0 APFoo.tla` — the candidate implies the goal (`IndInv => Safety`).
+`apalache-mc check --config=APFoo.cfg --init=Init --inv=IndInv --length=0 APFoo.tla` — the initial states satisfy the candidate (`Init => IndInv`).
+`apalache-mc check --config=APFoo.cfg --init=IndInv --inv=IndInv --length=1 APFoo.tla` — one step cannot leave the candidate (`IndInv /\ Next => IndInv'`); this is the same obligation as your TLAPS inductive step.
+`apalache-mc check --config=APFoo.cfg --init=IndInv --inv=Safety --length=0 APFoo.tla` — the candidate implies the goal (`IndInv => Safety`).
 
 The two checks that start from `--init=IndInv` need the candidate to assign every variable, so shape it `TypeOK /\ H` with `TypeOK` one `v \in S` clause per variable. Handing them a bare safety predicate instead yields an assignment error (`x' is used before it is assigned`) rather than a counterexample. The stripped model frequently leaves no `TypeOK` behind, so writing one is part of the work; bound any variable the spec types as `Nat` (`num \in [P -> 0..4]`) to keep the check cheap, and widen the bound before trusting a counterexample that looks like an artifact of it.
 

--- a/src/evaluator/prompts/proof-from-scratch.txt
+++ b/src/evaluator/prompts/proof-from-scratch.txt
@@ -17,6 +17,46 @@ Keep iterating until `check_proof_bin {benchmark_basename} --mode proof-from-scr
 
 Your solution must also parse under the standard TLA+ parser (SANY): the checker rejects a file SANY cannot parse (reported as `[SANY-INVALID]`), so avoid constructs SANY rejects such as an operator parameter or bound variable that shadows a declared CONSTANT/VARIABLE; you can check just the syntax in seconds (without a full proof run) via `check_proof_bin {benchmark_basename} --sany-only`.
 
+# Validating inductive invariant candidates with a model checker
+
+Two model checkers are installed: Apalache as `apalache-mc`, and TLC in `/opt/sany/lib/tla2tools.jar`. Use one to test an inductive invariant candidate in seconds, before investing in a TLAPS proof of it. Prefer Apalache; fall back to TLC when the spec cannot be made to typecheck.
+For a candidate `IndInv` (typically a type invariant conjoined with the extra state constraints you need) and the safety predicate `Safety` that the target theorem is about, three checks together say "IndInv is inductive and strong enough" — run them against the typed wrapper module described below, `APFoo.tla` here:
+`apalache-mc check --init=Init --inv=IndInv --length=0 APFoo.tla` — the initial states satisfy the candidate (`Init => IndInv`).
+`apalache-mc check --init=IndInv --inv=IndInv --length=1 APFoo.tla` — one step cannot leave the candidate (`IndInv /\ Next => IndInv'`); this is the same obligation as your TLAPS inductive step.
+`apalache-mc check --init=IndInv --inv=Safety --length=0 APFoo.tla` — the candidate implies the goal (`IndInv => Safety`).
+
+The two checks that start from `--init=IndInv` need the candidate to assign every variable, so shape it `TypeOK /\ H` with `TypeOK` one `v \in S` clause per variable. Handing them a bare safety predicate instead yields an assignment error (`x' is used before it is assigned`) rather than a counterexample. The stripped model frequently leaves no `TypeOK` behind, so writing one is part of the work; bound any variable the spec types as `Nat` (`num \in [P -> 0..4]`) to keep the check cheap, and widen the bound before trusting a counterexample that looks like an artifact of it.
+
+When a check fails, Apalache reports a counterexample and writes it to `violation1.tla` in a timestamped run directory under `_apalache-out/<module>.tla/` (redirect with `--out-dir` or `--run-dir`); the log line `Check the trace in: ...` gives the exact path. Read it — it says precisely why the candidate is wrong.
+A failure of the second check is the informative one: it gives a concrete pair of states, one satisfying `IndInv` and a successor violating it, and the trailing `InvariantViolation` formula names the conjunct that broke. That state pair is exactly the case your candidate fails to rule out, i.e. the missing fact you must add to strengthen `IndInv` — and the same gap that would leave your TLAPS inductive step unprovable.
+A failure of the first check means the candidate excludes legitimate initial states; a failure of the third means it is too weak to imply the goal.
+Strengthen the candidate from the counterexample and re-run all three checks until each one passes.
+
+Apalache needs typed declarations and finite CONSTANTS, but {benchmark_basename} must not be modified. Prefer the non-invasive wrapper: a new module that re-declares the CONSTANTS and VARIABLES with `\* @type:` annotations and then INSTANCEs the original, leaving the spec itself untouched. For a spec `Foo.tla` declaring `CONSTANT N` and `VARIABLE active`, write `APFoo.tla`:
+  ---- MODULE APFoo ----
+  EXTENDS Naturals
+  CONSTANT
+    \* @type: Int;
+    N
+  VARIABLE
+    \* @type: Set(Int);
+    active
+  INSTANCE Foo
+  ====
+The re-declared names must match the original's so the implicit INSTANCE substitution binds them, and each annotation must sit between the `CONSTANT`/`VARIABLE` keyword and the name it types — one per name, including inside a multi-name `VARIABLES a, b, c` block. A comment above the keyword is not read: Apalache stops with `Expected a type annotation for VARIABLE <name>`. Define your candidate `IndInv` in the wrapper too, so the spec under proof stays untouched while you iterate. Run the three checks against the wrapper (`apalache-mc check ... APFoo.tla`), fixing the CONSTANTS in a `.cfg` file (`CONSTANT N = 5`) or with `--cinit`; for a constant of uninterpreted type, define a `<Const>Val` operator in the wrapper and substitute it in the `.cfg` (`Jug <- JugVal`). If a polymorphic helper (`Sum`, `Range`, `ToSet`, ...) defeats the type checker, shadow it in the wrapper with a monomorphic version.
+Only if the wrapper cannot be made to typecheck should you fall back to annotating a scratch copy of the module (e.g. `mkdir -p scratch && cp {benchmark_basename} scratch/Candidate.tla`).
+Either way it is a private exploration tool and not part of your solution: your solution must never EXTEND or INSTANCE it, and it must not change {benchmark_basename} or any dependency file.
+Apalache cannot type every spec. When the type checker cannot be satisfied even through a wrapper, check the candidate with TLC instead, which is untyped (the technique is Lamport's "Using TLC to Check Inductive Invariance"). Keep it non-invasive the same way: a separate `MCFoo.tla` that EXTENDS the original and defines your candidate, plus an `MCFoo.cfg` beside it. TLC is not on PATH — run it as `java -cp /opt/sany/lib/tla2tools.jar tlc2.TLC -deadlock -config MCFoo.cfg MCFoo.tla`.
+The inductive step is checked by making the candidate its own initial predicate: `IndInv /\ Next => IndInv'` holds exactly when `IndInv` is an ordinary invariant of the spec started in `IndInv`, so the `.cfg` reads
+  INIT IndInv
+  NEXT Next
+  INVARIANT IndInv
+Check `Init => IndInv` separately by running TLC on the real spec (`SPECIFICATION Spec` with `INVARIANT IndInv`), and get `IndInv => Safety` for free by making `Safety` a conjunct of `IndInv`.
+This needs the same `TypeOK /\ H` shape as the Apalache checks, with `TypeOK` clauses TLC can enumerate. TLC builds every state satisfying `TypeOK` before filtering by `H`, so the cost is the product of those set sizes and it explodes fast — start with the tiniest model that is still interesting. Two ways to get further: move a conjunct of `H` up among the `TypeOK` conjuncts, immediately after the ones binding the variables it mentions, so TLC prunes before enumerating the rest; and switch to probabilistic checking by replacing `v \in S` with `v \in RandomSubset(k, S)` from the `Randomization` module (bundled in tla2tools.jar), rewriting `v \subseteq W` as `v \in SUBSET W` and covering it with `RandomSetOfSubsets(k, p, W)`. Aim for a few dozen initial states.
+A reported violation carries the same signal Apalache gives: the two-state trace is a state satisfying `IndInv` followed by a successor that does not, naming the fact your candidate is missing. The converse does not hold once random subsets are involved — finding no error then proves nothing, so re-run it a dozen times, and abandon a run whose search depth passes roughly a dozen steps.
+
+A model checker's verdict is evidence, not a proof: both tools check one small finite instance, so a candidate that passes still has to be proved in TLAPS, and only `check_proof_bin` reporting PASS finishes the task. Never cite Apalache or TLC as justification for a proof step.
+
 # Constraints
 
 You should not change any existing module header, existing operator definitions, CONSTANT or VARIABLE declarations, ASSUME/ASSUMPTION declarations, or the target THEOREM statement; new LEMMAs and new helper operator definitions you add as scaffolding above the target theorem are fine.

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -69,6 +69,13 @@ VERDICT_ICONS = {"PASS": "✅", "FAIL": "❌", "CHEATING": "⚠️", "TIMEOUT": 
 # Set to True to stream agent output to terminal during container runs
 STREAM_AGENT_OUTPUT = True
 
+# Heading of the prompt section that teaches falsifying an inductive invariant
+# candidate with a model checker (Apalache, or TLC when a spec cannot be typed).
+# Its presence is stamped on every result: the container always ships both
+# checkers, so what actually varies between runs is whether the agent was told
+# to use them, and a result is only comparable against others prompted alike.
+INDINV_PROMPT_MARKER = "# Validating inductive invariant candidates"
+
 # Backoff between infra retries (seconds); the last value repeats. Short: the
 # observed startup blips clear within seconds-to-minutes.
 INFRA_RETRY_BACKOFF = (15, 30, 60)
@@ -755,6 +762,7 @@ def run_single_benchmark(item: WorkItem):
         )
         with open(os.path.join(input_dir, "prompt.txt"), "w") as f:
             f.write(prompt)
+        result["indinv_check_prompted"] = INDINV_PROMPT_MARKER in prompt
 
         # Run the agent
         agent_jsonl = os.path.join(agent_dir, "output.jsonl")


### PR DESCRIPTION
## Rationale

Proof-from-scratch agents had no model checker. The prompt advertised tlapm, the stdlib, CommunityModules and SANY — nothing that can *falsify* a candidate inductive invariant. That was the failure mode: prior proof-from-scratch attempts died on gate `B:discharge`, a parsable proof whose obligations could not be discharged because the invariant was too weak. A model checker turns a guess-and-prove loop into a seconds-long refutation loop.

## Changes

Three commits, one concern each:

- **Install Apalache 0.58.3 in the agent container** (`docker/base.Dockerfile`), following the existing tlapm/tla2tools download-inside-Docker pattern; `apalache-mc` symlinked onto PATH. `scripts/install_deps.sh` bumped to match so host and container agree.
- **Document inductive-invariance checking** in `src/evaluator/prompts/proof-from-scratch.txt`,  with two interchangeable backends (below).
- **Record whether the prompt offered the technique**: result["indinv_check_prompted"]`.

The last one is deliberately not a capability probe. Both checkers now ship unconditionally, so their presence is a constant that says nothing about a run; what varies is whether the agent was *told* to use them, and a result is only comparable against others prompted alike. The flag is derived from the prompt actually handed to the agent rather than from a static mode lookup, so it stays correct for the variants that omit the section: proof-completion and the tool-free one-shot prompts record false, while a continuation round inherits the full prompt and records true.

## Checking inductive invariants

Apalache is the preferred path: the three checks (`Init => IndInv`, `IndInv /\ Next => IndInv'`, `IndInv => Safety`) and how to read the counterexample — the state pair from the inductive step names the conjunct that broke, which is the fact needed to strengthen the candidate.

Apalache cannot type every spec, so TLC is documented as the fallback, using Lamport's technique from *Using TLC to Check Inductive Invariance*: make the candidate its own initial predicate (`INIT IndInv` / `NEXT Next` / `INVARIANT IndInv`) so the inductive step becomes an ordinary invariance check. Includes the enumeration blowup and both mitigations — hoisting conjuncts of `H` between the `TypeOK` conjuncts, and probabilistic checking via `RandomSubset` /`RandomSetOfSubsets` from the bundled `Randomization` module — plus the asymmetry that a violation is conclusive while a clean probabilistic run proves nothing.

TLC needs no new dependency: it already ships in `tla2tools.jar`, but is not on PATH and was never mentioned to agents. It is invoked as `java -cp /opt/sany/lib/tla2tools.jar tlc2.TLC -deadlock -config MCFoo.cfg MCFoo.tla`.

## Keeping the spec untouched

Both tools want edits the benchmark forbids — Apalache needs `@type:` annotations and pinned CONSTANTS, TLC needs a candidate definition and a `.cfg`. Following the technique in tlaplus/Examples `15733ef`, the prompt directs that work into a side module: an `AP<Spec>` wrapper that re-declares CONSTANTS and VARIABLES with annotations and INSTANCEs the original for Apalache, or an `MC<Spec>` module that EXTENDS the original for TLC. Annotating a scratch copy remains the last resort.

Either form is exploration-only and the solution is forbidden from `EXTEND`ing it. Safe by construction: `tlacheck/rules/smuggled_module.py` only flags agent modules reachable via `EXTENDS` from the solution, pinned by `test_unreferenced_scratch_module_not_flagged`.