### PR TITLE
Make layered proof-completion generation the default

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -273,12 +273,16 @@ uv run tlaps-bench generate
 uv run tlaps-bench generate --mode proof-from-scratch
 ```
 
-`--layered` emits the layered suite described in [Layered-task trust boundary](#layered-task-trust-boundary): one read-only `<base>Model.tla` per source, one read-only `<task>Scaffold.tla` per target, an editable `<task>.tla` holding the fixed theorem statement and the marked proof region, and a `manifest.json` naming every task's exact context.
+Proof-completion generation emits the layered suite described in [Layered-task trust boundary](#layered-task-trust-boundary): one read-only `<base>Model.tla` per source, one read-only `<task>Scaffold.tla` per target, an editable `<task>.tla` holding the fixed theorem statement and the marked proof region, and a `manifest.json` naming every task's exact context. Use `--legacy` only for the old generators.
 
 ```bash
-uv run tlaps-bench generate --mode proof-completion --layered
-uv run tlaps-bench generate --mode proof-completion --layered --filter EWD840   # one source group
+uv run tlaps-bench generate --mode proof-completion
+uv run tlaps-bench generate --mode proof-completion --filter EWD840   # one source group
+uv run tlaps-bench generate --mode proof-completion --legacy         # old single-file layout
+uv run tlaps-bench generate --mode proof-completion --legacy --shared-model  # old shared-model layout
 ```
+
+`--output-dir` works with the default layered generator and with `--legacy --shared-model`. The flat `--legacy` generator writes only to `benchmark/proof-completion/`.
 
 Every task is parsed back through the evaluator's own contract, then gated: each one must parse under standalone SANY with only its manifest context, and any task whose `PROOF OBVIOUS` placeholder already verifies is dropped as degenerate. `--skip-gates` bypasses both for fast iteration; a shipped dataset is generated with them. A `--filter` or positional-file run regenerates only the tasks belonging to the sources it processed and needs the existing manifest to preserve the rest. `benchmark/<mode>/audit.log` records every drop, every leak check, and every task that the previous dataset had but the run did not regenerate.
 

--- a/docs/apalache_examples_unverifiable.json
+++ b/docs/apalache_examples_unverifiable.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Proof-completion candidates from konnov/apalache-examples excluded because their UPSTREAM reference proof does not verify under the tlapm pinned by this repository (1.6.0-pre, build 80172c6) within the grader's default 600s budget. Upstream reports all obligations proved with build b064bce-dirty; the same obligations fail when the unmodified upstream sources are checked directly (tlapm --toolbox on source/), so this is a prover-version gap, not a defect in the import. Ruled out by experiment: the upstream --stretch 2 flag, the Isabelle backend, and validate.py's regex proof extraction. A task whose only known reference proof fails this repo's checker has no demonstrated ground truth, so it is not shipped.",
   "_reproduce": [
-    "uv run tlaps-bench generate --shared-model   # 341 candidates; the triviality gate self-heals 22",
+    "uv run tlaps-bench generate --mode proof-completion --legacy --shared-model   # 341 candidates; the triviality gate self-heals 22",
     "uv run tlaps-bench validate --no-container --filter apalache_examples_ --jobs 3 --timeout 600",
     "then delete the tasks listed under 'excluded'"
   ],

--- a/src/dataset/proof_completion/generate.py
+++ b/src/dataset/proof_completion/generate.py
@@ -10,11 +10,12 @@ generate a standalone .tla file where:
 - Files with INSTANCE dependencies have dependency files copied alongside
 - Each benchmark file works standalone (with its dependency files)
 
-Layered layout (`--layered`, Issue #86)
----------------------------------------
+Layered layout (default, Issue #86)
+-----------------------------------
 The layouts above put the whole task in ONE editable module, so an agent can
 "prove" the goal by weakening the specification, redefining the scaffolding, or
-restating the theorem. `--layered` splits each task by ownership instead:
+restating the theorem. The default generator splits each task by ownership
+instead:
 
     <base>Model.tla        declarations, assumptions, state machine, Spec, fairness
     <task>Scaffold.tla     this target's given definitions + preceding lemmas
@@ -1001,9 +1002,9 @@ def process_module_dir(module_dir_name):
 
 
 # ---------------------------------------------------------------------------
-# Shared-model proof-completion (opt-in via --shared-model). Reuses the certified proof-from-scratch dump
+# Legacy shared-model proof-completion (opt-in via --legacy --shared-model). Reuses the certified proof-from-scratch dump
 # engine (src/dataset/proof_from_scratch/generate.py) for the model extraction + helpers,
-# and adds an proof-completion-specific task builder. Default (no flag) keeps the regex path.
+# and adds an proof-completion-specific task builder.
 # ---------------------------------------------------------------------------
 def _load_l2_engine():
     """Load the proof-from-scratch generator as the shared-model engine. proof-from-scratch does
@@ -2144,41 +2145,40 @@ def main():
 
     parser = argparse.ArgumentParser(description="Generate proof-completion benchmarks.")
     parser.add_argument(
-        "--shared-model",
+        "--legacy",
         action="store_true",
-        help="Emit one proof-free <Module>.tla model per output dir "
-        "and have tasks EXTEND it instead of inlining the spec.",
+        help="Use a legacy generator instead of the default layered layout.",
     )
     parser.add_argument(
-        "--layered",
+        "--shared-model",
         action="store_true",
-        help="Split each task into <base>Model.tla + <task>Scaffold.tla + "
-        "<task>.tla (editable, with proof markers) and write manifest.json "
-        "mapping each task to its exact read-only context (Issue #86). "
-        "Implies the shared-model split.",
+        help="Legacy mode only: emit one proof-free <Module>.tla model per output dir "
+        "and have tasks EXTEND it instead of inlining the spec.",
     )
     parser.add_argument(
         "--skip-gates",
         action="store_true",
-        help="Layered mode only: skip the SANY and triviality gates. "
+        help="Skip the SANY and triviality gates for layered generation. "
         "For fast iteration — a shipped dataset must be generated with them.",
     )
+    parser.add_argument("--source-dir", default=None, help="Directory of source .tla files (default: source/)")
+    parser.add_argument("--filter", default=None, help="Substring limiting which source files are processed")
     parser.add_argument(
-        "--source-dir", default=None, help="Directory of source .tla files (default: source/); layered mode only"
+        "--output-dir",
+        default=None,
+        help="Output directory for layered or legacy shared-model generation (default: benchmark/proof-completion)",
     )
-    parser.add_argument(
-        "--filter", default=None, help="Substring limiting which source files are processed; layered mode only"
-    )
-    parser.add_argument("--output-dir", default=None, help="Output directory (default: benchmark/proof-completion)")
-    parser.add_argument("files", nargs="*", help="Specific source .tla files to process; layered mode only")
+    parser.add_argument("files", nargs="*", help="Specific source .tla files to process")
     args = parser.parse_args()
 
-    if args.layered and args.shared_model:
-        parser.error("--layered already performs the model split; do not combine with --shared-model")
-    if not args.layered and (args.filter or args.files or args.source_dir or args.skip_gates):
-        parser.error("--source-dir, --filter, --skip-gates and positional files require --layered")
+    if args.shared_model and not args.legacy:
+        parser.error("--shared-model requires --legacy; layered generation already performs the model split")
+    if args.legacy and args.output_dir is not None and not args.shared_model:
+        parser.error("--output-dir requires --shared-model with --legacy")
+    if args.legacy and (args.filter is not None or args.files or args.source_dir is not None or args.skip_gates):
+        parser.error("--source-dir, --filter, --skip-gates and positional files are unavailable with --legacy")
 
-    if args.layered:
+    if not args.legacy:
         generate_layered(
             output_root=args.output_dir,
             source_dir=args.source_dir,

--- a/tests/common/test_cli.py
+++ b/tests/common/test_cli.py
@@ -26,3 +26,42 @@ def test_public_check_enables_strict_proof_from_scratch_default(monkeypatch):
         "passthrough": ["Task.tla", "--mode", "proof-from-scratch"],
         "entry_kwargs": {"require_canonical_for_proof_from_scratch": True},
     }
+
+
+def test_generate_routes_legacy_shared_model_arguments(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_dispatch(prog, module_name, attr, passthrough, *, entry_kwargs=None):
+        captured.update(
+            prog=prog,
+            module_name=module_name,
+            attr=attr,
+            passthrough=passthrough,
+            entry_kwargs=entry_kwargs,
+        )
+        return 0
+
+    monkeypatch.setattr(cli, "_dispatch", fake_dispatch)
+    output_dir = tmp_path / "shared-model"
+
+    assert (
+        cli.main(
+            [
+                "generate",
+                "--mode",
+                "proof-completion",
+                "--legacy",
+                "--shared-model",
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    assert captured == {
+        "prog": "tlaps-bench generate --mode proof-completion",
+        "module_name": "dataset.proof_completion.generate",
+        "attr": "main",
+        "passthrough": ["--legacy", "--shared-model", "--output-dir", str(output_dir)],
+        "entry_kwargs": None,
+    }

--- a/tests/dataset/test_proof_completion_duplicate_gate.py
+++ b/tests/dataset/test_proof_completion_duplicate_gate.py
@@ -130,14 +130,16 @@ def test_drop_detail_omits_all_zero_counts():
 
 
 @pytest.mark.parametrize("shared_model", [False, True])
-def test_main_omits_all_zero_drop_detail(monkeypatch, capsys, tmp_path, shared_model):
+def test_legacy_main_omits_all_zero_drop_detail(monkeypatch, capsys, tmp_path, shared_model):
     monkeypatch.setattr(generate, "BENCHMARK_DIR", str(tmp_path))
     monkeypatch.setattr(generate, "generate_shared_model_l1", lambda output_root: 1)
     monkeypatch.setattr(generate, "find_source_dirs", lambda: [])
     monkeypatch.setattr(generate, "_run_duplicate_gate", lambda directory: [])
     monkeypatch.setattr(generate, "_run_sany_gate", lambda directory: 0)
     monkeypatch.setattr(generate, "_prune_unreferenced_dependencies", lambda directory: [])
-    argv = ["generate.py", "--shared-model"] if shared_model else ["generate.py"]
+    argv = ["generate.py", "--legacy"]
+    if shared_model:
+        argv.append("--shared-model")
     monkeypatch.setattr(sys, "argv", argv)
 
     generate.main()
@@ -145,3 +147,136 @@ def test_main_omits_all_zero_drop_detail(monkeypatch, capsys, tmp_path, shared_m
     output = capsys.readouterr().out
     assert "0 duplicates" not in output
     assert "0 degenerate tasks" not in output
+
+
+def test_main_defaults_to_layered(monkeypatch):
+    calls = []
+    monkeypatch.setattr(generate, "generate_layered", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(sys, "argv", ["generate.py"])
+
+    generate.main()
+
+    assert calls == [
+        {
+            "output_root": None,
+            "source_dir": None,
+            "filter_substring": None,
+            "files": [],
+            "run_gates": True,
+        }
+    ]
+
+
+def test_main_forwards_layered_inputs(monkeypatch, tmp_path):
+    calls = []
+    source_dir = tmp_path / "source"
+    output_dir = tmp_path / "output"
+    source_file = source_dir / "Group" / "Spec.tla"
+    monkeypatch.setattr(generate, "generate_layered", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate.py",
+            "--source-dir",
+            str(source_dir),
+            "--filter",
+            "Group",
+            "--output-dir",
+            str(output_dir),
+            "--skip-gates",
+            str(source_file),
+        ],
+    )
+
+    generate.main()
+
+    assert calls == [
+        {
+            "output_root": str(output_dir),
+            "source_dir": str(source_dir),
+            "filter_substring": "Group",
+            "files": [str(source_file)],
+            "run_gates": False,
+        }
+    ]
+
+
+def test_shared_model_requires_legacy(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["generate.py", "--shared-model"])
+
+    with pytest.raises(SystemExit):
+        generate.main()
+
+    assert "--shared-model requires --legacy" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("shared_model", [False, True])
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ["--skip-gates"],
+        ["--filter", "Group"],
+        ["--source-dir", "source"],
+        ["source/Group/Spec.tla"],
+    ],
+)
+def test_legacy_rejects_layered_only_inputs(monkeypatch, extra, shared_model):
+    argv = ["generate.py", "--legacy"]
+    if shared_model:
+        argv.append("--shared-model")
+    monkeypatch.setattr(sys, "argv", [*argv, *extra])
+
+    with pytest.raises(SystemExit):
+        generate.main()
+
+
+def test_flat_legacy_rejects_output_dir_without_deleting_it(monkeypatch, capsys, tmp_path):
+    sentinel = tmp_path / "keep.txt"
+    sentinel.write_text("keep")
+    monkeypatch.setattr(sys, "argv", ["generate.py", "--legacy", "--output-dir", str(tmp_path)])
+
+    with pytest.raises(SystemExit):
+        generate.main()
+
+    assert "--output-dir requires --shared-model with --legacy" in capsys.readouterr().err
+    assert sentinel.read_text() == "keep"
+
+
+def test_legacy_shared_model_accepts_output_dir(monkeypatch, tmp_path):
+    output_dir = tmp_path / "generated"
+    calls = []
+    monkeypatch.setattr(
+        generate,
+        "generate_shared_model_l1",
+        lambda output_root: calls.append(("generate", output_root)) or 1,
+    )
+    monkeypatch.setattr(
+        generate,
+        "_run_duplicate_gate",
+        lambda directory: calls.append(("duplicates", directory)) or [],
+    )
+    monkeypatch.setattr(
+        generate,
+        "_run_sany_gate",
+        lambda directory: calls.append(("sany", directory)) or 0,
+    )
+    monkeypatch.setattr(
+        generate,
+        "_prune_unreferenced_dependencies",
+        lambda directory: calls.append(("prune", directory)) or [],
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["generate.py", "--legacy", "--shared-model", "--output-dir", str(output_dir)],
+    )
+
+    generate.main()
+
+    assert calls == [
+        ("generate", str(output_dir)),
+        ("duplicates", str(output_dir)),
+        ("sany", str(output_dir)),
+        ("prune", str(output_dir)),
+    ]


### PR DESCRIPTION
## Summary

Depends on #92.

- Make layered proof-completion generation the default.
- Move the old generators behind `--legacy`.
- Require `--legacy` for `--shared-model`.
- Reject layered-only options in legacy mode.
- Update CLI tests and usage docs.

After #92 merges, this PR will contain only the default-switch commit.