### PR TITLE
Require a deterministic Z3 budget (SMTT("rN")) in the proof prompts

### DIFF
--- a/src/evaluator/prompts/proof-completion.txt
+++ b/src/evaluator/prompts/proof-completion.txt
@@ -21,6 +21,7 @@ Your solution must also parse under the standard TLA+ parser (SANY): the checker
 You should not change any module header, operator definitions, CONSTANT or VARIABLE declarations, ASSUME/ASSUMPTION declarations, or THEOREM/LEMMA statements that appear above `PROOF OBVIOUS`; you should not change any preceding `PROOF OMITTED` proofs.
 You should never use `PROOF OMITTED` or bare `OMITTED` in your proof.
 You are not allowed to introduce new top-level AXIOM, ASSUME, ASSUMPTION, CONSTANT, or VARIABLE declarations, or weaken theorem statements or add extra hypotheses.
+Bound the SMT/Z3 backend with a deterministic budget `SMTT("rN")` (for example `SMTT("r5")`), capped at `SMTT("r30")`; do not use the wall-clock forms `SMT` or `SMTT(n)`, and if an obligation needs more than the cap, decompose it into smaller steps rather than raising the budget.
 Before you are done, run `check_proof_bin {benchmark_basename} --mode proof-completion` to verify you have not made any illegal changes.
 Do not browse or fetch any external websites — network access is disabled.
 Do not look for example proof files or solutions outside the current working directory.

--- a/src/evaluator/prompts/proof-from-scratch.txt
+++ b/src/evaluator/prompts/proof-from-scratch.txt
@@ -85,5 +85,6 @@ A model checker's verdict is evidence, not a proof: both tools check one small f
 - Do not add `EXTENDS`, `INSTANCE`, nested modules, `CONSTANT`, `VARIABLE`, `ASSUME`, `ASSUMPTION`, or `AXIOM` declarations.
 - Every helper `LEMMA` or `THEOREM` must be named and fully proved.
 - Never use `PROOF OMITTED` or bare `OMITTED`, and never restate the target as an unproved or circular helper.
+- Bound the SMT/Z3 backend with a deterministic budget `SMTT("rN")` (for example `SMTT("r5")`), capped at `SMTT("r30")`; do not use the wall-clock forms `SMT` or `SMTT(n)`, and if a step needs more than the cap, decompose it rather than raising the budget.
 - New operator and lemma names must be fresh; do not shadow names from the task or its context.
 - Do not browse or fetch external material. Work only from the files in this workspace and your knowledge of TLA+/TLAPS.


### PR DESCRIPTION
## What

Add one constraint to the two agentic proof prompts
(`proof-completion.txt`, `proof-from-scratch.txt`): proofs must bound the
SMT/Z3 backend with a deterministic budget `SMTT("rN")` (capped at `"r30"`),
not the wall-clock forms `SMT` / `SMTT(n)`.

## Why

Wall-clock SMT timeouts make a proof's pass/fail depend on CPU speed and load,
so the same proof can close on one machine and time out on another — a source of
non-reproducible grading. tlapm's `SMTT("rN")` (tlaplus/tlapm#283) bounds Z3 by
a deterministic resource count instead, so the outcome is identical across
machines and reruns for a fixed Z3 build. Capping at `"r30"` and requiring
decomposition beyond it keeps per-obligation cost bounded and pushes toward
finer-grained proofs.

## Scope / notes

- Only the two agentic modes; the one-shot prompts are left unchanged, since a
  single tool-free response doesn't iterate on or tune backend timeouts.
- Requires a tlapm that includes tlaplus/tlapm#283. The `1.6.0-pre` rolling
  pre-release the Docker image pulls was rebuilt from `main` right after #283
  merged, so it already carries `SMTT("rN")`.
