### PR TITLE
Record how many tools an agent called

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -114,9 +114,12 @@ ENV SANY_RUN_SH=/opt/sany/src/dataset/sany-dump/run.sh \
     TLAPS_IN_CONTAINER=1
 
 # Layer 8: Provider runners
+RUN pip install --no-cache-dir --break-system-packages \
+    'tree-sitter>=0.25.2' 'tree-sitter-bash>=0.25.1' 'tree-sitter-javascript>=0.25.0'
 COPY src/evaluator/__init__.py src/evaluator/agent_skills.py /opt/evaluator/
 COPY src/evaluator/backends/litellm_agent.py /opt/litellm_agent.py
 COPY src/evaluator/backends/oneshot_runner.py /opt/oneshot_runner.py
+COPY src/evaluator/toolcalls.py /opt/toolcalls.py
 COPY src/evaluator/backends/codex_usage_wrapper.py /opt/codex_usage_wrapper.py
 
 # Lock down checker + SANY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "pyyaml>=6.0.3",
     "pytest",
     "ruff",
+    "tree-sitter>=0.25.2",
+    "tree-sitter-bash>=0.25.1",
+    "tree-sitter-javascript>=0.25.0",
 ]
 
 [project.scripts]

--- a/src/evaluator/backends/claude_code.py
+++ b/src/evaluator/backends/claude_code.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 from typing import Any
 
+from evaluator import toolcalls
 from evaluator.cost import calculate_model_aggregate_cost_usd
 from evaluator.usage import RequestUsage, UsageCost, UsageSummary, nonnegative_float, nonnegative_int
 
@@ -431,6 +432,121 @@ def parse_claude_code_usage(
     )
 
 
+def _tool_call_summary(jsonl_path: str) -> toolcalls.ToolCallSummary:
+    """Count dispatched ``tool_use`` blocks and require one final result envelope."""
+
+    evidence = toolcalls.EventStreamEvidence()
+    commands: list[str | None] = []
+    seen_calls: dict[str, tuple[int, dict[str, Any]]] = {}
+    completed_ids: dict[str, int] = {}
+    anonymous_call_observed = False
+    anonymous_call_command: str | None = None
+    anonymous_result_observed = False
+    identity_valid = True
+    warnings: list[str] = []
+    result_count = 0
+    activity_after_result = False
+    for event_index, event in enumerate(toolcalls.iter_events(jsonl_path, evidence)):
+        event_type = event.get("type")
+        if event_type == "result":
+            result_count += 1
+        elif result_count and event_type in {"assistant", "user", "system"}:
+            activity_after_result = True
+        if event_type not in {"assistant", "user"}:
+            continue
+        message = event.get("message")
+        if not isinstance(message, dict):
+            evidence.warn(f"Claude Code {event_type} event has an invalid message object")
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            evidence.warn(f"Claude Code {event_type} event has invalid message content")
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                evidence.warn(f"Claude Code {event_type} content contains a malformed block")
+                continue
+            block_type = block.get("type")
+            if not isinstance(block_type, str):
+                evidence.warn(f"Claude Code {event_type} content block has an invalid type")
+                continue
+            if event_type == "user":
+                if block_type != "tool_result":
+                    continue
+                raw_result_id = block.get("tool_use_id")
+                result_id = raw_result_id if isinstance(raw_result_id, str) and raw_result_id else None
+                if result_id is None:
+                    identity_valid = False
+                    anonymous_result_observed = True
+                    warnings.append("Claude Code tool_result has a missing or invalid tool_use_id")
+                elif result_id in completed_ids:
+                    identity_valid = False
+                    warnings.append("Claude Code tool-call stream contains a duplicate tool_result ID")
+                else:
+                    completed_ids[result_id] = event_index
+                continue
+            if block_type != "tool_use":
+                continue
+            record_anonymous_call = False
+            call_id = block.get("id")
+            if isinstance(call_id, str) and call_id:
+                previous = seen_calls.get(call_id)
+                if previous is not None:
+                    identity_valid = False
+                    warning = (
+                        "Claude Code tool-call stream contains a conflicting tool_use ID"
+                        if previous[1] != block
+                        else "Claude Code tool-call stream contains a duplicate tool_use ID"
+                    )
+                    warnings.append(warning)
+                    continue
+                seen_calls[call_id] = (event_index, block)
+            else:
+                identity_valid = False
+                warnings.append("Claude Code tool_use has a missing or invalid ID")
+                # Without a native ID, repeated payloads cannot prove distinct
+                # calls. Keep one positive witness for a genuine lower bound.
+                if anonymous_call_observed:
+                    continue
+                anonymous_call_observed = True
+                record_anonymous_call = True
+            tool_input = block.get("input")
+            command = (
+                tool_input.get("command") if block.get("name") == "Bash" and isinstance(tool_input, dict) else None
+            )
+            command = command if isinstance(command, str) else None
+            if record_anonymous_call:
+                anonymous_call_command = command
+            else:
+                commands.append(command)
+
+    missing_results = set(seen_calls) - set(completed_ids)
+    orphan_results = set(completed_ids) - set(seen_calls)
+    out_of_order = sum(
+        completed_ids[call_id] <= seen_calls[call_id][0] for call_id in set(seen_calls) & set(completed_ids)
+    )
+    if missing_results:
+        identity_valid = False
+        warnings.append(f"Claude Code tool-call stream has {len(missing_results)} unfinished tool call(s)")
+    if orphan_results:
+        identity_valid = False
+        commands.extend(None for _ in orphan_results)
+        warnings.append(f"Claude Code tool-call stream has {len(orphan_results)} orphan tool result(s)")
+    if out_of_order:
+        identity_valid = False
+        warnings.append(f"Claude Code tool-call stream has {out_of_order} result(s) before their tool use")
+    if not seen_calls and not completed_ids:
+        if anonymous_call_observed:
+            commands.append(anonymous_call_command)
+        elif anonymous_result_observed:
+            commands.append(None)
+
+    lifecycle_complete = result_count == 1 and not activity_after_result and identity_valid
+    if result_count != 1 or activity_after_result:
+        warnings.append("Claude Code tool-call stream has no unique final result")
+    return toolcalls.summarize(commands, evidence, lifecycle_complete=lifecycle_complete, warnings=warnings)
+
+
 class ClaudeCodeBackend(AgenticBackend):
     name = "claude_code"
     requires_public_pricing = True
@@ -689,3 +805,6 @@ class ClaudeCodeBackend(AgenticBackend):
             complete=False,
             warnings=("Claude Code usage events unavailable",),
         )
+
+    def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
+        return {"tool_calls": _tool_call_summary(jsonl_path).to_dict()}

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -44,7 +44,7 @@ _RETRY_AT_RE = re.compile(r"try again at\s+(\d{1,2}):(\d{2})\s*([AaPp][Mm])")
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 _CODEX_USAGE_SOURCE = "codex_cli_turn_completed"
 _CODEX_CHILD_USAGE_SOURCE = "codex_rollout_child_token_count"
-_CODEX_CHILD_USAGE_COMPATIBLE_VERSIONS = frozenset({3, CODEX_CHILD_USAGE_VERSION})
+_CODEX_CHILD_USAGE_COMPATIBLE_VERSIONS = frozenset({3, 4, CODEX_CHILD_USAGE_VERSION})
 _MODEL_ACTIVITY_ITEM_TYPES = frozenset(
     {
         "agent_message",
@@ -185,8 +185,8 @@ def _parse_child_usage_audit(
     event: dict[str, Any],
 ) -> tuple[_CodexChildUsageAudit | None, tuple[str, ...]]:
     version = event.get("version")
-    # v4 only adds the independent tool-call tally; its usage payload is still
-    # wire-compatible with v3 records that may already be archived.
+    # Later versions add independent tool-call data, but retain the v3 usage
+    # payload so archived usage audits remain readable.
     if type(version) is not int or version not in _CODEX_CHILD_USAGE_COMPATIBLE_VERSIONS:
         return None, ("Codex child-usage audit has an unsupported version",)
 
@@ -296,11 +296,13 @@ def _parse_child_usage_audit(
 def _parse_child_tool_audit(
     event: dict[str, Any],
 ) -> tuple[_CodexChildToolAudit | None, tuple[str, ...]]:
-    """Validate the tool-only, privacy-preserving part of a child audit."""
+    """Validate the tool-only, privacy-preserving session-tree audit."""
 
     version = event.get("version")
     if type(version) is not int or version != CODEX_CHILD_USAGE_VERSION:
         return None, ("Codex child tool-call audit has an unsupported version",)
+    if event.get("tool_calls_scope") != "session_tree":
+        return None, ("Codex tool-call audit has an invalid scope",)
     root_thread_id = event.get("root_thread_id")
     if not isinstance(root_thread_id, str) or not root_thread_id:
         return None, ("Codex child tool-call audit has no root thread ID",)
@@ -677,7 +679,7 @@ def _same_tool_item(left: dict[str, Any], right: dict[str, Any]) -> bool:
 
 
 def _parse_tool_calls(jsonl_path: str) -> toolcalls.ToolCallSummary:
-    """Count root dispatches and merge the wrapper's sanitized child tally."""
+    """Use the rollout session-tree audit, with CLI root events as fallback."""
 
     evidence = toolcalls.EventStreamEvidence()
     starts: dict[str, list[tuple[int, dict[str, Any]]]] = {}
@@ -694,7 +696,10 @@ def _parse_tool_calls(jsonl_path: str) -> toolcalls.ToolCallSummary:
     saw_stream_lag = False
     saw_multi_agent_activity = False
     child_audit_starts = 0
+    child_audit_start_indexes: list[int] = []
+    child_audit_start_versions: list[object] = []
     child_audit_events = 0
+    child_audit_indexes: list[int] = []
     child_audits: list[_CodexChildToolAudit] = []
     warnings: list[str] = []
 
@@ -712,8 +717,11 @@ def _parse_tool_calls(jsonl_path: str) -> toolcalls.ToolCallSummary:
             terminals.append((index, event_type))
         elif event_type == CODEX_CHILD_USAGE_START_EVENT:
             child_audit_starts += 1
+            child_audit_start_indexes.append(index)
+            child_audit_start_versions.append(event.get("version"))
         elif event_type == CODEX_CHILD_USAGE_EVENT:
             child_audit_events += 1
+            child_audit_indexes.append(index)
             audit, audit_warnings = _parse_child_tool_audit(event)
             warnings.extend(audit_warnings)
             if audit is not None:
@@ -915,16 +923,17 @@ def _parse_tool_calls(jsonl_path: str) -> toolcalls.ToolCallSummary:
         warnings=warnings,
     )
 
+    def invalid_session_tree_audit(*audit_warnings: str) -> toolcalls.ToolCallSummary:
+        return toolcalls.ToolCallSummary.from_commands(
+            (),
+            available=True,
+            complete=False,
+            warnings=(*summary.warnings, *warnings, *audit_warnings),
+        )
+
     if child_audit_starts == 0:
         if child_audit_events:
-            return summary.merge(
-                toolcalls.ToolCallSummary.from_commands(
-                    (),
-                    available=True,
-                    complete=False,
-                    warnings=("Codex child tool-call audit appeared without its start sentinel",),
-                )
-            )
+            return invalid_session_tree_audit("Codex child tool-call audit appeared without its start sentinel")
         if saw_multi_agent_activity:
             return summary.merge(
                 toolcalls.ToolCallSummary.from_commands(
@@ -936,26 +945,19 @@ def _parse_tool_calls(jsonl_path: str) -> toolcalls.ToolCallSummary:
             )
         return summary
 
-    if child_audit_starts != 1 or child_audit_events != 1 or len(child_audits) != 1:
-        return summary.merge(
-            toolcalls.ToolCallSummary.from_commands(
-                (),
-                available=True,
-                complete=False,
-                warnings=("Codex child tool-call audit is missing or ambiguous",),
-            )
-        )
+    if (
+        child_audit_starts != 1
+        or child_audit_start_versions != [CODEX_CHILD_USAGE_VERSION]
+        or child_audit_events != 1
+        or len(child_audits) != 1
+    ):
+        return invalid_session_tree_audit("Codex child tool-call audit is missing or ambiguous")
+    if child_audit_start_indexes != [0] or child_audit_indexes != [evidence.event_count - 1]:
+        return invalid_session_tree_audit("Codex child tool-call audit has an invalid stream position")
     child_audit = child_audits[0]
     if len(root_thread_ids) != 1 or root_thread_ids[0] != child_audit.root_thread_id:
-        return summary.merge(
-            toolcalls.ToolCallSummary.from_commands(
-                (),
-                available=True,
-                complete=False,
-                warnings=("Codex child tool-call audit does not match the primary thread",),
-            )
-        )
-    return summary.merge(child_audit.tool_calls)
+        return invalid_session_tree_audit("Codex child tool-call audit does not match the primary thread")
+    return child_audit.tool_calls
 
 
 class CodexBackend(AgenticBackend):

--- a/src/evaluator/backends/codex.py
+++ b/src/evaluator/backends/codex.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from evaluator import quota
+from evaluator import quota, toolcalls
 from evaluator.usage import RequestUsage, UsageSummary
 
 from .agentic import AgenticBackend
@@ -44,6 +44,7 @@ _RETRY_AT_RE = re.compile(r"try again at\s+(\d{1,2}):(\d{2})\s*([AaPp][Mm])")
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 _CODEX_USAGE_SOURCE = "codex_cli_turn_completed"
 _CODEX_CHILD_USAGE_SOURCE = "codex_rollout_child_token_count"
+_CODEX_CHILD_USAGE_COMPATIBLE_VERSIONS = frozenset({3, CODEX_CHILD_USAGE_VERSION})
 _MODEL_ACTIVITY_ITEM_TYPES = frozenset(
     {
         "agent_message",
@@ -55,6 +56,10 @@ _MODEL_ACTIVITY_ITEM_TYPES = frozenset(
         "web_search",
         "todo_list",
     }
+)
+# Item types that are a tool call rather than the model thinking out loud.
+_TOOL_ITEM_TYPES = frozenset(
+    {"command_execution", "file_change", "mcp_tool_call", "collab_tool_call", "todo_list", "web_search"}
 )
 _STREAM_LAG_RE = re.compile(r"event stream lagged; dropped\s+\d+\s+events?", re.IGNORECASE)
 
@@ -82,6 +87,12 @@ class _CodexChildUsageAudit:
     requests: tuple[RequestUsage, ...]
     complete: bool
     warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _CodexChildToolAudit:
+    root_thread_id: str
+    tool_calls: toolcalls.ToolCallSummary
 
 
 @dataclass(frozen=True)
@@ -174,7 +185,9 @@ def _parse_child_usage_audit(
     event: dict[str, Any],
 ) -> tuple[_CodexChildUsageAudit | None, tuple[str, ...]]:
     version = event.get("version")
-    if type(version) is not int or version != CODEX_CHILD_USAGE_VERSION:
+    # v4 only adds the independent tool-call tally; its usage payload is still
+    # wire-compatible with v3 records that may already be archived.
+    if type(version) is not int or version not in _CODEX_CHILD_USAGE_COMPATIBLE_VERSIONS:
         return None, ("Codex child-usage audit has an unsupported version",)
 
     root_thread_id = event.get("root_thread_id")
@@ -278,6 +291,24 @@ def _parse_child_usage_audit(
         ),
         (),
     )
+
+
+def _parse_child_tool_audit(
+    event: dict[str, Any],
+) -> tuple[_CodexChildToolAudit | None, tuple[str, ...]]:
+    """Validate the tool-only, privacy-preserving part of a child audit."""
+
+    version = event.get("version")
+    if type(version) is not int or version != CODEX_CHILD_USAGE_VERSION:
+        return None, ("Codex child tool-call audit has an unsupported version",)
+    root_thread_id = event.get("root_thread_id")
+    if not isinstance(root_thread_id, str) or not root_thread_id:
+        return None, ("Codex child tool-call audit has no root thread ID",)
+    raw_summary = event.get("tool_calls")
+    summary = toolcalls.ToolCallSummary.from_dict(raw_summary)
+    if not isinstance(raw_summary, dict) or not summary.available:
+        return None, ("Codex child tool-call audit is missing or invalid",)
+    return _CodexChildToolAudit(root_thread_id=root_thread_id, tool_calls=summary), ()
 
 
 def _request_token_totals(requests: tuple[RequestUsage, ...]) -> tuple[int, int, int, int, int]:
@@ -636,6 +667,297 @@ def _parse_codex_run(jsonl_path: str) -> _ParsedCodexRun:
     )
 
 
+def _tool_command(item: dict[str, Any]) -> str | None:
+    command = item.get("command")
+    return command if item.get("type") == "command_execution" and isinstance(command, str) else None
+
+
+def _same_tool_item(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    return left.get("type") == right.get("type") and _tool_command(left) == _tool_command(right)
+
+
+def _parse_tool_calls(jsonl_path: str) -> toolcalls.ToolCallSummary:
+    """Count root dispatches and merge the wrapper's sanitized child tally."""
+
+    evidence = toolcalls.EventStreamEvidence()
+    starts: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+    updates: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+    completions: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+    anonymous_starts: list[tuple[int, dict[str, Any]]] = []
+    anonymous_updates: list[tuple[int, dict[str, Any]]] = []
+    anonymous_completions: list[tuple[int, dict[str, Any]]] = []
+    root_thread_ids: list[str | None] = []
+    root_thread_indexes: list[int] = []
+    turn_started_indexes: list[int] = []
+    terminals: list[tuple[int, str]] = []
+    trailing_root_activity = False
+    saw_stream_lag = False
+    saw_multi_agent_activity = False
+    child_audit_starts = 0
+    child_audit_events = 0
+    child_audits: list[_CodexChildToolAudit] = []
+    warnings: list[str] = []
+
+    for index, event in enumerate(toolcalls.iter_events(jsonl_path, evidence)):
+        event_type = event.get("type")
+        if terminals and event_type in {"turn.started", "turn.completed", "turn.failed"}:
+            trailing_root_activity = True
+        if event_type == "thread.started":
+            thread_id = event.get("thread_id")
+            root_thread_ids.append(thread_id if isinstance(thread_id, str) and thread_id else None)
+            root_thread_indexes.append(index)
+        elif event_type == "turn.started":
+            turn_started_indexes.append(index)
+        elif event_type in {"turn.completed", "turn.failed"}:
+            terminals.append((index, event_type))
+        elif event_type == CODEX_CHILD_USAGE_START_EVENT:
+            child_audit_starts += 1
+        elif event_type == CODEX_CHILD_USAGE_EVENT:
+            child_audit_events += 1
+            audit, audit_warnings = _parse_child_tool_audit(event)
+            warnings.extend(audit_warnings)
+            if audit is not None:
+                child_audits.append(audit)
+
+        item = event.get("item")
+        if not event_type.startswith("item."):
+            continue
+        if not isinstance(item, dict):
+            evidence.warn("Codex item event has an invalid item object")
+            continue
+        if terminals and index > terminals[-1][0]:
+            trailing_root_activity = True
+        item_type = item.get("type")
+        if not isinstance(item_type, str):
+            evidence.warn("Codex item event has a missing or invalid item type")
+            continue
+        if item_type == "collab_tool_call":
+            saw_multi_agent_activity = True
+        elif item_type == "error":
+            message = item.get("message")
+            if isinstance(message, str) and _STREAM_LAG_RE.search(message):
+                saw_stream_lag = True
+        if item_type not in _TOOL_ITEM_TYPES or event_type not in {
+            "item.started",
+            "item.updated",
+            "item.completed",
+        }:
+            continue
+        item_id = item.get("id")
+        if event_type == "item.started":
+            target, anonymous = starts, anonymous_starts
+        elif event_type == "item.updated":
+            target, anonymous = updates, anonymous_updates
+        else:
+            target, anonymous = completions, anonymous_completions
+        if isinstance(item_id, str) and item_id:
+            target.setdefault(item_id, []).append((index, item))
+        else:
+            anonymous.append((index, item))
+
+    lifecycle_complete = True
+    if saw_stream_lag:
+        evidence.warn("Codex reported dropped JSONL events; tool-call totals may be incomplete")
+    if len(root_thread_ids) != 1 or root_thread_ids[0] is None:
+        warnings.append("Codex tool-call stream does not identify exactly one primary thread")
+        lifecycle_complete = False
+    if len(turn_started_indexes) != 1:
+        warnings.append("Codex tool-call stream does not contain exactly one turn.started event")
+        lifecycle_complete = False
+    if len(terminals) != 1 or terminals[0][1] not in {"turn.completed", "turn.failed"}:
+        warnings.append("Codex tool-call stream did not end in one terminal turn event")
+        lifecycle_complete = False
+    if trailing_root_activity:
+        warnings.append("Codex tool-call stream contains item activity after its terminal event")
+        lifecycle_complete = False
+    if (
+        len(root_thread_indexes) == 1
+        and len(turn_started_indexes) == 1
+        and len(terminals) == 1
+        and not (root_thread_indexes[0] < turn_started_indexes[0] < terminals[0][0])
+    ):
+        warnings.append("Codex tool-call stream has an invalid thread/turn event order")
+        lifecycle_complete = False
+
+    tool_item_indexes = [
+        index
+        for entries in (
+            *starts.values(),
+            *updates.values(),
+            *completions.values(),
+            anonymous_starts,
+            anonymous_updates,
+            anonymous_completions,
+        )
+        for index, _item in entries
+    ]
+    if (
+        tool_item_indexes
+        and len(turn_started_indexes) == 1
+        and len(terminals) == 1
+        and any(not (turn_started_indexes[0] < index < terminals[0][0]) for index in tool_item_indexes)
+    ):
+        warnings.append("Codex tool-call stream contains tool activity outside its active turn")
+        lifecycle_complete = False
+
+    observed: list[tuple[int, str | None]] = []
+    all_item_ids = set(starts) | set(updates) | set(completions)
+    todo_ids = {
+        item_id
+        for item_id in all_item_ids
+        if any(
+            item.get("type") == "todo_list"
+            for entries in (starts.get(item_id, ()), updates.get(item_id, ()), completions.get(item_id, ()))
+            for _index, item in entries
+        )
+    }
+    for item_id in sorted(
+        todo_ids,
+        key=lambda candidate: min(
+            index
+            for entries in (starts.get(candidate, ()), updates.get(candidate, ()), completions.get(candidate, ()))
+            for index, _item in entries
+        ),
+    ):
+        started = starts.get(item_id, [])
+        updated = updates.get(item_id, [])
+        completed = completions.get(item_id, [])
+        all_entries = [*started, *updated, *completed]
+        if started:
+            observed.append((started[0][0], _tool_command(started[0][1])))
+        todo_updates = [(index, item) for index, item in updated if item.get("type") == "todo_list"]
+        observed.extend((index, None) for index, _item in todo_updates)
+        if not started and not todo_updates and completed:
+            observed.append((completed[0][0], _tool_command(completed[0][1])))
+
+        if any(item.get("type") != "todo_list" for _index, item in all_entries):
+            warnings.append(f"Codex todo item {item_id} conflicts with another tool item type")
+            lifecycle_complete = False
+        if len(started) != 1:
+            warning = "has no started event" if not started else "has duplicate started events"
+            warnings.append(f"Codex todo item {item_id} {warning}")
+            lifecycle_complete = False
+        if len(completed) != 1:
+            warning = "did not complete" if not completed else "has duplicate completed events"
+            warnings.append(f"Codex todo item {item_id} {warning}")
+            lifecycle_complete = False
+        if started and completed:
+            start_index = started[0][0]
+            completion_index = completed[0][0]
+            if completion_index <= start_index or any(
+                not (start_index < update_index < completion_index) for update_index, _item in updated
+            ):
+                warnings.append(f"Codex todo item {item_id} has an invalid update lifecycle")
+                lifecycle_complete = False
+
+    for item_id, entries in starts.items():
+        if item_id in todo_ids:
+            continue
+        first_index, first_item = entries[0]
+        observed.append((first_index, _tool_command(first_item)))
+        if len(entries) > 1:
+            warnings.append(f"Codex tool item {item_id} has duplicate started events")
+            lifecycle_complete = False
+        if any(not _same_tool_item(first_item, item) for _, item in entries[1:]):
+            warnings.append(f"Codex tool item {item_id} has conflicting started events")
+            lifecycle_complete = False
+        completed = completions.get(item_id, [])
+        if not completed:
+            warnings.append(f"Codex tool item {item_id} started but did not complete")
+            lifecycle_complete = False
+        else:
+            if len(completed) > 1:
+                warnings.append(f"Codex tool item {item_id} has duplicate completed events")
+                lifecycle_complete = False
+            if any(index <= first_index or not _same_tool_item(first_item, item) for index, item in completed):
+                warnings.append(f"Codex tool item {item_id} has an inconsistent completed event")
+                lifecycle_complete = False
+            first_completed = completed[0][1]
+            if any(not _same_tool_item(first_completed, item) for _, item in completed[1:]):
+                warnings.append(f"Codex tool item {item_id} has conflicting completed events")
+                lifecycle_complete = False
+    for item_id, entries in completions.items():
+        if item_id in starts or item_id in todo_ids:
+            continue
+        first_index, first_item = entries[0]
+        observed.append((first_index, _tool_command(first_item)))
+        warnings.append(f"Codex tool item {item_id} completed without a recorded start")
+        lifecycle_complete = False
+        if len(entries) > 1:
+            warnings.append(f"Codex tool item {item_id} has duplicate completed events")
+        if any(not _same_tool_item(first_item, item) for _, item in entries[1:]):
+            warnings.append(f"Codex tool item {item_id} has conflicting completed events")
+    for item_id, entries in updates.items():
+        if item_id in todo_ids:
+            continue
+        warnings.append(f"Codex tool item {item_id} has an unexpected updated event")
+        lifecycle_complete = False
+        if item_id not in starts and item_id not in completions:
+            first_index, first_item = entries[0]
+            observed.append((first_index, _tool_command(first_item)))
+    # Without IDs, repeated lifecycle records cannot be distinguished from
+    # repeated calls.  Keep one positive dispatch witness per signature so the
+    # degraded result remains a genuine lower bound instead of over-counting a
+    # replayed start or completion.
+    anonymous_witnesses = [*anonymous_starts, *anonymous_updates, *anonymous_completions]
+    if anonymous_witnesses and not starts and not updates and not completions:
+        index, item = min(anonymous_witnesses, key=lambda entry: entry[0])
+        observed.append((index, _tool_command(item)))
+    if anonymous_starts or anonymous_updates or anonymous_completions:
+        warnings.append("Codex tool-call stream contains tool items without IDs")
+        lifecycle_complete = False
+
+    observed.sort(key=lambda entry: entry[0])
+    summary = toolcalls.summarize(
+        (command for _, command in observed),
+        evidence,
+        lifecycle_complete=lifecycle_complete,
+        warnings=warnings,
+    )
+
+    if child_audit_starts == 0:
+        if child_audit_events:
+            return summary.merge(
+                toolcalls.ToolCallSummary.from_commands(
+                    (),
+                    available=True,
+                    complete=False,
+                    warnings=("Codex child tool-call audit appeared without its start sentinel",),
+                )
+            )
+        if saw_multi_agent_activity:
+            return summary.merge(
+                toolcalls.ToolCallSummary.from_commands(
+                    (),
+                    available=True,
+                    complete=False,
+                    warnings=("Codex multi-agent activity has no child tool-call audit",),
+                )
+            )
+        return summary
+
+    if child_audit_starts != 1 or child_audit_events != 1 or len(child_audits) != 1:
+        return summary.merge(
+            toolcalls.ToolCallSummary.from_commands(
+                (),
+                available=True,
+                complete=False,
+                warnings=("Codex child tool-call audit is missing or ambiguous",),
+            )
+        )
+    child_audit = child_audits[0]
+    if len(root_thread_ids) != 1 or root_thread_ids[0] != child_audit.root_thread_id:
+        return summary.merge(
+            toolcalls.ToolCallSummary.from_commands(
+                (),
+                available=True,
+                complete=False,
+                warnings=("Codex child tool-call audit does not match the primary thread",),
+            )
+        )
+    return summary.merge(child_audit.tool_calls)
+
+
 class CodexBackend(AgenticBackend):
     name = "codex"
     requires_public_pricing = True
@@ -899,6 +1221,9 @@ class CodexBackend(AgenticBackend):
             return target
         except Exception:
             return None
+
+    def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
+        return {"tool_calls": _parse_tool_calls(jsonl_path).to_dict()}
 
     def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         parsed = _parse_codex_run(jsonl_path)

--- a/src/evaluator/backends/codex_usage_wrapper.py
+++ b/src/evaluator/backends/codex_usage_wrapper.py
@@ -9,8 +9,10 @@ Prompts and other rollout content never leave the Codex state directory.
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import os
+import shlex
 import subprocess
 import sys
 from collections.abc import Iterable, Sequence
@@ -18,9 +20,20 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
+import tree_sitter_javascript
+from tree_sitter import Language, Node, Parser
+
+if __package__:
+    from evaluator import toolcalls as _toolcalls
+else:
+    # Local evaluator runs execute this file by path, so Python otherwise adds
+    # only ``.../backends`` to sys.path while the shared module lives one level up.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import toolcalls as _toolcalls
+
 CODEX_CHILD_USAGE_EVENT = "tlaps.codex_child_usage"
 CODEX_CHILD_USAGE_START_EVENT = "tlaps.codex_child_usage.started"
-CODEX_CHILD_USAGE_VERSION = 3
+CODEX_CHILD_USAGE_VERSION = 4
 
 _TOKEN_FIELDS = (
     "input_tokens",
@@ -31,6 +44,8 @@ _TOKEN_FIELDS = (
 )
 _TURN_STARTED_TYPES = frozenset({"task_started", "turn_started"})
 _TURN_COMPLETED_TYPES = frozenset({"task_complete", "turn_complete"})
+_CONTINUATION_TOOL_NAMES = frozenset({"wait", "write_stdin"})
+_JAVASCRIPT_LANGUAGE = Language(tree_sitter_javascript.language())
 
 
 @dataclass(frozen=True)
@@ -63,6 +78,8 @@ class _TimelineItem:
     turn_id: str | None = None
     totals: _TokenTotals | None = None
     model: str | None = None
+    tool_id: str | None = None
+    command: str | None = None
 
 
 @dataclass(frozen=True)
@@ -94,6 +111,7 @@ class _UsageRollout:
     timeline: tuple[_TimelineItem, ...]
     referenced_child_ids: frozenset[str]
     invalid_indexes: tuple[int, ...]
+    tool_invalid_indexes: tuple[int, ...]
     unsupported_service_tier: bool
 
     @property
@@ -103,6 +121,10 @@ class _UsageRollout:
     @property
     def structurally_complete(self) -> bool:
         return not self.invalid_indexes
+
+    @property
+    def tool_structurally_complete(self) -> bool:
+        return not self.tool_invalid_indexes
 
 
 def _strict_token(value: object) -> int | None:
@@ -150,15 +172,162 @@ def _parse_meta_record(value: object) -> _RolloutMeta | None:
     )
 
 
+def _call_arguments(value: object) -> dict[str, object] | None:
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _shell_command(value: object) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list) and all(isinstance(part, str) for part in value):
+        return shlex.join(value)
+    return None
+
+
+def _javascript_text(source: bytes, node: Node) -> str:
+    return source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+def _javascript_nodes(root: Node) -> Iterable[Node]:
+    pending = [root]
+    while pending:
+        node = pending.pop()
+        yield node
+        pending.extend(reversed(node.named_children))
+
+
+def _javascript_static_string(source: bytes, node: Node) -> str | None:
+    if node.type != "string":
+        return None
+    raw = _javascript_text(source, node)
+    try:
+        value = json.loads(raw) if raw.startswith('"') else ast.literal_eval(raw)
+    except (json.JSONDecodeError, SyntaxError, ValueError):
+        return None
+    return value if isinstance(value, str) else None
+
+
+def _javascript_object_command(source: bytes, node: Node) -> str | None:
+    """Return one unambiguous literal ``cmd`` property from an object."""
+
+    command: str | None = None
+    for child in node.named_children:
+        # Spreads, computed properties, and methods can override ``cmd`` at
+        # runtime. Keep those objects conservative instead of guessing.
+        if child.type != "pair":
+            return None
+        key = child.child_by_field_name("key")
+        value = child.child_by_field_name("value")
+        if key is None or value is None:
+            return None
+        key_name = (
+            _javascript_text(source, key)
+            if key.type in {"identifier", "property_identifier"}
+            else _javascript_static_string(source, key)
+        )
+        if key_name is None:
+            return None
+        if key_name != "cmd":
+            continue
+        if command is not None:
+            return None
+        command = _javascript_static_string(source, value)
+        if command is None:
+            return None
+    return command
+
+
+def _code_mode_shell_commands(value: object) -> tuple[str, ...]:
+    """Extract literal ``tools.exec_command`` commands from one code-mode call."""
+
+    if not isinstance(value, str):
+        return ()
+    source = value.encode("utf-8", errors="replace")
+    tree = Parser(_JAVASCRIPT_LANGUAGE).parse(source)
+    if tree.root_node.has_error:
+        return ()
+
+    commands: list[str] = []
+    for node in _javascript_nodes(tree.root_node):
+        if node.type != "call_expression":
+            continue
+        function = node.child_by_field_name("function")
+        if function is None or _javascript_text(source, function) != "tools.exec_command":
+            continue
+        arguments = node.child_by_field_name("arguments")
+        if arguments is None or not arguments.named_children:
+            continue
+        options = arguments.named_children[0]
+        if options.type != "object":
+            continue
+        command = _javascript_object_command(source, options)
+        if command is not None:
+            commands.append(command)
+    return tuple(commands)
+
+
+def _tool_dispatch(payload: dict[str, object]) -> tuple[str | None, str | None] | None:
+    """Extract one sanitized rollout dispatch, excluding command polling."""
+
+    item_type = payload.get("type")
+    if item_type == "function_call":
+        name = payload.get("name")
+        if name in _CONTINUATION_TOOL_NAMES:
+            return None
+        call_id = payload.get("call_id")
+        command = None
+        if name in {"exec_command", "shell_command"}:
+            arguments = _call_arguments(payload.get("arguments"))
+            if arguments is not None:
+                command_key = "cmd" if name == "exec_command" else "command"
+                command = _shell_command(arguments.get(command_key))
+        return (call_id if isinstance(call_id, str) and call_id else None, command)
+    if item_type == "custom_tool_call":
+        name = payload.get("name")
+        if name in _CONTINUATION_TOOL_NAMES:
+            return None
+        call_id = payload.get("call_id")
+        commands = _code_mode_shell_commands(payload.get("input")) if name == "exec" else ()
+        command = "\n".join(commands) if commands else None
+        return (call_id if isinstance(call_id, str) and call_id else None, command)
+    if item_type == "local_shell_call":
+        item_id = payload.get("id")
+        action = payload.get("action")
+        command = _shell_command(action.get("command")) if isinstance(action, dict) else None
+        return (item_id if isinstance(item_id, str) and item_id else None, command)
+    if item_type in {"computer_call", "mcp_tool_call", "tool_search_call", "web_search_call"}:
+        raw_call_id = payload.get("call_id")
+        item_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id else payload.get("id")
+        return (item_id if isinstance(item_id, str) and item_id else None, None)
+    return None
+
+
 def _read_usage_rollout(path: Path) -> _UsageRollout | None:
     meta: _RolloutMeta | None = None
     timeline: list[_TimelineItem] = []
     referenced_child_ids: set[str] = set()
     invalid_indexes: list[int] = []
+    tool_invalid_indexes: list[int] = []
     unsupported_service_tier = False
     try:
-        with path.open(encoding="utf-8") as rollout:
-            for index, raw in enumerate(rollout):
+        with path.open("rb") as rollout:
+            for index, raw_bytes in enumerate(rollout):
+                try:
+                    raw = raw_bytes.decode("utf-8")
+                except UnicodeError:
+                    if index == 0:
+                        return None
+                    invalid_indexes.append(index)
+                    tool_invalid_indexes.append(index)
+                    continue
                 if not raw.strip():
                     continue
                 try:
@@ -167,18 +336,25 @@ def _read_usage_rollout(path: Path) -> _UsageRollout | None:
                     if index == 0:
                         return None
                     invalid_indexes.append(index)
+                    tool_invalid_indexes.append(index)
                     continue
                 if not isinstance(record, dict):
                     if index == 0:
                         return None
                     invalid_indexes.append(index)
+                    tool_invalid_indexes.append(index)
                     continue
                 if index == 0:
                     meta = _parse_meta_record(record)
                     if meta is None:
                         return None
                     continue
-                if record.get("type") == "turn_context":
+                record_type = record.get("type")
+                if not isinstance(record_type, str):
+                    invalid_indexes.append(index)
+                    tool_invalid_indexes.append(index)
+                    continue
+                if record_type == "turn_context":
                     payload = record.get("payload")
                     turn_id = payload.get("turn_id") if isinstance(payload, dict) else None
                     model = payload.get("model") if isinstance(payload, dict) else None
@@ -187,13 +363,33 @@ def _read_usage_rollout(path: Path) -> _UsageRollout | None:
                     else:
                         invalid_indexes.append(index)
                     continue
-                if record.get("type") != "event_msg":
+                if record_type == "response_item":
+                    payload = record.get("payload")
+                    if not isinstance(payload, dict):
+                        invalid_indexes.append(index)
+                        tool_invalid_indexes.append(index)
+                        continue
+                    if not isinstance(payload.get("type"), str):
+                        invalid_indexes.append(index)
+                        tool_invalid_indexes.append(index)
+                        continue
+                    dispatch = _tool_dispatch(payload)
+                    if dispatch is not None:
+                        tool_id, command = dispatch
+                        timeline.append(_TimelineItem(index=index, kind="tool", tool_id=tool_id, command=command))
+                    continue
+                if record_type != "event_msg":
                     continue
                 payload = record.get("payload")
                 if not isinstance(payload, dict):
                     invalid_indexes.append(index)
+                    tool_invalid_indexes.append(index)
                     continue
                 event_type = payload.get("type")
+                if not isinstance(event_type, str):
+                    invalid_indexes.append(index)
+                    tool_invalid_indexes.append(index)
+                    continue
                 if event_type == "thread_settings_applied":
                     settings = payload.get("thread_settings")
                     if not isinstance(settings, dict):
@@ -219,26 +415,31 @@ def _read_usage_rollout(path: Path) -> _UsageRollout | None:
                         timeline.append(_TimelineItem(index=index, kind="started", turn_id=turn_id))
                     else:
                         invalid_indexes.append(index)
+                        tool_invalid_indexes.append(index)
                 elif event_type in _TURN_COMPLETED_TYPES:
                     turn_id = payload.get("turn_id")
                     if isinstance(turn_id, str) and turn_id:
                         timeline.append(_TimelineItem(index=index, kind="completed", turn_id=turn_id))
                     else:
                         invalid_indexes.append(index)
+                        tool_invalid_indexes.append(index)
                 elif event_type == "turn_aborted":
                     turn_id = payload.get("turn_id")
                     if turn_id is None or (isinstance(turn_id, str) and turn_id):
                         timeline.append(_TimelineItem(index=index, kind="aborted", turn_id=turn_id))
                     else:
                         invalid_indexes.append(index)
+                        tool_invalid_indexes.append(index)
                 elif event_type == "sub_agent_activity":
                     child_thread_id = payload.get("agent_thread_id")
                     if isinstance(child_thread_id, str) and child_thread_id:
                         referenced_child_ids.add(child_thread_id)
                     else:
                         invalid_indexes.append(index)
-    except (OSError, UnicodeError):
+                        tool_invalid_indexes.append(index)
+    except OSError:
         invalid_indexes.append(len(timeline) + 1)
+        tool_invalid_indexes.append(len(timeline) + 1)
     if meta is None:
         return None
     return _UsageRollout(
@@ -246,6 +447,7 @@ def _read_usage_rollout(path: Path) -> _UsageRollout | None:
         timeline=tuple(timeline),
         referenced_child_ids=frozenset(referenced_child_ids),
         invalid_indexes=tuple(invalid_indexes),
+        tool_invalid_indexes=tuple(tool_invalid_indexes),
         unsupported_service_tier=unsupported_service_tier,
     )
 
@@ -376,6 +578,125 @@ def _analyze_rollout(
     return safe_delta, tuple(requests), warning_codes
 
 
+def _analyze_tool_rollout(
+    rollout: _UsageRollout,
+    parent: _UsageRollout | None,
+    *,
+    allow_empty: bool,
+) -> tuple[list[str | None], set[str]]:
+    """Return this rollout's own dispatches, excluding inherited fork history."""
+
+    warning_codes: set[str] = set()
+    inherited_turn_ids: frozenset[str] = frozenset()
+    forked = rollout.meta.forked_from_id is not None
+    if forked:
+        if (
+            parent is None
+            or not parent.tool_structurally_complete
+            or rollout.meta.forked_from_id != rollout.meta.parent_thread_id
+        ):
+            return [], {"child_tool_boundary_unavailable"}
+        inherited_turn_ids = parent.turn_ids
+
+    own_starts = [
+        item for item in rollout.timeline if item.kind == "started" and item.turn_id not in inherited_turn_ids
+    ]
+    # Only forked rollouts contain an inherited parent prefix. A direct child
+    # may be truncated before its first task_started record; keep any earlier
+    # tool evidence so it cannot be published as an exact zero.
+    boundary = own_starts[0].index if forked and own_starts else 0
+    if forked and not own_starts:
+        if not rollout.tool_structurally_complete:
+            warning_codes.add("child_tool_stream_invalid")
+        if not allow_empty:
+            warning_codes.add("child_tool_lifecycle_invalid")
+    if forked and own_starts and any(index < boundary for index in rollout.tool_invalid_indexes):
+        return [], {"child_tool_boundary_unavailable"}
+
+    prefix_tool_indexes_to_skip: set[int] = set()
+    if forked:
+        assert parent is not None
+        parent_tool_pairs = {
+            (item.tool_id, item.command) for item in parent.timeline if item.kind == "tool" and item.tool_id is not None
+        }
+        parent_tool_ids = {tool_id for tool_id, _command in parent_tool_pairs}
+        for item in rollout.timeline:
+            if item.kind != "tool" or (own_starts and item.index >= boundary):
+                continue
+            if item.tool_id is not None and (item.tool_id, item.command) in parent_tool_pairs:
+                prefix_tool_indexes_to_skip.add(item.index)
+                continue
+            warning_codes.add("child_tool_boundary_unavailable")
+            # An ID-less record, or an ID whose payload conflicts with the
+            # parent, may be a replay of inherited history. Do not double-count
+            # it. A new stable ID is independent positive child evidence.
+            if item.tool_id is None or item.tool_id in parent_tool_ids:
+                prefix_tool_indexes_to_skip.add(item.index)
+
+    commands: list[str | None] = []
+    active_turns: set[str] = set()
+    finished_turns: set[str] = set()
+    seen_tools: dict[str, str | None] = {}
+    seen_tool_indexes: dict[str, int] = {}
+    anonymous_tool_observed = False
+    anonymous_command_index: int | None = None
+    for item in rollout.timeline:
+        if item.turn_id in inherited_turn_ids:
+            continue
+        if (
+            forked
+            and (not own_starts or item.index < boundary)
+            and (item.kind != "tool" or item.index in prefix_tool_indexes_to_skip)
+        ):
+            continue
+        if item.kind == "started" and item.turn_id:
+            if active_turns or item.turn_id in finished_turns:
+                warning_codes.add("child_tool_lifecycle_invalid")
+            active_turns.add(item.turn_id)
+        elif item.kind == "completed" and item.turn_id:
+            if item.turn_id not in active_turns:
+                warning_codes.add("child_tool_lifecycle_invalid")
+            active_turns.discard(item.turn_id)
+            finished_turns.add(item.turn_id)
+        elif item.kind == "aborted":
+            # Aborted is still an explicit terminal for dispatch enumeration;
+            # failure status alone does not imply that earlier tool records are
+            # missing. Orphan/ambiguous aborts remain lifecycle gaps.
+            if item.turn_id and item.turn_id in active_turns:
+                active_turns.discard(item.turn_id)
+                finished_turns.add(item.turn_id)
+            else:
+                warning_codes.add("child_tool_lifecycle_invalid")
+        elif item.kind == "tool":
+            if len(active_turns) != 1:
+                warning_codes.add("child_tool_lifecycle_invalid")
+            if item.tool_id is None:
+                # ID-less records cannot prove whether repeated payloads are
+                # separate dispatches. Keep one witness so the degraded count
+                # remains a genuine lower bound.
+                if not anonymous_tool_observed:
+                    anonymous_command_index = len(commands)
+                    commands.append(item.command)
+                    anonymous_tool_observed = True
+                warning_codes.add("child_tool_id_invalid")
+            elif item.tool_id not in seen_tools:
+                seen_tools[item.tool_id] = item.command
+                seen_tool_indexes[item.tool_id] = len(commands)
+                commands.append(item.command)
+            else:
+                warning_codes.add("child_tool_id_duplicate")
+                if seen_tools[item.tool_id] != item.command:
+                    commands[seen_tool_indexes[item.tool_id]] = None
+                    warning_codes.add("child_tool_id_conflict")
+    if seen_tools and anonymous_command_index is not None:
+        commands.pop(anonymous_command_index)
+    if active_turns or (not own_starts and not allow_empty):
+        warning_codes.add("child_tool_lifecycle_invalid")
+    if not rollout.tool_structurally_complete:
+        warning_codes.add("child_tool_stream_invalid")
+    return commands, warning_codes
+
+
 def _belongs_to_tree(thread_id: str, root_thread_id: str, by_thread: dict[str, _UsageRollout]) -> bool:
     seen: set[str] = set()
     while thread_id != root_thread_id:
@@ -393,16 +714,19 @@ def collect_child_usage(root_thread_id: str, candidate_paths: Iterable[Path]) ->
     """Build a sanitized audit for one newly-created Codex session tree."""
 
     warning_codes: set[str] = set()
+    tool_warning_codes: set[str] = set()
     by_thread: dict[str, _UsageRollout] = {}
     duplicate_thread_ids: set[str] = set()
     for path in sorted(candidate_paths):
         rollout = _read_usage_rollout(path)
         if rollout is None:
             warning_codes.add("new_rollout_metadata_invalid")
+            tool_warning_codes.add("new_rollout_metadata_invalid")
         elif rollout.meta.session_id != root_thread_id or rollout.meta.thread_id in duplicate_thread_ids:
             continue
         elif rollout.meta.thread_id in by_thread:
             warning_codes.add("duplicate_thread_rollout")
+            tool_warning_codes.add("duplicate_thread_rollout")
             by_thread.pop(rollout.meta.thread_id)
             duplicate_thread_ids.add(rollout.meta.thread_id)
         else:
@@ -418,24 +742,30 @@ def collect_child_usage(root_thread_id: str, candidate_paths: Iterable[Path]) ->
     requests: list[_SanitizedRequest] = []
     if not root_is_primary:
         warning_codes.add("root_rollout_missing")
+        tool_warning_codes.add("root_rollout_missing")
     else:
         assert root is not None
         _root_totals, root_requests, root_warnings = _analyze_rollout(root, None, allow_empty=True)
         requests.extend(root_requests)
         warning_codes.update(root_warnings)
+        _root_commands, root_tool_warnings = _analyze_tool_rollout(root, None, allow_empty=True)
+        tool_warning_codes.update(root_tool_warnings)
 
     known_thread_ids = set(by_thread)
     if any(rollout.referenced_child_ids - known_thread_ids for rollout in by_thread.values()):
         warning_codes.add("referenced_child_rollout_missing")
+        tool_warning_codes.add("referenced_child_rollout_missing")
 
     child_count = 0
     totals = _TokenTotals()
+    child_commands: list[str | None] = []
     for thread_id, rollout in sorted(by_thread.items()):
         if thread_id == root_thread_id:
             continue
         child_count += 1
         if not _belongs_to_tree(thread_id, root_thread_id, by_thread):
             warning_codes.add("thread_tree_invalid")
+            tool_warning_codes.add("thread_tree_invalid")
             continue
         parent_thread_id = rollout.meta.parent_thread_id
         child_totals, child_requests, child_warnings = _analyze_rollout(
@@ -446,6 +776,25 @@ def collect_child_usage(root_thread_id: str, candidate_paths: Iterable[Path]) ->
         totals += child_totals
         requests.extend(child_requests)
         warning_codes.update(child_warnings)
+        rollout_commands, rollout_tool_warnings = _analyze_tool_rollout(
+            rollout,
+            by_thread.get(parent_thread_id) if parent_thread_id else None,
+            allow_empty=False,
+        )
+        child_commands.extend(rollout_commands)
+        tool_warning_codes.update(rollout_tool_warnings)
+
+    tool_warnings = (
+        (f"Codex child tool-call audit is incomplete ({', '.join(sorted(tool_warning_codes))})",)
+        if tool_warning_codes
+        else ()
+    )
+    child_tool_calls = _toolcalls.ToolCallSummary.from_commands(
+        child_commands,
+        available=True,
+        complete=not tool_warning_codes,
+        warnings=tool_warnings,
+    )
 
     return {
         "type": CODEX_CHILD_USAGE_EVENT,
@@ -456,6 +805,7 @@ def collect_child_usage(root_thread_id: str, candidate_paths: Iterable[Path]) ->
         "requests": [request.to_dict() for request in requests],
         "complete": not warning_codes,
         "warning_codes": sorted(warning_codes),
+        "tool_calls": child_tool_calls.to_dict(),
     }
 
 
@@ -564,6 +914,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "requests": [],
                 "complete": False,
                 "warning_codes": ["audit_failed"],
+                "tool_calls": _toolcalls.ToolCallSummary.from_commands(
+                    (),
+                    available=True,
+                    complete=False,
+                    warnings=("Codex child tool-call audit failed",),
+                ).to_dict(),
             }
         print(json.dumps(audit, separators=(",", ":"), sort_keys=True), flush=True)
     return return_code if return_code >= 0 else 128 - return_code

--- a/src/evaluator/backends/codex_usage_wrapper.py
+++ b/src/evaluator/backends/codex_usage_wrapper.py
@@ -1,9 +1,9 @@
-"""Stream ``codex exec`` JSONL and append a sanitized child-thread usage audit.
+"""Stream ``codex exec`` JSONL and append a sanitized rollout-tree audit.
 
 Codex's public ``turn.completed`` event reports only the primary thread. Rollout
 files persist native cumulative token counters for the full session tree, so this
-wrapper emits child aggregates plus sanitized per-request token/model metadata.
-Prompts and other rollout content never leave the Codex state directory.
+wrapper emits child token aggregates, session-tree tool calls, and sanitized
+per-request metadata. Prompts and rollout content never leave the state directory.
 """
 
 from __future__ import annotations
@@ -33,7 +33,7 @@ else:
 
 CODEX_CHILD_USAGE_EVENT = "tlaps.codex_child_usage"
 CODEX_CHILD_USAGE_START_EVENT = "tlaps.codex_child_usage.started"
-CODEX_CHILD_USAGE_VERSION = 4
+CODEX_CHILD_USAGE_VERSION = 5
 
 _TOKEN_FIELDS = (
     "input_tokens",
@@ -44,7 +44,6 @@ _TOKEN_FIELDS = (
 )
 _TURN_STARTED_TYPES = frozenset({"task_started", "turn_started"})
 _TURN_COMPLETED_TYPES = frozenset({"task_complete", "turn_complete"})
-_CONTINUATION_TOOL_NAMES = frozenset({"wait", "write_stdin"})
 _JAVASCRIPT_LANGUAGE = Language(tree_sitter_javascript.language())
 
 
@@ -275,13 +274,11 @@ def _code_mode_shell_commands(value: object) -> tuple[str, ...]:
 
 
 def _tool_dispatch(payload: dict[str, object]) -> tuple[str | None, str | None] | None:
-    """Extract one sanitized rollout dispatch, excluding command polling."""
+    """Extract one sanitized outer rollout dispatch."""
 
     item_type = payload.get("type")
     if item_type == "function_call":
         name = payload.get("name")
-        if name in _CONTINUATION_TOOL_NAMES:
-            return None
         call_id = payload.get("call_id")
         command = None
         if name in {"exec_command", "shell_command"}:
@@ -292,18 +289,23 @@ def _tool_dispatch(payload: dict[str, object]) -> tuple[str | None, str | None] 
         return (call_id if isinstance(call_id, str) and call_id else None, command)
     if item_type == "custom_tool_call":
         name = payload.get("name")
-        if name in _CONTINUATION_TOOL_NAMES:
-            return None
         call_id = payload.get("call_id")
         commands = _code_mode_shell_commands(payload.get("input")) if name == "exec" else ()
         command = "\n".join(commands) if commands else None
         return (call_id if isinstance(call_id, str) and call_id else None, command)
     if item_type == "local_shell_call":
-        item_id = payload.get("id")
+        raw_call_id = payload.get("call_id")
+        item_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id else payload.get("id")
         action = payload.get("action")
         command = _shell_command(action.get("command")) if isinstance(action, dict) else None
         return (item_id if isinstance(item_id, str) and item_id else None, command)
-    if item_type in {"computer_call", "mcp_tool_call", "tool_search_call", "web_search_call"}:
+    if item_type in {
+        "computer_call",
+        "image_generation_call",
+        "mcp_tool_call",
+        "tool_search_call",
+        "web_search_call",
+    }:
         raw_call_id = payload.get("call_id")
         item_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id else payload.get("id")
         return (item_id if isinstance(item_id, str) and item_id else None, None)
@@ -711,7 +713,7 @@ def _belongs_to_tree(thread_id: str, root_thread_id: str, by_thread: dict[str, _
 
 
 def collect_child_usage(root_thread_id: str, candidate_paths: Iterable[Path]) -> dict[str, object]:
-    """Build a sanitized audit for one newly-created Codex session tree."""
+    """Build a sanitized usage and tool-call audit for one Codex session tree."""
 
     warning_codes: set[str] = set()
     tool_warning_codes: set[str] = set()
@@ -740,6 +742,7 @@ def collect_child_usage(root_thread_id: str, candidate_paths: Iterable[Path]) ->
         and root.meta.forked_from_id is None
     )
     requests: list[_SanitizedRequest] = []
+    session_commands: list[str | None] = []
     if not root_is_primary:
         warning_codes.add("root_rollout_missing")
         tool_warning_codes.add("root_rollout_missing")
@@ -748,7 +751,8 @@ def collect_child_usage(root_thread_id: str, candidate_paths: Iterable[Path]) ->
         _root_totals, root_requests, root_warnings = _analyze_rollout(root, None, allow_empty=True)
         requests.extend(root_requests)
         warning_codes.update(root_warnings)
-        _root_commands, root_tool_warnings = _analyze_tool_rollout(root, None, allow_empty=True)
+        root_commands, root_tool_warnings = _analyze_tool_rollout(root, None, allow_empty=True)
+        session_commands.extend(root_commands)
         tool_warning_codes.update(root_tool_warnings)
 
     known_thread_ids = set(by_thread)
@@ -758,7 +762,6 @@ def collect_child_usage(root_thread_id: str, candidate_paths: Iterable[Path]) ->
 
     child_count = 0
     totals = _TokenTotals()
-    child_commands: list[str | None] = []
     for thread_id, rollout in sorted(by_thread.items()):
         if thread_id == root_thread_id:
             continue
@@ -781,16 +784,16 @@ def collect_child_usage(root_thread_id: str, candidate_paths: Iterable[Path]) ->
             by_thread.get(parent_thread_id) if parent_thread_id else None,
             allow_empty=False,
         )
-        child_commands.extend(rollout_commands)
+        session_commands.extend(rollout_commands)
         tool_warning_codes.update(rollout_tool_warnings)
 
     tool_warnings = (
-        (f"Codex child tool-call audit is incomplete ({', '.join(sorted(tool_warning_codes))})",)
+        (f"Codex session-tree tool-call audit is incomplete ({', '.join(sorted(tool_warning_codes))})",)
         if tool_warning_codes
         else ()
     )
-    child_tool_calls = _toolcalls.ToolCallSummary.from_commands(
-        child_commands,
+    session_tool_calls = _toolcalls.ToolCallSummary.from_commands(
+        session_commands,
         available=True,
         complete=not tool_warning_codes,
         warnings=tool_warnings,
@@ -799,13 +802,14 @@ def collect_child_usage(root_thread_id: str, candidate_paths: Iterable[Path]) ->
     return {
         "type": CODEX_CHILD_USAGE_EVENT,
         "version": CODEX_CHILD_USAGE_VERSION,
+        "tool_calls_scope": "session_tree",
         "root_thread_id": root_thread_id,
         "child_count": child_count,
         **totals.to_dict(),
         "requests": [request.to_dict() for request in requests],
         "complete": not warning_codes,
         "warning_codes": sorted(warning_codes),
-        "tool_calls": child_tool_calls.to_dict(),
+        "tool_calls": session_tool_calls.to_dict(),
     }
 
 
@@ -908,6 +912,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             audit = {
                 "type": CODEX_CHILD_USAGE_EVENT,
                 "version": CODEX_CHILD_USAGE_VERSION,
+                "tool_calls_scope": "session_tree",
                 "root_thread_id": root_thread_id,
                 "child_count": 0,
                 **_TokenTotals().to_dict(),

--- a/src/evaluator/backends/copilot.py
+++ b/src/evaluator/backends/copilot.py
@@ -8,6 +8,7 @@ import subprocess
 from dataclasses import replace
 from typing import Any
 
+from evaluator import toolcalls
 from evaluator.usage import RequestUsage, UsageCost, UsageSummary, nonnegative_float, nonnegative_int
 
 from .agentic import AgenticBackend
@@ -318,6 +319,222 @@ def parse_copilot_otel(path: str) -> UsageSummary | None:
     return usage
 
 
+_COPILOT_ACTIVITY_EVENTS = frozenset(
+    {
+        "assistant.message",
+        "assistant.turn_start",
+        "tool.execution_start",
+        "tool.execution_complete",
+        "tool.execution_partial_result",
+    }
+)
+
+
+def _copilot_data(event: dict[str, Any]) -> dict[str, Any]:
+    data = event.get("data")
+    return data if isinstance(data, dict) else {}
+
+
+def _copilot_call(data: dict[str, Any], *, name_key: str) -> tuple[str | None, str | None]:
+    raw_name = data.get(name_key)
+    name = raw_name if isinstance(raw_name, str) and raw_name else None
+    arguments = data.get("arguments")
+    command = arguments.get("command") if name == "bash" and isinstance(arguments, dict) else None
+    return name, command if isinstance(command, str) else None
+
+
+def _same_copilot_call(left: tuple[object, str | None], right: tuple[object, str | None]) -> bool:
+    left_name, left_command = left
+    right_name, right_command = right
+    return left_name == right_name and (left_command is None or right_command is None or left_command == right_command)
+
+
+def _copilot_shutdown_type(event: dict[str, Any]) -> object:
+    return event.get("shutdownType", _copilot_data(event).get("shutdownType"))
+
+
+def _tool_call_summary(jsonl_path: str) -> toolcalls.ToolCallSummary:
+    """Count announced tool requests and require a final clean lifecycle envelope."""
+
+    evidence = toolcalls.EventStreamEvidence()
+    requests: dict[str, tuple[object, str | None]] = {}
+    starts: dict[str, tuple[object, str | None]] = {}
+    completions: set[str] = set()
+    request_indexes: dict[str, int] = {}
+    start_indexes: dict[str, int] = {}
+    completion_indexes: dict[str, int] = {}
+    partials: set[str] = set()
+    anonymous_witnesses: list[str | None] = []
+    lifecycle_valid = True
+    clean_terminals = 0
+    hard_terminal = False
+    activity_after_clean_terminal = False
+    warnings: list[str] = []
+
+    for event_index, event in enumerate(toolcalls.iter_events(jsonl_path, evidence)):
+        event_type = event.get("type")
+        if clean_terminals and event_type in _COPILOT_ACTIVITY_EVENTS:
+            activity_after_clean_terminal = True
+
+        if event_type == "result":
+            clean_terminals += 1
+        elif event_type == "session.shutdown":
+            if _copilot_shutdown_type(event) == "routine":
+                clean_terminals += 1
+            else:
+                hard_terminal = True
+        elif event_type == "abort" or (event_type == "session.error" and clean_terminals):
+            hard_terminal = True
+
+        if event_type == "assistant.message":
+            raw_data = event.get("data")
+            if not isinstance(raw_data, dict):
+                evidence.warn("Copilot assistant message has an invalid data object")
+                continue
+            data = raw_data
+            raw_requests = data.get("toolRequests", [])
+            if not isinstance(raw_requests, list):
+                lifecycle_valid = False
+                warnings.append("Copilot assistant message has invalid toolRequests")
+                continue
+            for request in raw_requests:
+                if not isinstance(request, dict):
+                    if not anonymous_witnesses:
+                        anonymous_witnesses.append(None)
+                    lifecycle_valid = False
+                    warnings.append("Copilot tool request is malformed")
+                    continue
+                call = _copilot_call(request, name_key="name")
+                if call[0] is None:
+                    lifecycle_valid = False
+                    warnings.append("Copilot tool request has a missing or invalid name")
+                raw_call_id = request.get("toolCallId")
+                call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id else None
+                if call_id is None:
+                    if not anonymous_witnesses:
+                        anonymous_witnesses.append(call[1])
+                    lifecycle_valid = False
+                    warnings.append("Copilot tool request has a missing or invalid toolCallId")
+                    continue
+                previous = requests.get(call_id)
+                if previous is not None:
+                    lifecycle_valid = False
+                    warning = (
+                        "Copilot tool-call stream contains a conflicting toolCallId"
+                        if not _same_copilot_call(previous, call)
+                        else "Copilot tool-call stream contains a duplicate toolCallId"
+                    )
+                    warnings.append(warning)
+                    continue
+                requests[call_id] = call
+                request_indexes[call_id] = event_index
+            continue
+
+        if event_type not in {
+            "tool.execution_start",
+            "tool.execution_partial_result",
+            "tool.execution_complete",
+        }:
+            continue
+
+        data = _copilot_data(event)
+        raw_call_id = data.get("toolCallId")
+        call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id else None
+        if call_id is None:
+            if not anonymous_witnesses:
+                anonymous_witnesses.append(None)
+            lifecycle_valid = False
+            warnings.append(f"Copilot {event_type} has a missing or invalid toolCallId")
+            continue
+
+        if event_type == "tool.execution_partial_result":
+            partials.add(call_id)
+            continue
+
+        if event_type == "tool.execution_start":
+            call = _copilot_call(data, name_key="toolName")
+            if call[0] is None:
+                lifecycle_valid = False
+                warnings.append("Copilot execution start has a missing or invalid toolName")
+            previous = starts.get(call_id)
+            if previous is not None:
+                lifecycle_valid = False
+                warning = (
+                    "Copilot tool-call stream contains a conflicting execution start"
+                    if not _same_copilot_call(previous, call)
+                    else "Copilot tool-call stream contains a duplicate execution start"
+                )
+                warnings.append(warning)
+            else:
+                starts[call_id] = call
+                start_indexes[call_id] = event_index
+            continue
+
+        if call_id in completions:
+            lifecycle_valid = False
+            warnings.append("Copilot tool-call stream contains a duplicate execution completion")
+            continue
+        completions.add(call_id)
+        completion_indexes[call_id] = event_index
+
+    commands: list[str | None] = []
+    all_call_ids = set(requests) | set(starts) | completions | partials
+    missing_requests = 0
+    missing_starts = 0
+    unfinished = 0
+    conflicts = 0
+    ordering_conflicts = 0
+    for call_id in all_call_ids:
+        request = requests.get(call_id)
+        start = starts.get(call_id)
+        call = request if request is not None else start
+        commands.append(call[1] if call is not None else None)
+        if request is None:
+            missing_requests += 1
+        if start is None:
+            missing_starts += 1
+        if call_id not in completions:
+            unfinished += 1
+        if request is not None and start is not None and not _same_copilot_call(request, start):
+            conflicts += 1
+        if request is not None and start is not None and call_id in completions:
+            if not (request_indexes[call_id] < start_indexes[call_id] < completion_indexes[call_id]):
+                ordering_conflicts += 1
+    if missing_requests:
+        lifecycle_valid = False
+        warnings.append(f"Copilot tool-call stream has {missing_requests} execution(s) without a tool request")
+    if missing_starts:
+        lifecycle_valid = False
+        warnings.append(f"Copilot tool-call stream has {missing_starts} execution(s) without a start event")
+    if unfinished:
+        lifecycle_valid = False
+        warnings.append(f"Copilot tool-call stream ended with {unfinished} unfinished tool execution(s)")
+    if conflicts:
+        lifecycle_valid = False
+        warnings.append(f"Copilot tool-call stream has {conflicts} request/start conflict(s)")
+    if ordering_conflicts:
+        lifecycle_valid = False
+        warnings.append(f"Copilot tool-call stream has {ordering_conflicts} out-of-order tool lifecycle(s)")
+    if not all_call_ids:
+        commands.extend(anonymous_witnesses)
+    if clean_terminals != 1:
+        warnings.append("Copilot tool-call stream has no unique clean terminal event")
+    if hard_terminal:
+        warnings.append("Copilot tool-call stream contains a terminal abort or error shutdown")
+    if activity_after_clean_terminal:
+        warnings.append("Copilot tool-call stream contains run activity after a clean terminal event")
+
+    lifecycle_complete = (
+        clean_terminals == 1 and not hard_terminal and not activity_after_clean_terminal and lifecycle_valid
+    )
+    return toolcalls.summarize(
+        commands,
+        evidence,
+        lifecycle_complete=lifecycle_complete,
+        warnings=warnings,
+    )
+
+
 class CopilotBackend(AgenticBackend):
     name = "copilot"
     requires_public_pricing = True
@@ -443,6 +660,9 @@ class CopilotBackend(AgenticBackend):
         # can't reach it: the GitHub MCP server is off (--disable-builtin-mcps)
         # and web_fetch is excluded, so this only enables the auth handshake.
         return detect_firewall_hosts(self.model) + ["api.github.com"]
+
+    def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
+        return {"tool_calls": _tool_call_summary(jsonl_path).to_dict()}
 
     def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         lines: list[str] = []

--- a/src/evaluator/backends/cursor.py
+++ b/src/evaluator/backends/cursor.py
@@ -9,6 +9,7 @@ import subprocess
 from ipaddress import ip_address
 from urllib.parse import urlparse
 
+from evaluator import toolcalls
 from evaluator.usage import UsageSummary
 
 from .agentic import AgenticBackend
@@ -51,6 +52,109 @@ def _result_usage(event: dict[str, object]) -> UsageSummary | None:
         sources=(_USAGE_SOURCE,),
         available=True,
         complete=True,
+    )
+
+
+def _cursor_call(event: dict[str, object]) -> tuple[str | None, str | None]:
+    call = event.get("tool_call")
+    if not isinstance(call, dict) or not call:
+        return None, None
+    kind = next(iter(call))
+    if kind != "shellToolCall":
+        return kind, None
+    body = call.get(kind)
+    args = body.get("args") if isinstance(body, dict) else None
+    command = args.get("command") if isinstance(args, dict) else None
+    return kind, command if isinstance(command, str) else None
+
+
+def _same_cursor_call(started: tuple[str | None, str | None], completed: tuple[str | None, str | None]) -> bool:
+    start_kind, start_command = started
+    completed_kind, completed_command = completed
+    return start_kind == completed_kind and (
+        start_command is None or completed_command is None or start_command == completed_command
+    )
+
+
+def _tool_call_summary(jsonl_path: str) -> toolcalls.ToolCallSummary:
+    """Count Cursor's started/completed pairs once and validate its final result."""
+
+    evidence = toolcalls.EventStreamEvidence()
+    commands: list[str | None] = []
+    starts: dict[str, tuple[str | None, str | None]] = {}
+    completed_ids: set[str] = set()
+    invalid_calls: dict[str, tuple[str | None, str | None]] = {}
+    anonymous_witnesses: list[str | None] = []
+    lifecycle_warnings: list[str] = []
+    result_count = 0
+    activity_after_result = False
+    for event in toolcalls.iter_events(jsonl_path, evidence):
+        event_type = event.get("type")
+        if event_type == "result":
+            result_count += 1
+            continue
+        if result_count and event_type in {"assistant", "system", "tool_call"}:
+            activity_after_result = True
+        if event_type != "tool_call":
+            continue
+        subtype = event.get("subtype")
+        raw_call = event.get("tool_call")
+        if not isinstance(raw_call, dict) or not raw_call or len(raw_call) != 1:
+            lifecycle_warnings.append("Cursor tool call has an invalid tool_call object")
+        call = _cursor_call(event)
+        kind, command = call
+        raw_call_id = event.get("call_id")
+        call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id else None
+        if not isinstance(subtype, str) or subtype not in {"started", "completed"}:
+            if call_id is None and not anonymous_witnesses:
+                anonymous_witnesses.append(command)
+            elif call_id is not None:
+                previous = invalid_calls.get(call_id)
+                if previous is None:
+                    invalid_calls[call_id] = call
+                elif not _same_cursor_call(previous, call):
+                    lifecycle_warnings.append("Cursor invalid lifecycle records disagree for one call_id")
+            lifecycle_warnings.append("Cursor tool-call stream contains an invalid lifecycle subtype")
+            continue
+        if call_id is None:
+            if not anonymous_witnesses:
+                anonymous_witnesses.append(command)
+            lifecycle_warnings.append("Cursor tool call has a missing or invalid call_id")
+            continue
+        if subtype == "started":
+            if call_id in starts or call_id in completed_ids:
+                lifecycle_warnings.append("Cursor tool-call stream contains a duplicate call_id")
+            else:
+                starts[call_id] = call
+                commands.append(command)
+        else:
+            if call_id in completed_ids:
+                lifecycle_warnings.append("Cursor tool-call stream contains a duplicate completion")
+            elif call_id not in starts:
+                completed_ids.add(call_id)
+                commands.append(command)
+                lifecycle_warnings.append("Cursor tool completion is missing its start event")
+            else:
+                completed_ids.add(call_id)
+                if not _same_cursor_call(starts[call_id], call):
+                    lifecycle_warnings.append("Cursor tool start and completion disagree")
+
+    for call_id, call in invalid_calls.items():
+        if call_id not in starts and call_id not in completed_ids:
+            commands.append(call[1])
+    if not starts and not completed_ids and not invalid_calls:
+        commands.extend(anonymous_witnesses)
+    open_calls = set(starts) - completed_ids
+    if open_calls:
+        lifecycle_warnings.append("Cursor tool start is missing its completion event")
+    terminal_complete = result_count == 1 and not activity_after_result
+    if not terminal_complete:
+        lifecycle_warnings.append("Cursor tool-call stream has no unique final result")
+    return toolcalls.summarize(
+        commands,
+        evidence,
+        lifecycle_complete=terminal_complete and not lifecycle_warnings,
+        warnings=lifecycle_warnings,
     )
 
 
@@ -263,6 +367,9 @@ class CursorBackend(AgenticBackend):
             available=False,
             warnings=("Cursor terminal result usage is unavailable or invalid",),
         )
+
+    def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
+        return {"tool_calls": _tool_call_summary(jsonl_path).to_dict()}
 
     @staticmethod
     def _summarize_args(kind: str, args: dict) -> str:

--- a/src/evaluator/backends/cursor.py
+++ b/src/evaluator/backends/cursor.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import subprocess
+from dataclasses import dataclass
 from ipaddress import ip_address
 from urllib.parse import urlparse
 
@@ -55,23 +56,38 @@ def _result_usage(event: dict[str, object]) -> UsageSummary | None:
     )
 
 
-def _cursor_call(event: dict[str, object]) -> tuple[str | None, str | None]:
-    call = event.get("tool_call")
-    if not isinstance(call, dict) or not call:
-        return None, None
-    kind = next(iter(call))
-    if kind != "shellToolCall":
-        return kind, None
-    body = call.get(kind)
-    args = body.get("args") if isinstance(body, dict) else None
+@dataclass(frozen=True)
+class _CursorCall:
+    kind: str
+    body: dict[str, object]
+
+
+def _cursor_call(event: dict[str, object]) -> _CursorCall | None:
+    raw_call = event.get("tool_call")
+    if not isinstance(raw_call, dict):
+        return None
+    calls = [
+        _CursorCall(kind=kind, body=body)
+        for kind, body in raw_call.items()
+        if isinstance(kind, str) and kind.endswith("ToolCall") and isinstance(body, dict)
+    ]
+    return calls[0] if len(calls) == 1 else None
+
+
+def _cursor_command(call: _CursorCall | None) -> str | None:
+    if call is None or call.kind != "shellToolCall":
+        return None
+    args = call.body.get("args")
     command = args.get("command") if isinstance(args, dict) else None
-    return kind, command if isinstance(command, str) else None
+    return command if isinstance(command, str) else None
 
 
-def _same_cursor_call(started: tuple[str | None, str | None], completed: tuple[str | None, str | None]) -> bool:
-    start_kind, start_command = started
-    completed_kind, completed_command = completed
-    return start_kind == completed_kind and (
+def _same_cursor_call(started: _CursorCall | None, completed: _CursorCall | None) -> bool:
+    if started is None or completed is None:
+        return started is completed
+    start_command = _cursor_command(started)
+    completed_command = _cursor_command(completed)
+    return started.kind == completed.kind and (
         start_command is None or completed_command is None or start_command == completed_command
     )
 
@@ -81,9 +97,9 @@ def _tool_call_summary(jsonl_path: str) -> toolcalls.ToolCallSummary:
 
     evidence = toolcalls.EventStreamEvidence()
     commands: list[str | None] = []
-    starts: dict[str, tuple[str | None, str | None]] = {}
+    starts: dict[str, _CursorCall | None] = {}
     completed_ids: set[str] = set()
-    invalid_calls: dict[str, tuple[str | None, str | None]] = {}
+    invalid_calls: dict[str, _CursorCall | None] = {}
     anonymous_witnesses: list[str | None] = []
     lifecycle_warnings: list[str] = []
     result_count = 0
@@ -98,21 +114,19 @@ def _tool_call_summary(jsonl_path: str) -> toolcalls.ToolCallSummary:
         if event_type != "tool_call":
             continue
         subtype = event.get("subtype")
-        raw_call = event.get("tool_call")
-        if not isinstance(raw_call, dict) or not raw_call or len(raw_call) != 1:
-            lifecycle_warnings.append("Cursor tool call has an invalid tool_call object")
         call = _cursor_call(event)
-        kind, command = call
+        if call is None:
+            lifecycle_warnings.append("Cursor tool call has an invalid tool_call object")
+        command = _cursor_command(call)
         raw_call_id = event.get("call_id")
         call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id else None
         if not isinstance(subtype, str) or subtype not in {"started", "completed"}:
             if call_id is None and not anonymous_witnesses:
                 anonymous_witnesses.append(command)
             elif call_id is not None:
-                previous = invalid_calls.get(call_id)
-                if previous is None:
+                if call_id not in invalid_calls:
                     invalid_calls[call_id] = call
-                elif not _same_cursor_call(previous, call):
+                elif not _same_cursor_call(invalid_calls[call_id], call):
                     lifecycle_warnings.append("Cursor invalid lifecycle records disagree for one call_id")
             lifecycle_warnings.append("Cursor tool-call stream contains an invalid lifecycle subtype")
             continue
@@ -141,7 +155,7 @@ def _tool_call_summary(jsonl_path: str) -> toolcalls.ToolCallSummary:
 
     for call_id, call in invalid_calls.items():
         if call_id not in starts and call_id not in completed_ids:
-            commands.append(call[1])
+            commands.append(_cursor_command(call))
     if not starts and not completed_ids and not invalid_calls:
         commands.extend(anonymous_witnesses)
     open_calls = set(starts) - completed_ids
@@ -307,11 +321,11 @@ class CursorBackend(AgenticBackend):
 
                     elif etype == "tool_call":
                         subtype = event.get("subtype", "")
-                        tc = event.get("tool_call", {})
-                        if not isinstance(tc, dict) or not tc:
+                        call = _cursor_call(event)
+                        if call is None:
                             continue
-                        kind = next(iter(tc))
-                        body = tc.get(kind) if isinstance(tc.get(kind), dict) else {}
+                        kind = call.kind
+                        body = call.body
                         args = body.get("args", {}) if isinstance(body, dict) else {}
                         if subtype == "started":
                             lines.append(f"[TOOL] {kind} {self._summarize_args(kind, args)}")

--- a/src/evaluator/backends/litellm.py
+++ b/src/evaluator/backends/litellm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 
+from evaluator import toolcalls
 from evaluator.usage import RequestUsage, UsageCost, UsageSummary, nonnegative_float, nonnegative_int
 
 from .agentic import AgenticBackend
@@ -16,6 +17,159 @@ from .litellm_common import (
     credential_mounts,
     uses_bedrock,
 )
+
+
+def _tool_commands(
+    jsonl_path: str,
+    evidence: toolcalls.EventStreamEvidence,
+) -> tuple[list[str | None], bool, tuple[str, ...]]:
+    """Collect dispatched calls and require the producer's terminal usage record."""
+
+    commands: list[str | None] = []
+    command_indexes: dict[tuple[int | None, str], int] = {}
+    seen_ids: set[tuple[int | None, str]] = set()
+    open_ids: list[tuple[int | None, str]] = []
+    completed_ids: set[tuple[int | None, str]] = set()
+    call_names: dict[tuple[int | None, str], str | None] = {}
+    unknown_absorbed_iterations: dict[str, int] = {}
+    anonymous_open = False
+    anonymous_witness_observed = False
+    anonymous_command_index: int | None = None
+    warnings: list[str] = []
+    terminal_count = 0
+    activity_after_terminal = False
+    call_ids_valid = True
+
+    def canonical_call_key(call_id: str | None, iteration: int | None) -> tuple[int | None, str] | None:
+        if call_id is None:
+            return None
+        unknown_key = (None, call_id)
+        if unknown_key in seen_ids:
+            if iteration is None:
+                return unknown_key
+            absorbed_iteration = unknown_absorbed_iterations.get(call_id)
+            if absorbed_iteration is None:
+                unknown_absorbed_iterations[call_id] = iteration
+                return unknown_key
+            if absorbed_iteration == iteration:
+                return unknown_key
+        if iteration is None:
+            return next(
+                (key for key in seen_ids if key[1] == call_id and key[0] is not None),
+                unknown_key,
+            )
+        return (iteration, call_id)
+
+    for event in toolcalls.iter_events(jsonl_path, evidence):
+        event_type = event.get("type")
+        if event_type == "usage":
+            terminal_count += 1
+            continue
+        if terminal_count and event_type in {"error", "request_usage", "response", "tool_call", "tool_result"}:
+            activity_after_terminal = True
+        if event_type not in {"tool_call", "tool_result"}:
+            continue
+
+        raw_call_id = event.get("toolCallId")
+        call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id else None
+        raw_iteration = event.get("iteration")
+        iteration = raw_iteration if type(raw_iteration) is int and raw_iteration > 0 else None
+        if iteration is None:
+            call_ids_valid = False
+            warnings.append(f"LiteLLM {event_type} has a missing or invalid iteration")
+        raw_name = event.get("name")
+        name = raw_name if isinstance(raw_name, str) and raw_name else None
+        if name is None:
+            call_ids_valid = False
+            warnings.append(f"LiteLLM {event_type} has a missing or invalid name")
+        call_key = canonical_call_key(call_id, iteration)
+        if event_type == "tool_result":
+            if call_key is None:
+                call_ids_valid = False
+                warnings.append("LiteLLM tool_result has missing or invalid toolCallId")
+                if anonymous_open:
+                    anonymous_open = False
+                elif open_ids:
+                    open_ids.pop(0)
+                elif not anonymous_witness_observed:
+                    anonymous_command_index = len(commands)
+                    commands.append(None)
+                    anonymous_witness_observed = True
+            elif call_key in open_ids:
+                open_ids.remove(call_key)
+                completed_ids.add(call_key)
+                if call_names.get(call_key) != name:
+                    call_ids_valid = False
+                    warnings.append("LiteLLM tool_call and tool_result names disagree")
+            elif call_key in completed_ids:
+                call_ids_valid = False
+                warnings.append("LiteLLM tool-call stream contains a duplicate tool_result")
+            elif call_key in seen_ids:
+                call_ids_valid = False
+                warnings.append("LiteLLM tool_result has no open dispatch")
+            elif any(seen_call_id == call_id for _seen_iteration, seen_call_id in seen_ids):
+                call_ids_valid = False
+                warnings.append("LiteLLM tool_result iteration disagrees with its tool_call")
+            else:
+                seen_ids.add(call_key)
+                completed_ids.add(call_key)
+                command_indexes[call_key] = len(commands)
+                commands.append(None)
+                call_ids_valid = False
+                warnings.append("LiteLLM tool_result has no matching tool_call")
+            continue
+
+        args = event.get("args")
+        if not isinstance(args, dict):
+            call_ids_valid = False
+            warnings.append("LiteLLM tool_call has invalid args")
+        command = args.get("command") if name == "bash" and isinstance(args, dict) else None
+        command = command if isinstance(command, str) else None
+        record_anonymous_command = False
+        if call_key is None:
+            # Legacy records had no ID. Preserve their observed calls, but they
+            # cannot prove that duplicate dispatch records were not counted.
+            call_ids_valid = False
+            warnings.append("LiteLLM tool_call has missing or invalid toolCallId")
+            if anonymous_open:
+                continue
+            anonymous_open = True
+            if anonymous_witness_observed:
+                continue
+            anonymous_witness_observed = True
+            record_anonymous_command = True
+        elif call_key in seen_ids:
+            call_ids_valid = False
+            warnings.append("LiteLLM tool-call stream contains a duplicate toolCallId")
+            existing_index = command_indexes.get(call_key)
+            if existing_index is not None and (call_names.get(call_key) != name or commands[existing_index] != command):
+                commands[existing_index] = None
+            continue
+        else:
+            seen_ids.add(call_key)
+            open_ids.append(call_key)
+            call_names[call_key] = name
+            command_indexes[call_key] = len(commands)
+
+        if record_anonymous_command:
+            anonymous_command_index = len(commands)
+        commands.append(command)
+
+    if terminal_count == 0:
+        warnings.append("LiteLLM terminal usage event was not observed for tool-call accounting")
+    elif terminal_count > 1:
+        warnings.append("LiteLLM tool-call stream contains multiple terminal usage events")
+    if activity_after_terminal:
+        warnings.append("LiteLLM tool-call stream contains events after the terminal usage event")
+    if seen_ids and anonymous_command_index is not None:
+        commands.pop(anonymous_command_index)
+    unfinished = len(open_ids) + int(anonymous_open)
+    if unfinished:
+        call_ids_valid = False
+        warnings.append(f"LiteLLM tool-call stream ended with {unfinished} unfinished tool execution(s)")
+
+    lifecycle_complete = terminal_count == 1 and not activity_after_terminal and call_ids_valid
+    return commands, lifecycle_complete, tuple(dict.fromkeys(warnings))
 
 
 class LiteLLMBackend(AgenticBackend):
@@ -55,6 +209,17 @@ class LiteLLMBackend(AgenticBackend):
 
     def check_auth(self) -> str | None:
         return check_auth(self.model, self.name)
+
+    def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
+        evidence = toolcalls.EventStreamEvidence()
+        commands, lifecycle_complete, warnings = _tool_commands(jsonl_path, evidence)
+        summary = toolcalls.summarize(
+            commands,
+            evidence,
+            lifecycle_complete=lifecycle_complete,
+            warnings=warnings,
+        )
+        return {"tool_calls": summary.to_dict()}
 
     def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         lines: list[str] = []

--- a/src/evaluator/backends/litellm_agent.py
+++ b/src/evaluator/backends/litellm_agent.py
@@ -282,21 +282,56 @@ def main() -> int:
         # Execute tool calls
         for tc in tool_calls:
             fn_name = tc.function.name
+            raw_arguments = tc.function.arguments
+            arguments_valid = True
             try:
-                fn_args = json.loads(tc.function.arguments)
+                fn_args = json.loads(raw_arguments)
+                if not isinstance(fn_args, dict):
+                    raise TypeError("tool arguments must be a JSON object")
             except (json.JSONDecodeError, TypeError):
                 fn_args = {}
-                err_result = f"ERROR: malformed JSON in tool arguments: {tc.function.arguments[:200]}"
+                arguments_valid = False
+                err_result = f"ERROR: malformed JSON in tool arguments: {str(raw_arguments)[:200]}"
+
+            tool_call_event = {
+                "type": "tool_call",
+                "toolCallId": tc.id,
+                "name": fn_name,
+                "args": fn_args,
+                "iteration": i,
+            }
+            if not arguments_valid:
+                tool_call_event["arguments_valid"] = False
+            # This is the dispatch record: emit it before attempting execution,
+            # including when the model supplied malformed arguments.
+            print(json.dumps(tool_call_event), flush=True)
+
+            if not arguments_valid:
                 print(
-                    json.dumps({"type": "tool_result", "name": fn_name, "result": err_result, "iteration": i}),
+                    json.dumps(
+                        {
+                            "type": "tool_result",
+                            "toolCallId": tc.id,
+                            "name": fn_name,
+                            "result": err_result,
+                            "iteration": i,
+                        }
+                    ),
                     flush=True,
                 )
                 messages.append({"role": "tool", "tool_call_id": tc.id, "content": err_result})
                 continue
-            print(json.dumps({"type": "tool_call", "name": fn_name, "args": fn_args, "iteration": i}), flush=True)
             result = exec_tool(fn_name, fn_args, args.workspace)
             print(
-                json.dumps({"type": "tool_result", "name": fn_name, "result": result[:2000], "iteration": i}),
+                json.dumps(
+                    {
+                        "type": "tool_result",
+                        "toolCallId": tc.id,
+                        "name": fn_name,
+                        "result": result[:2000],
+                        "iteration": i,
+                    }
+                ),
                 flush=True,
             )
             messages.append(

--- a/src/evaluator/backends/pi.py
+++ b/src/evaluator/backends/pi.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
+from evaluator import toolcalls
 from evaluator.usage import RequestUsage, UsageCost, UsageSummary
 
 from .agentic import AgenticBackend
@@ -424,6 +425,123 @@ def _event_proves_model_activity(event: dict[str, Any]) -> bool:
     return not _is_pre_stream_exception_fallback(message)
 
 
+def _tool_commands(
+    jsonl_path: str,
+    evidence: toolcalls.EventStreamEvidence,
+) -> tuple[list[str | None], bool, tuple[str, ...]]:
+    """Collect Pi tool starts and validate the session-level lifecycle."""
+
+    commands: list[str | None] = []
+    seen_ids: set[str] = set()
+    open_ids: set[str] = set()
+    tool_names: dict[str, str | None] = {}
+    anonymous_witness_observed = False
+    anonymous_command_index: int | None = None
+    anonymous_open = False
+    warnings: list[str] = []
+    settled = False
+    settled_count = 0
+    activity_after_settled = False
+    tool_lifecycle_valid = True
+
+    for event in toolcalls.iter_events(jsonl_path, evidence):
+        event_type = event.get("type")
+        if settled and event_type in _PI_RUN_ACTIVITY_EVENTS:
+            activity_after_settled = True
+
+        if event_type == "agent_settled":
+            settled = True
+            settled_count += 1
+            continue
+        if event_type not in {"tool_execution_start", "tool_execution_update", "tool_execution_end"}:
+            continue
+
+        raw_call_id = event.get("toolCallId")
+        call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id else None
+        raw_tool_name = event.get("toolName")
+        tool_name = raw_tool_name if isinstance(raw_tool_name, str) and raw_tool_name else None
+        if tool_name is None:
+            tool_lifecycle_valid = False
+            warnings.append(f"Pi {event_type} has a missing or invalid toolName")
+        if event_type == "tool_execution_start":
+            args = event.get("args")
+            if not isinstance(args, dict):
+                tool_lifecycle_valid = False
+                warnings.append("Pi tool_execution_start has invalid args")
+            command = args.get("command") if tool_name == "bash" and isinstance(args, dict) else None
+            command = command if isinstance(command, str) else None
+            if call_id is None:
+                # The event still proves one dispatch, but it cannot participate
+                # in native-ID deduplication or lifecycle correlation.
+                if not anonymous_witness_observed:
+                    anonymous_command_index = len(commands)
+                    commands.append(command)
+                    anonymous_witness_observed = True
+                anonymous_open = True
+                tool_lifecycle_valid = False
+                warnings.append("Pi tool_execution_start has missing or invalid toolCallId")
+                continue
+            if call_id in seen_ids:
+                tool_lifecycle_valid = False
+                warnings.append("Pi tool-call stream contains a duplicate toolCallId")
+                continue
+            seen_ids.add(call_id)
+            open_ids.add(call_id)
+            tool_names[call_id] = tool_name
+            commands.append(command)
+            continue
+
+        # An update/end without its start is positive evidence of a call whose
+        # dispatch record was lost. Count it once by native ID, conservatively as
+        # other, and make the observed tally a lower bound.
+        if call_id is not None and call_id not in seen_ids:
+            seen_ids.add(call_id)
+            tool_names[call_id] = tool_name
+            commands.append(None)
+            tool_lifecycle_valid = False
+            warnings.append(f"Pi {event_type} has no matching tool_execution_start")
+        elif call_id is None:
+            if not anonymous_witness_observed:
+                anonymous_command_index = len(commands)
+                commands.append(None)
+                anonymous_witness_observed = True
+            if event_type == "tool_execution_end":
+                anonymous_open = False
+            tool_lifecycle_valid = False
+            warnings.append(f"Pi {event_type} has missing or invalid toolCallId")
+        elif event_type == "tool_execution_end":
+            if tool_names.get(call_id) != tool_name:
+                tool_lifecycle_valid = False
+                warnings.append("Pi tool start and end names disagree")
+            if call_id not in open_ids:
+                tool_lifecycle_valid = False
+                warnings.append("Pi tool_execution_end has no open tool execution")
+            open_ids.discard(call_id)
+        elif call_id not in open_ids:
+            tool_lifecycle_valid = False
+            warnings.append("Pi tool_execution_update occurred after its tool execution ended")
+        elif tool_names.get(call_id) != tool_name:
+            tool_lifecycle_valid = False
+            warnings.append("Pi tool start and update names disagree")
+
+    if not settled:
+        warnings.append("Pi agent_settled was not observed for tool-call accounting")
+    if settled_count > 1:
+        warnings.append("Pi tool-call stream contains multiple agent_settled events")
+    if activity_after_settled:
+        warnings.append("Pi tool-call stream contains run activity after agent_settled")
+    if seen_ids and anonymous_command_index is not None:
+        commands.pop(anonymous_command_index)
+    if open_ids or anonymous_open:
+        tool_lifecycle_valid = False
+        warnings.append(
+            f"Pi tool-call stream ended with {len(open_ids) + int(anonymous_open)} unfinished tool execution(s)"
+        )
+
+    lifecycle_complete = bool(settled and settled_count == 1 and not activity_after_settled and tool_lifecycle_valid)
+    return commands, lifecycle_complete, tuple(dict.fromkeys(warnings))
+
+
 def _parse_pi_run(
     jsonl_path: str,
     *,
@@ -827,6 +945,17 @@ class PiBackend(AgenticBackend):
         # compatibility fields cannot omit cache writes or diverge from usage.
         del input_tokens, output_tokens
         return _parse_pi_run(jsonl_path, configured_provider=self.provider).usage
+
+    def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
+        evidence = toolcalls.EventStreamEvidence()
+        commands, lifecycle_complete, warnings = _tool_commands(jsonl_path, evidence)
+        summary = toolcalls.summarize(
+            commands,
+            evidence,
+            lifecycle_complete=lifecycle_complete,
+            warnings=warnings,
+        )
+        return {"tool_calls": summary.to_dict()}
 
     def retry_may_duplicate_model_work(self, jsonl_path: str) -> bool:
         # Pi emits final usage only at message_end. Native assistant-stream or

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -43,7 +43,7 @@ from common.container import (
     forward_env,
 )
 from common.task_contract import TaskContractError
-from evaluator import quota
+from evaluator import quota, toolcalls
 from evaluator.agent_skills import discover_agent_skills
 from evaluator.backends import get_backend, list_backends
 from evaluator.backends.base import Backend, SubmissionDisposition
@@ -1530,6 +1530,12 @@ def _run_continuations(
             if formal_round or not _supports_cost_time(item.backend):
                 aggregate_usage = UsageSummary.from_dict(result.get("usage")).merge(round_usage)
                 result["usage"] = aggregate_usage.to_dict()
+                if "tool_calls" in result or "tool_calls" in round_result:
+                    result["tool_calls"] = (
+                        toolcalls.ToolCallSummary.from_dict(result.get("tool_calls"))
+                        .merge(toolcalls.ToolCallSummary.from_dict(round_result.get("tool_calls")))
+                        .to_dict()
+                    )
                 result["time_secs"] = _sum_accounting_values(
                     result.get("time_secs"),
                     round_result.get("time_secs"),

--- a/src/evaluator/toolcalls.py
+++ b/src/evaluator/toolcalls.py
@@ -1,0 +1,586 @@
+"""Count agent tool calls and conservatively classify explicit TLA+ checkers.
+
+Backends record different JSONL event vocabularies, but they all reduce to one
+entry per dispatched tool call: a shell command for shell tools and ``None`` for
+everything else.  This module owns the shared count schema, evidence semantics,
+stream-integrity tracking, and shell parsing used by those adapters.
+
+``total`` describes observed agent tool dispatches.  TLAPS, TLC, Apalache, and
+``other`` partition that total.  Classification is deliberately conservative:
+commands that cannot be resolved statically are ``other``.  Evidence fields are
+about whether dispatches were completely enumerated, not whether every Bash
+construct could be classified or whether the agent run itself succeeded.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import tree_sitter_bash
+from tree_sitter import Language, Node, Parser
+
+TLAPS = "tlaps"
+TLC = "tlc"
+APALACHE = "apalache"
+OTHER = "other"
+CATEGORIES = (TLAPS, TLC, APALACHE, OTHER)
+COUNT_KEYS = ("total", *CATEGORIES)
+
+_BASH_LANGUAGE = Language(tree_sitter_bash.language())
+_MAX_SHELL_DEPTH = 8
+_SHELL_EXECUTABLES = frozenset({"bash", "dash", "ksh", "sh", "zsh"})
+
+# Wrappers whose remaining operand is itself a command.  Their option grammars
+# vary, so this intentionally handles only the common literal shapes emitted by
+# agents.  Tree-sitter supplies the command boundary; this loop only peels the
+# leading wrapper and simple operands.
+_WRAPPERS = frozenset({"command", "env", "exec", "nice", "nohup", "stdbuf", "sudo", "time", "timeout", "xargs"})
+_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_TIMEOUT_DURATION = re.compile(r"^\d+(?:\.\d+)?[smhd]?$")
+_WRAPPER_OPTIONS_WITH_VALUE = {
+    "env": frozenset({"--argv0", "--chdir", "--split-string", "--unset", "-C", "-S", "-u"}),
+    "exec": frozenset({"-a"}),
+    "nice": frozenset({"--adjustment", "-n"}),
+    "stdbuf": frozenset({"--error", "--input", "--output", "-e", "-i", "-o"}),
+    "sudo": frozenset(
+        {
+            "--chdir",
+            "--chroot",
+            "--close-from",
+            "--command-timeout",
+            "--group",
+            "--host",
+            "--other-user",
+            "--prompt",
+            "--role",
+            "--type",
+            "--user",
+            "-C",
+            "-D",
+            "-R",
+            "-T",
+            "-U",
+            "-g",
+            "-h",
+            "-p",
+            "-r",
+            "-t",
+            "-u",
+        }
+    ),
+    "time": frozenset({"--format", "--output", "-f", "-o"}),
+    "timeout": frozenset({"--kill-after", "--signal", "-k", "-s"}),
+    "xargs": frozenset(
+        {
+            "--arg-file",
+            "--delimiter",
+            "--eof",
+            "--max-args",
+            "--max-chars",
+            "--max-lines",
+            "--max-procs",
+            "--replace",
+            "-E",
+            "-I",
+            "-L",
+            "-P",
+            "-a",
+            "-d",
+            "-n",
+            "-s",
+        }
+    ),
+}
+
+_TLAPS_EXECUTABLES = frozenset({"tlapm"})
+_CHECK_PROOF_EXECUTABLES = frozenset({"check_proof", "check_proof_bin"})
+_TLC_EXECUTABLES = frozenset({"tlc", "tlc2"})
+_JAVA_MAIN_CLASS = re.compile(r"^[a-z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+$")
+_JAVA_OPTIONS_WITH_VALUE = frozenset(
+    {
+        "--class-path",
+        "--add-exports",
+        "--add-modules",
+        "--add-opens",
+        "--add-reads",
+        "--enable-native-access",
+        "--limit-modules",
+        "--module-path",
+        "--module-source-path",
+        "--patch-module",
+        "--source",
+        "--upgrade-module-path",
+        "-classpath",
+        "-cp",
+        "-p",
+    }
+)
+_JAVA_TERMINAL_OPTIONS = frozenset(
+    {
+        "--describe-module",
+        "--dry-run",
+        "--help",
+        "--help-extra",
+        "--list-modules",
+        "--validate-modules",
+        "--version",
+        "-?",
+        "-X",
+        "-d",
+        "-h",
+        "-help",
+        "-version",
+    }
+)
+
+
+def _unique_strings(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(value for value in values if value))
+
+
+@dataclass(frozen=True)
+class ToolCallSummary:
+    """Serializable counts plus evidence about dispatch enumeration."""
+
+    total: int = 0
+    tlaps: int = 0
+    tlc: int = 0
+    apalache: int = 0
+    other: int = 0
+    available: bool = False
+    complete: bool = False
+    is_lower_bound: bool = False
+    warnings: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        counts = (self.total, self.tlaps, self.tlc, self.apalache, self.other)
+        if any(type(value) is not int or value < 0 for value in counts):
+            raise ValueError("tool-call counts must be non-negative integers")
+        if any(type(value) is not bool for value in (self.available, self.complete, self.is_lower_bound)):
+            raise ValueError("tool-call evidence fields must be booleans")
+        if type(self.warnings) is not tuple or any(
+            not isinstance(warning, str) or not warning for warning in self.warnings
+        ):
+            raise ValueError("tool-call warnings must be non-empty strings")
+        if self.total != self.tlaps + self.tlc + self.apalache + self.other:
+            raise ValueError("tool-call categories must partition total")
+        if self.complete and not self.available:
+            raise ValueError("a complete tool-call summary must be available")
+        if self.is_lower_bound != (self.available and not self.complete):
+            raise ValueError("tool-call evidence status is inconsistent")
+        if not self.available and self.total:
+            raise ValueError("an unavailable tool-call summary cannot contain observed calls")
+
+    @classmethod
+    def from_commands(
+        cls,
+        commands: Iterable[str | None],
+        *,
+        available: bool,
+        complete: bool,
+        warnings: Iterable[str] = (),
+    ) -> ToolCallSummary:
+        counts = tally(commands)
+        return cls(
+            **counts,
+            available=available,
+            complete=complete,
+            is_lower_bound=available and not complete,
+            warnings=_unique_strings(warnings),
+        )
+
+    @classmethod
+    def from_dict(cls, value: object) -> ToolCallSummary:
+        """Read recorded data for continuation aggregation, failing closed."""
+
+        if not isinstance(value, Mapping):
+            return cls(warnings=("tool-call summary is missing or invalid",))
+        counts: dict[str, int] = {}
+        for key in COUNT_KEYS:
+            raw = value.get(key)
+            if type(raw) is not int or raw < 0:
+                return cls(warnings=("tool-call summary has invalid counts",))
+            counts[key] = raw
+        raw_warnings = value.get("warnings", [])
+        if not isinstance(raw_warnings, list) or any(not isinstance(item, str) or not item for item in raw_warnings):
+            return cls(warnings=("tool-call summary has invalid warnings",))
+        for key in ("available", "complete", "is_lower_bound"):
+            if type(value.get(key)) is not bool:
+                return cls(warnings=("tool-call summary has invalid evidence",))
+        warnings = _unique_strings(raw_warnings)
+        try:
+            return cls(
+                **counts,
+                available=value["available"],
+                complete=value["complete"],
+                is_lower_bound=value["is_lower_bound"],
+                warnings=warnings,
+            )
+        except ValueError:
+            return cls(warnings=("tool-call summary has inconsistent evidence",))
+
+    def merge(self, other: ToolCallSummary) -> ToolCallSummary:
+        """Aggregate two formal rounds while preserving evidence gaps."""
+
+        available = self.available or other.available
+        complete = self.complete and other.complete
+        return ToolCallSummary(
+            total=self.total + other.total,
+            tlaps=self.tlaps + other.tlaps,
+            tlc=self.tlc + other.tlc,
+            apalache=self.apalache + other.apalache,
+            other=self.other + other.other,
+            available=available,
+            complete=complete,
+            is_lower_bound=available and not complete,
+            warnings=_unique_strings((*self.warnings, *other.warnings)),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "total": self.total,
+            "tlaps": self.tlaps,
+            "tlc": self.tlc,
+            "apalache": self.apalache,
+            "other": self.other,
+            "available": self.available,
+            "complete": self.complete,
+            "is_lower_bound": self.is_lower_bound,
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass
+class EventStreamEvidence:
+    """Mutable integrity evidence populated while a JSONL stream is consumed."""
+
+    opened: bool = False
+    available: bool = False
+    valid: bool = True
+    event_count: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    def warn(self, warning: str) -> None:
+        self.valid = False
+        if warning not in self.warnings:
+            self.warnings.append(warning)
+
+    def final_warnings(self) -> tuple[str, ...]:
+        warnings = list(self.warnings)
+        if not self.opened:
+            warnings.append("tool-call event stream is missing or unreadable")
+        elif not self.available:
+            warnings.append("tool-call event stream has no JSON object events")
+        return _unique_strings(warnings)
+
+
+def iter_events(jsonl_path: str, evidence: EventStreamEvidence | None = None) -> Iterator[dict[str, Any]]:
+    """Stream JSON-object events while retaining malformed/read-error evidence."""
+
+    state = evidence if evidence is not None else EventStreamEvidence()
+    try:
+        with open(jsonl_path, "rb") as handle:
+            state.opened = True
+            for raw_bytes in handle:
+                try:
+                    raw = raw_bytes.decode("utf-8").strip()
+                except UnicodeError:
+                    state.warn("tool-call event stream contains invalid text encoding")
+                    continue
+                if not raw:
+                    continue
+                try:
+                    event = json.loads(raw)
+                except (ValueError, RecursionError):
+                    state.warn("tool-call event stream contains malformed JSON")
+                    continue
+                if not isinstance(event, dict):
+                    state.warn("tool-call event stream contains a non-object event")
+                    continue
+                state.available = True
+                state.event_count += 1
+                if not isinstance(event.get("type"), str):
+                    state.warn("tool-call event stream contains an event without a string type")
+                    continue
+                yield event
+    except OSError:
+        if state.opened:
+            state.warn("tool-call event stream ended with a read error")
+        else:
+            state.valid = False
+
+
+def _node_text(source: bytes, node: Node) -> str:
+    return source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+def _commands_in_expansions(node: Node) -> Iterator[Node]:
+    if node.type in {"command_substitution", "process_substitution"}:
+        yield from _command_nodes(node)
+        return
+    for child in node.named_children:
+        yield from _commands_in_expansions(child)
+
+
+def _command_nodes(node: Node) -> Iterator[Node]:
+    """Yield command nodes, evaluating nested substitutions before their host."""
+
+    # Defining a function does not dispatch anything in its body.  Resolving a
+    # later function call would require runtime shell state, which this
+    # classifier deliberately does not attempt to model.
+    if node.type == "function_definition":
+        return
+    if node.type == "command":
+        command_name = node.child_by_field_name("name")
+        for child in node.named_children:
+            if (
+                child.type == "subshell"
+                and command_name is not None
+                and command_name.start_byte == node.start_byte
+                and command_name.text == b"time"
+            ):
+                yield from _command_nodes(child)
+            else:
+                yield from _commands_in_expansions(child)
+        yield node
+        return
+    for child in node.named_children:
+        yield from _command_nodes(child)
+
+
+def _basename(token: str) -> str:
+    return token.rsplit("/", 1)[-1]
+
+
+def _wrapper_operands(executable: str, operands: list[str]) -> list[str] | None:
+    options_with_value = _WRAPPER_OPTIONS_WITH_VALUE.get(executable, frozenset())
+    while operands:
+        arg = operands[0]
+        if arg == "--":
+            operands = operands[1:]
+            break
+        option = next(
+            (
+                candidate
+                for candidate in options_with_value
+                if arg == candidate
+                or (candidate.startswith("--") and arg.startswith(candidate + "="))
+                or (candidate.startswith("-") and not candidate.startswith("--") and arg.startswith(candidate))
+            ),
+            None,
+        )
+        if option is not None:
+            if arg == option:
+                if len(operands) < 2:
+                    return None
+                operands = operands[2:]
+            else:
+                operands = operands[1:]
+            continue
+        if arg.startswith("-") or (arg.startswith("+") and len(arg) > 1):
+            operands = operands[1:]
+            continue
+        break
+    if executable == "timeout":
+        if not operands or not _TIMEOUT_DURATION.fullmatch(operands[0]):
+            return None
+        operands = operands[1:]
+    return operands
+
+
+def _unwrap_wrapper(tokens: list[str]) -> tuple[str, list[str]] | None:
+    while tokens and _ASSIGNMENT.match(tokens[0]):
+        tokens = tokens[1:]
+    while tokens:
+        if not tokens:
+            return None
+        executable = _basename(tokens[0])
+        if executable not in _WRAPPERS:
+            return executable, tokens[1:]
+        operands = tokens[1:]
+        if executable == "command" and any(
+            arg.startswith("-") and not arg.startswith("--") and any(flag in arg[1:] for flag in "Vv")
+            for arg in operands
+        ):
+            return None
+        operands = _wrapper_operands(executable, operands)
+        if operands is None:
+            return None
+        if executable == "env":
+            while operands and _ASSIGNMENT.match(operands[0]):
+                operands = operands[1:]
+        elif operands and _ASSIGNMENT.match(operands[0]):
+            return None
+        if not operands:
+            return None
+        tokens = operands
+    return None
+
+
+def _shell_script(args: list[str]) -> str | None:
+    options_with_value = {"--init-file", "--rcfile", "+O", "+o", "-O", "-o"}
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--":
+            return None
+        if arg in options_with_value:
+            index += 2
+            continue
+        if arg.startswith("--") or (arg.startswith("+") and len(arg) > 1):
+            index += 1
+            continue
+        if arg.startswith("-") and len(arg) > 1:
+            if "c" in arg[1:]:
+                script_index = index + 1
+                if script_index < len(args) and args[script_index] == "--":
+                    script_index += 1
+                return args[script_index] if script_index < len(args) else None
+            index += 1
+            continue
+        # The first non-option is a script filename.  Later ``-c`` text is an
+        # argument to that script, not an option interpreted by this shell.
+        return None
+    return None
+
+
+def _invocations(command: str, *, depth: int = 0) -> Iterator[tuple[str, list[str]]]:
+    """Yield explicit executable invocations from a Bash program."""
+
+    if depth >= _MAX_SHELL_DEPTH:
+        return
+    source = command.encode("utf-8", errors="replace")
+    tree = Parser(_BASH_LANGUAGE).parse(source)
+    for node in _command_nodes(tree.root_node):
+        try:
+            tokens = shlex.split(_node_text(source, node))
+        except ValueError:
+            continue
+        invocation = _unwrap_wrapper(tokens)
+        if invocation is None:
+            continue
+        executable, args = invocation
+        if executable in _SHELL_EXECUTABLES:
+            script = _shell_script(args)
+            if script is not None:
+                yield from _invocations(script, depth=depth + 1)
+            continue
+        yield executable, args
+
+
+def _java_launch_target(args: list[str]) -> tuple[str, str] | None:
+    """Return Java's first launch target, before application arguments begin."""
+
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in _JAVA_TERMINAL_OPTIONS or any(
+            option.startswith("--") and arg.startswith(option + "=") for option in _JAVA_TERMINAL_OPTIONS
+        ):
+            return None
+        if arg in _JAVA_OPTIONS_WITH_VALUE:
+            index += 2
+            continue
+        if arg == "-jar":
+            return ("jar", args[index + 1]) if index + 1 < len(args) else None
+        if arg in {"-m", "--module"}:
+            return ("module", args[index + 1]) if index + 1 < len(args) else None
+        if arg.startswith("--module="):
+            return ("module", arg.partition("=")[2])
+        if arg.startswith("-"):
+            index += 1
+            continue
+        return ("class", arg)
+    return None
+
+
+def _java_category(args: list[str]) -> str | None:
+    """Resolve the launched main class or ``-jar`` target, without guessing."""
+
+    target = _java_launch_target(args)
+    if target is None:
+        return None
+    target_type, value = target
+    if target_type == "module":
+        return None
+    if target_type == "jar":
+        lowered = _basename(value).lower()
+        if "apalache" in lowered:
+            return APALACHE
+        if lowered == "tla2tools.jar":
+            return TLC
+        return None
+    if not _JAVA_MAIN_CLASS.fullmatch(value):
+        return None
+    lowered = value.lower()
+    if "apalache" in lowered:
+        return APALACHE
+    if "sany" in lowered or lowered.startswith("pcal."):
+        return None
+    return TLC if lowered.startswith("tlc2.") else None
+
+
+def _category(executable: str, args: list[str]) -> str | None:
+    if executable in _TLAPS_EXECUTABLES:
+        return TLAPS
+    if executable in _CHECK_PROOF_EXECUTABLES:
+        return None if "--sany-only" in args else TLAPS
+    if executable.startswith("apalache"):
+        return APALACHE
+    if executable in _TLC_EXECUTABLES:
+        return TLC
+    if executable == "java":
+        return _java_category(args)
+    return None
+
+
+def classify_command(command: str | None) -> str:
+    """Classify one agent shell-tool dispatch by its first explicit checker."""
+
+    if not command:
+        return OTHER
+    try:
+        for executable, args in _invocations(command):
+            category = _category(executable, args)
+            if category is not None:
+                return category
+    except RecursionError:
+        # Deeply generated shell syntax must not make result recording fail.
+        # It is classification-ambiguous, so preserve the dispatch as other.
+        return OTHER
+    return OTHER
+
+
+def tally(commands: Iterable[str | None]) -> dict[str, int]:
+    """Return numeric counts for one entry per observed agent tool dispatch."""
+
+    counts = dict.fromkeys(CATEGORIES, 0)
+    total = 0
+    for command in commands:
+        counts[classify_command(command)] += 1
+        total += 1
+    return {"total": total, **counts}
+
+
+def summarize(
+    commands: Iterable[str | None],
+    evidence: EventStreamEvidence,
+    *,
+    lifecycle_complete: bool,
+    warnings: Iterable[str] = (),
+) -> ToolCallSummary:
+    """Build one summary from observed calls and backend lifecycle evidence."""
+
+    all_warnings = (*evidence.final_warnings(), *warnings)
+    complete = evidence.available and evidence.valid and lifecycle_complete
+    return ToolCallSummary.from_commands(
+        commands,
+        available=evidence.available,
+        complete=complete,
+        warnings=all_warnings,
+    )

--- a/tests/evaluator/test_codex_structured_usage.py
+++ b/tests/evaluator/test_codex_structured_usage.py
@@ -1,6 +1,7 @@
 """Structured usage parsing for the native Codex CLI JSONL contract."""
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -316,6 +317,23 @@ def test_complete_child_audit_aggregates_parent_and_child_native_usage(tmp_path)
         "codex_rollout_child_token_count",
     )
     assert usage.warnings == ()
+
+
+def test_version_three_child_usage_remains_readable(tmp_path):
+    output = tmp_path / "output.jsonl"
+    legacy_audit = _child_audit()
+    legacy_audit["version"] = 3
+    _write_jsonl(
+        output,
+        {"type": "thread.started", "thread_id": "parent"},
+        _completed_usage(),
+        legacy_audit,
+    )
+
+    usage = CodexBackend().parse_usage(str(output), input_tokens=280, output_tokens=70)
+
+    assert usage.status == "complete"
+    assert (usage.input_tokens, usage.output_tokens) == (280, 70)
 
 
 def test_v3_prices_two_large_requests_individually_instead_of_one_aggregate_tier(tmp_path):
@@ -799,6 +817,8 @@ def test_codex_local_command_uses_the_installed_usage_wrapper(tmp_path):
 
     assert Path(command[1]).resolve() == Path("src/evaluator/backends/codex_usage_wrapper.py").resolve()
     assert command[2:4] == ["--", "codex"]
+    completed = subprocess.run(command[:2] + ["--help"], capture_output=True, text=True, timeout=10)
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_codex_last_message_is_isolated_across_retries():

--- a/tests/evaluator/test_codex_structured_usage.py
+++ b/tests/evaluator/test_codex_structured_usage.py
@@ -319,10 +319,11 @@ def test_complete_child_audit_aggregates_parent_and_child_native_usage(tmp_path)
     assert usage.warnings == ()
 
 
-def test_version_three_child_usage_remains_readable(tmp_path):
+@pytest.mark.parametrize("version", (3, 4))
+def test_legacy_child_usage_versions_remain_readable(version, tmp_path):
     output = tmp_path / "output.jsonl"
     legacy_audit = _child_audit()
-    legacy_audit["version"] = 3
+    legacy_audit["version"] = version
     _write_jsonl(
         output,
         {"type": "thread.started", "thread_id": "parent"},

--- a/tests/evaluator/test_codex_toolcalls.py
+++ b/tests/evaluator/test_codex_toolcalls.py
@@ -314,7 +314,7 @@ def test_only_canonical_root_lifecycle_order_is_complete(tmp_path):
         assert summary["complete"] is (events == canonical)
 
 
-def test_complete_matching_child_audit_is_merged_without_raw_commands(tmp_path):
+def test_complete_session_tree_audit_replaces_cli_root_events(tmp_path):
     path = _write_jsonl(
         tmp_path / "output.jsonl",
         {"type": "tlaps.codex_child_usage.started", "version": CODEX_CHILD_USAGE_VERSION},
@@ -326,6 +326,7 @@ def test_complete_matching_child_audit_is_merged_without_raw_commands(tmp_path):
         {
             "type": "tlaps.codex_child_usage",
             "version": CODEX_CHILD_USAGE_VERSION,
+            "tool_calls_scope": "session_tree",
             "root_thread_id": "root",
             "tool_calls": {
                 "total": 2,
@@ -342,16 +343,51 @@ def test_complete_matching_child_audit_is_merged_without_raw_commands(tmp_path):
     )
 
     assert _summary(CodexBackend(), path) == {
-        "total": 3,
+        "total": 2,
         "tlaps": 1,
         "tlc": 1,
         "apalache": 0,
-        "other": 1,
+        "other": 0,
         "available": True,
         "complete": True,
         "is_lower_bound": False,
         "warnings": [],
     }
+
+
+def test_lower_bound_session_tree_audit_is_not_added_to_cli_root_events(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "tlaps.codex_child_usage.started", "version": CODEX_CHILD_USAGE_VERSION},
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", "command", "command_execution", "tlapm Root.tla"),
+        _item("item.completed", "command", "command_execution", "tlapm Root.tla"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+        {
+            "type": "tlaps.codex_child_usage",
+            "version": CODEX_CHILD_USAGE_VERSION,
+            "tool_calls_scope": "session_tree",
+            "root_thread_id": "root",
+            "tool_calls": {
+                "total": 1,
+                "tlaps": 0,
+                "tlc": 0,
+                "apalache": 0,
+                "other": 1,
+                "available": True,
+                "complete": False,
+                "is_lower_bound": True,
+                "warnings": ["rollout audit incomplete"],
+            },
+        },
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["tlaps"], summary["other"]) == (1, 0, 1)
+    assert summary["is_lower_bound"] is True
+    assert summary["warnings"] == ["rollout audit incomplete"]
 
 
 def test_started_child_audit_that_never_finishes_is_a_lower_bound(tmp_path):
@@ -368,6 +404,111 @@ def test_started_child_audit_that_never_finishes_is_a_lower_bound(tmp_path):
     assert summary["total"] == 0
     assert summary["is_lower_bound"] is True
     assert any("missing or ambiguous" in warning for warning in summary["warnings"])
+
+
+def test_legacy_child_audit_does_not_fall_back_to_nested_cli_commands(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "tlaps.codex_child_usage.started", "version": 4},
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", "tlaps", "command_execution", "tlapm Foo.tla"),
+        _item("item.completed", "tlaps", "command_execution", "tlapm Foo.tla"),
+        _item("item.started", "tlc", "command_execution", "tlc Foo.tla"),
+        _item("item.completed", "tlc", "command_execution", "tlc Foo.tla"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+        {
+            "type": "tlaps.codex_child_usage",
+            "version": 4,
+            "root_thread_id": "root",
+            "tool_calls": {
+                "total": 0,
+                "tlaps": 0,
+                "tlc": 0,
+                "apalache": 0,
+                "other": 0,
+                "available": True,
+                "complete": True,
+                "is_lower_bound": False,
+                "warnings": [],
+            },
+        },
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["tlaps"], summary["tlc"]) == (0, 0, 0)
+    assert summary["is_lower_bound"] is True
+    assert any("unsupported version" in warning for warning in summary["warnings"])
+
+
+def test_session_tree_audit_before_cli_activity_is_not_trusted(tmp_path):
+    audit = {
+        "type": "tlaps.codex_child_usage",
+        "version": CODEX_CHILD_USAGE_VERSION,
+        "tool_calls_scope": "session_tree",
+        "root_thread_id": "root",
+        "tool_calls": {
+            "total": 0,
+            "tlaps": 0,
+            "tlc": 0,
+            "apalache": 0,
+            "other": 0,
+            "available": True,
+            "complete": True,
+            "is_lower_bound": False,
+            "warnings": [],
+        },
+    }
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "tlaps.codex_child_usage.started", "version": CODEX_CHILD_USAGE_VERSION},
+        audit,
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", "command", "command_execution", "tlapm Foo.tla"),
+        _item("item.completed", "command", "command_execution", "tlapm Foo.tla"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert summary["total"] == 0
+    assert summary["is_lower_bound"] is True
+    assert any("invalid stream position" in warning for warning in summary["warnings"])
+
+
+def test_session_tree_sentinel_after_audit_is_not_trusted(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {
+            "type": "tlaps.codex_child_usage",
+            "version": CODEX_CHILD_USAGE_VERSION,
+            "tool_calls_scope": "session_tree",
+            "root_thread_id": "root",
+            "tool_calls": {
+                "total": 0,
+                "tlaps": 0,
+                "tlc": 0,
+                "apalache": 0,
+                "other": 0,
+                "available": True,
+                "complete": True,
+                "is_lower_bound": False,
+                "warnings": [],
+            },
+        },
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+        {"type": "tlaps.codex_child_usage.started", "version": CODEX_CHILD_USAGE_VERSION},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert summary["total"] == 0
+    assert summary["is_lower_bound"] is True
+    assert any("invalid stream position" in warning for warning in summary["warnings"])
 
 
 def test_legacy_clean_stream_without_child_sentinel_stays_complete(tmp_path):

--- a/tests/evaluator/test_codex_toolcalls.py
+++ b/tests/evaluator/test_codex_toolcalls.py
@@ -1,0 +1,412 @@
+"""Codex tool-call lifecycle and child-audit integration."""
+
+import json
+from itertools import permutations
+
+from evaluator.backends.codex import CodexBackend
+from evaluator.backends.codex_usage_wrapper import CODEX_CHILD_USAGE_VERSION
+
+
+def _write_jsonl(path, *events):
+    with path.open("w") as output:
+        for event in events:
+            output.write((event if isinstance(event, str) else json.dumps(event)) + "\n")
+    return str(path)
+
+
+def _item(event_type, item_id, item_type, command=None):
+    item = {"id": item_id, "type": item_type}
+    if command is not None:
+        item["command"] = command
+    return {"type": event_type, "item": item}
+
+
+def _summary(backend, path):
+    return backend.parse_run_metadata(path)["tool_calls"]
+
+
+def test_complete_root_counts_started_items_once_by_id(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", "command", "command_execution", "/bin/bash -lc 'tlapm Foo.tla'"),
+        _item("item.completed", "command", "command_execution", "/bin/bash -lc 'tlapm Foo.tla'"),
+        _item("item.started", "edit", "file_change"),
+        _item("item.completed", "edit", "file_change"),
+        _item("item.started", "todo", "todo_list"),
+        _item("item.completed", "todo", "todo_list"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    assert _summary(CodexBackend(), path) == {
+        "total": 3,
+        "tlaps": 1,
+        "tlc": 0,
+        "apalache": 0,
+        "other": 2,
+        "available": True,
+        "complete": True,
+        "is_lower_bound": False,
+        "warnings": [],
+    }
+
+
+def test_each_todo_update_is_a_distinct_update_plan_dispatch(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", "todo", "todo_list"),
+        _item("item.updated", "todo", "todo_list"),
+        _item("item.updated", "todo", "todo_list"),
+        _item("item.completed", "todo", "todo_list"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["other"]) == (3, 3)
+    assert summary["complete"] is True
+    assert summary["warnings"] == []
+
+
+def test_todo_update_outside_its_lifecycle_is_a_lower_bound(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", "todo", "todo_list"),
+        _item("item.completed", "todo", "todo_list"),
+        _item("item.updated", "todo", "todo_list"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["other"]) == (2, 2)
+    assert summary["is_lower_bound"] is True
+    assert any("invalid update lifecycle" in warning for warning in summary["warnings"])
+
+
+def test_orphan_todo_update_is_observed_but_not_claimed_exact(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.updated", "todo", "todo_list"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["other"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+def test_unfinished_todo_updates_are_counted_as_a_lower_bound(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", "todo", "todo_list"),
+        _item("item.updated", "todo", "todo_list"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["other"]) == (2, 2)
+    assert summary["is_lower_bound"] is True
+    assert any("did not complete" in warning for warning in summary["warnings"])
+
+
+def test_duplicate_native_item_lifecycle_is_deduplicated_but_not_claimed_exact(tmp_path):
+    start = _item("item.started", "command", "command_execution", "tlapm Foo.tla")
+    completed = _item("item.completed", "command", "command_execution", "tlapm Foo.tla")
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        start,
+        start,
+        completed,
+        completed,
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+def test_started_only_call_is_counted_as_a_lower_bound(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", "command", "command_execution", "/bin/bash -lc 'tlapm Foo.tla'"),
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is True
+    assert any("did not complete" in warning for warning in summary["warnings"])
+
+
+def test_completed_only_call_is_counted_as_a_lower_bound(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.completed", "command", "command_execution", "/bin/bash -lc 'tlapm Foo.tla'"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is True
+    assert any("without a recorded start" in warning for warning in summary["warnings"])
+
+
+def test_completed_only_file_change_remains_a_lower_bound(tmp_path):
+    # Codex currently emits matching started/completed file-change events. A
+    # completed-only record therefore means the dispatch boundary was lost.
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.completed", "edit", "file_change"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["other"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+    assert any("without a recorded start" in warning for warning in summary["warnings"])
+
+
+def test_anonymous_started_completed_pair_is_counted_once(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", None, "command_execution", "/bin/bash -lc 'tlapm Foo.tla'"),
+        _item("item.completed", None, "command_execution", "/bin/bash -lc 'tlapm Foo.tla'"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+    assert any("without IDs" in warning for warning in summary["warnings"])
+
+
+def test_replayed_anonymous_lifecycle_records_do_not_break_lower_bound(tmp_path):
+    start = _item("item.started", None, "command_execution", "/bin/bash -lc 'tlapm Foo.tla'")
+    completed = _item("item.completed", None, "command_execution", "/bin/bash -lc 'tlapm Foo.tla'")
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        start,
+        start,
+        completed,
+        completed,
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+def test_dropped_event_marker_downgrades_an_otherwise_clean_stream(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "warning",
+                "type": "error",
+                "message": "in-process app-server event stream lagged; dropped 3 events",
+            },
+        },
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert summary["total"] == 0
+    assert summary["is_lower_bound"] is True
+    assert any("dropped JSONL events" in warning for warning in summary["warnings"])
+
+
+def test_item_activity_after_turn_completed_downgrades_the_stream(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+        _item("item.started", "late", "command_execution", "tlapm Late.tla"),
+        _item("item.completed", "late", "command_execution", "tlapm Late.tla"),
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+    assert any("after its terminal" in warning for warning in summary["warnings"])
+
+
+def test_turn_activity_after_turn_completed_downgrades_the_stream(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+        {"type": "turn.started"},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert summary["total"] == 0
+    assert summary["is_lower_bound"] is True
+
+
+def test_thread_started_after_terminal_is_not_a_clean_lifecycle(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "turn.started"},
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+        {"type": "thread.started", "thread_id": "root"},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert summary["is_lower_bound"] is True
+    assert any("invalid thread/turn event order" in warning for warning in summary["warnings"])
+
+
+def test_only_canonical_root_lifecycle_order_is_complete(tmp_path):
+    canonical = (
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", "command", "command_execution", "tlapm Foo.tla"),
+        _item("item.completed", "command", "command_execution", "tlapm Foo.tla"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    for index, events in enumerate(permutations(canonical)):
+        path = _write_jsonl(tmp_path / f"order-{index}.jsonl", *events)
+        summary = _summary(CodexBackend(), path)
+
+        assert summary["complete"] is (events == canonical)
+
+
+def test_complete_matching_child_audit_is_merged_without_raw_commands(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "tlaps.codex_child_usage.started", "version": CODEX_CHILD_USAGE_VERSION},
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", "spawn", "collab_tool_call"),
+        _item("item.completed", "spawn", "collab_tool_call"),
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+        {
+            "type": "tlaps.codex_child_usage",
+            "version": CODEX_CHILD_USAGE_VERSION,
+            "root_thread_id": "root",
+            "tool_calls": {
+                "total": 2,
+                "tlaps": 1,
+                "tlc": 1,
+                "apalache": 0,
+                "other": 0,
+                "available": True,
+                "complete": True,
+                "is_lower_bound": False,
+                "warnings": [],
+            },
+        },
+    )
+
+    assert _summary(CodexBackend(), path) == {
+        "total": 3,
+        "tlaps": 1,
+        "tlc": 1,
+        "apalache": 0,
+        "other": 1,
+        "available": True,
+        "complete": True,
+        "is_lower_bound": False,
+        "warnings": [],
+    }
+
+
+def test_started_child_audit_that_never_finishes_is_a_lower_bound(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "tlaps.codex_child_usage.started", "version": CODEX_CHILD_USAGE_VERSION},
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert summary["total"] == 0
+    assert summary["is_lower_bound"] is True
+    assert any("missing or ambiguous" in warning for warning in summary["warnings"])
+
+
+def test_legacy_clean_stream_without_child_sentinel_stays_complete(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert summary["total"] == 0
+    assert summary["complete"] is True
+    assert summary["warnings"] == []
+
+
+def test_terminal_turn_failure_can_still_enumerate_every_tool_call(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "output.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        _item("item.started", "command", "command_execution", "/bin/bash -lc 'tlapm Foo.tla'"),
+        _item("item.completed", "command", "command_execution", "/bin/bash -lc 'tlapm Foo.tla'"),
+        {"type": "turn.failed", "error": {"message": "provider rejected the next request"}},
+    )
+
+    summary = _summary(CodexBackend(), path)
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["complete"] is True
+    assert summary["is_lower_bound"] is False
+    assert summary["warnings"] == []
+
+
+def test_missing_stream_is_unavailable(tmp_path):
+    summary = _summary(CodexBackend(), str(tmp_path / "missing.jsonl"))
+
+    assert summary["available"] is False
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is False
+    assert any("missing or unreadable" in warning for warning in summary["warnings"])

--- a/tests/evaluator/test_codex_usage_wrapper.py
+++ b/tests/evaluator/test_codex_usage_wrapper.py
@@ -82,6 +82,14 @@ def _tool_search(call_id: str) -> dict[str, object]:
     }
 
 
+def _response_tool(item_type: str, item_id: str, *, id_key: str = "id", **payload: object) -> dict[str, object]:
+    return {
+        "timestamp": "2026-07-28T00:00:00.000Z",
+        "type": "response_item",
+        "payload": {"type": item_type, id_key: item_id, **payload},
+    }
+
+
 def _tokens(
     input_tokens: int,
     cached_input_tokens: int,
@@ -532,23 +540,11 @@ def test_persisted_child_reference_requires_a_matching_rollout(tmp_path):
     assert "referenced_child_rollout_missing" in audit["warning_codes"]
 
 
-def test_child_tool_audit_counts_only_own_dispatches_and_excludes_continuations(tmp_path):
-    root_path = _rollout(
-        tmp_path,
-        "root",
-        _event("task_started", turn_id="root-turn"),
-        _context("root-turn"),
-        _tool("exec_command", "parent-call", {"cmd": "tlapm Parent.tla"}),
-        _tokens(100, 50, 20, 4),
-        _event("task_complete", turn_id="root-turn"),
-    )
+def test_session_tree_tool_audit_counts_child_dispatches_and_continuations(tmp_path):
+    root_path = _rollout(tmp_path, "root")
     child_path = _rollout(
         tmp_path,
         "child",
-        _meta("root", "root"),
-        _event("task_started", turn_id="root-turn"),
-        _tool("exec_command", "parent-call", {"cmd": "tlapm Parent.tla"}),
-        _event("task_complete", turn_id="root-turn"),
         _event("task_started", turn_id="child-turn"),
         _context("child-turn"),
         _tool("exec_command", "child-call", {"cmd": "/bin/bash -lc 'tlapm Child.tla'"}),
@@ -560,23 +556,112 @@ def test_child_tool_audit_counts_only_own_dispatches_and_excludes_continuations(
         _tokens(130, 60, 30, 6),
         _event("task_complete", turn_id="child-turn"),
         parent_thread_id="root",
-        forked_from_id="root",
     )
 
     audit = collect_child_usage("root", (root_path, child_path))
 
+    assert audit["tool_calls_scope"] == "session_tree"
     assert audit["tool_calls"] == {
-        "total": 3,
+        "total": 6,
         "tlaps": 1,
         "tlc": 0,
         "apalache": 0,
-        "other": 2,
+        "other": 5,
         "available": True,
         "complete": True,
         "is_lower_bound": False,
         "warnings": [],
     }
     assert "/bin/bash" not in json.dumps(audit)
+
+
+@pytest.mark.parametrize(
+    "dispatch",
+    (
+        _tool("wait", "function-wait", {"cell_id": "cell-1"}),
+        _tool("write_stdin", "function-write", {"session_id": 1}),
+        _custom_tool("wait", "custom-wait", '{"cell_id":"cell-1"}'),
+        _custom_tool("write_stdin", "custom-write", '{"session_id":1}'),
+    ),
+    ids=("function-wait", "function-write-stdin", "custom-wait", "custom-write-stdin"),
+)
+def test_session_tree_tool_audit_counts_each_continuation_dispatch(dispatch, tmp_path):
+    root_path = _rollout(
+        tmp_path,
+        "root",
+        _event("task_started", turn_id="root-turn"),
+        dispatch,
+        _event("task_complete", turn_id="root-turn"),
+    )
+
+    audit = collect_child_usage("root", (root_path,))
+
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["other"]) == (1, 1)
+    assert audit["tool_calls"]["complete"] is True
+
+
+@pytest.mark.parametrize(
+    "dispatch",
+    (
+        _response_tool("image_generation_call", "image-call"),
+        _response_tool(
+            "local_shell_call",
+            "shell-call",
+            id_key="call_id",
+            action={"command": "tlapm Local.tla"},
+        ),
+    ),
+    ids=("image-generation", "local-shell-call-id"),
+)
+def test_session_tree_tool_audit_counts_response_tool_variants(dispatch, tmp_path):
+    root_path = _rollout(
+        tmp_path,
+        "root",
+        _event("task_started", turn_id="root-turn"),
+        dispatch,
+        _event("task_complete", turn_id="root-turn"),
+    )
+
+    audit = collect_child_usage("root", (root_path,))
+
+    assert audit["tool_calls"]["total"] == 1
+    assert audit["tool_calls"]["complete"] is True
+    if dispatch["payload"]["type"] == "image_generation_call":
+        assert audit["tool_calls"]["other"] == 1
+    else:
+        assert audit["tool_calls"]["tlaps"] == 1
+
+
+def test_session_tree_tool_audit_counts_root_and_child_without_replaying_fork_prefix(tmp_path):
+    root_path = _rollout(
+        tmp_path,
+        "root",
+        _event("task_started", turn_id="root-turn"),
+        _tool("exec_command", "root-call", {"cmd": "tlapm Root.tla"}),
+        _event("task_complete", turn_id="root-turn"),
+    )
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _meta("root", "root"),
+        _event("task_started", turn_id="root-turn"),
+        _tool("exec_command", "root-call", {"cmd": "tlapm Root.tla"}),
+        _event("task_complete", turn_id="root-turn"),
+        _event("task_started", turn_id="child-turn"),
+        _custom_tool("apply_patch", "child-edit"),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+        forked_from_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["tlaps"], audit["tool_calls"]["other"]) == (
+        2,
+        1,
+        1,
+    )
+    assert audit["tool_calls"]["complete"] is True
 
 
 def test_code_mode_child_exec_uses_literal_nested_command_for_classification(tmp_path):
@@ -769,7 +854,7 @@ def test_forked_child_preserves_unmatched_prefix_tool_as_a_lower_bound(tmp_path)
     assert any("child_tool_boundary_unavailable" in warning for warning in audit["tool_calls"]["warnings"])
 
 
-def test_forked_child_does_not_double_count_ambiguous_prefix_tool(tmp_path):
+def test_session_tree_keeps_root_but_not_ambiguous_fork_prefix_tool(tmp_path):
     root_path = _rollout(
         tmp_path,
         "root",
@@ -789,7 +874,7 @@ def test_forked_child_does_not_double_count_ambiguous_prefix_tool(tmp_path):
 
     audit = collect_child_usage("root", (root_path, child_path))
 
-    assert audit["tool_calls"]["total"] == 0
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["tlaps"]) == (1, 1)
     assert audit["tool_calls"]["is_lower_bound"] is True
     assert any("child_tool_boundary_unavailable" in warning for warning in audit["tool_calls"]["warnings"])
 
@@ -920,6 +1005,7 @@ print(json.dumps({"type": "turn.completed", "usage": {"input_tokens": 1, "output
     assert records[-1] == {
         "type": "tlaps.codex_child_usage",
         "version": CODEX_CHILD_USAGE_VERSION,
+        "tool_calls_scope": "session_tree",
         "root_thread_id": "root-thread",
         "child_count": 0,
         "input_tokens": 0,

--- a/tests/evaluator/test_codex_usage_wrapper.py
+++ b/tests/evaluator/test_codex_usage_wrapper.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from evaluator.backends.codex_usage_wrapper import CODEX_CHILD_USAGE_VERSION, collect_child_usage, main
 
 
@@ -38,6 +40,45 @@ def _context(turn_id: str, model: str = "gpt-5.6-sol") -> dict[str, object]:
         "timestamp": "2026-07-28T00:00:00.000Z",
         "type": "turn_context",
         "payload": {"turn_id": turn_id, "model": model},
+    }
+
+
+def _tool(name: str, call_id: str, arguments: dict[str, object] | None = None) -> dict[str, object]:
+    return {
+        "timestamp": "2026-07-28T00:00:00.000Z",
+        "type": "response_item",
+        "payload": {
+            "type": "function_call",
+            "name": name,
+            "call_id": call_id,
+            "arguments": json.dumps(arguments or {}),
+        },
+    }
+
+
+def _custom_tool(name: str, call_id: str, tool_input: str = "redacted by the audit") -> dict[str, object]:
+    return {
+        "timestamp": "2026-07-28T00:00:00.000Z",
+        "type": "response_item",
+        "payload": {
+            "type": "custom_tool_call",
+            "name": name,
+            "call_id": call_id,
+            "input": tool_input,
+        },
+    }
+
+
+def _tool_search(call_id: str) -> dict[str, object]:
+    return {
+        "timestamp": "2026-07-28T00:00:00.000Z",
+        "type": "response_item",
+        "payload": {
+            "type": "tool_search_call",
+            "call_id": call_id,
+            "status": "completed",
+            "arguments": {"query": "redacted by the audit"},
+        },
     }
 
 
@@ -491,6 +532,355 @@ def test_persisted_child_reference_requires_a_matching_rollout(tmp_path):
     assert "referenced_child_rollout_missing" in audit["warning_codes"]
 
 
+def test_child_tool_audit_counts_only_own_dispatches_and_excludes_continuations(tmp_path):
+    root_path = _rollout(
+        tmp_path,
+        "root",
+        _event("task_started", turn_id="root-turn"),
+        _context("root-turn"),
+        _tool("exec_command", "parent-call", {"cmd": "tlapm Parent.tla"}),
+        _tokens(100, 50, 20, 4),
+        _event("task_complete", turn_id="root-turn"),
+    )
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _meta("root", "root"),
+        _event("task_started", turn_id="root-turn"),
+        _tool("exec_command", "parent-call", {"cmd": "tlapm Parent.tla"}),
+        _event("task_complete", turn_id="root-turn"),
+        _event("task_started", turn_id="child-turn"),
+        _context("child-turn"),
+        _tool("exec_command", "child-call", {"cmd": "/bin/bash -lc 'tlapm Child.tla'"}),
+        _tool("write_stdin", "child-poll", {"session_id": 1}),
+        _tool("wait", "child-code-mode-poll", {"cell_id": "cell-1"}),
+        _custom_tool("wait", "defensive-custom-poll", '{"cell_id":"cell-1"}'),
+        _custom_tool("apply_patch", "child-edit"),
+        _tool_search("child-search"),
+        _tokens(130, 60, 30, 6),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+        forked_from_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert audit["tool_calls"] == {
+        "total": 3,
+        "tlaps": 1,
+        "tlc": 0,
+        "apalache": 0,
+        "other": 2,
+        "available": True,
+        "complete": True,
+        "is_lower_bound": False,
+        "warnings": [],
+    }
+    assert "/bin/bash" not in json.dumps(audit)
+
+
+def test_code_mode_child_exec_uses_literal_nested_command_for_classification(tmp_path):
+    secret_command = "tlapm PrivateChild.tla"
+    root_path = _rollout(tmp_path, "root")
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _event("task_started", turn_id="child-turn"),
+        _custom_tool(
+            "exec",
+            "code-mode",
+            '// @exec: {"max_output_tokens": 100000}\n'
+            "const results = await Promise.all([\n"
+            '  tools.exec_command({cmd: "echo ready"}),\n'
+            f'  tools.exec_command({{cmd: "{secret_command}"}}),\n'
+            "]);\ntext(results.length);",
+        ),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["tlaps"]) == (1, 1)
+    assert audit["tool_calls"]["complete"] is True
+    assert secret_command not in json.dumps(audit)
+
+
+def test_non_code_mode_shell_command_uses_its_native_command_field(tmp_path):
+    root_path = _rollout(tmp_path, "root")
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _event("task_started", turn_id="child-turn"),
+        _tool("shell_command", "shell", {"command": ["tlapm", "Child.tla"]}),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["tlaps"]) == (1, 1)
+    assert audit["tool_calls"]["complete"] is True
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        '// tools.exec_command({cmd: "tlapm Comment.tla"});\ntext("done");',
+        "const example = 'tools.exec_command({cmd: \"tlapm String.tla\"})'; text(example);",
+        'const cmd = "tlapm Dynamic.tla"; await tools.exec_command({cmd});',
+        "await tools.exec_command({cmd: `tlapm ${name}.tla`});",
+        'await tools.exec_command({cmd: "tlapm First.tla", cmd: "echo safe"});',
+        'const opts = {cmd: "echo safe"}; await tools.exec_command({cmd: "tlapm Spread.tla", ...opts});',
+        'await tools.exec_command({cmd: "tlapm Computed.tla", ["cmd"]: "echo safe"});',
+        'await tools.exec_command({cmd: "tlapm Broken.tla"',
+    ),
+    ids=("comment", "string", "dynamic", "template", "duplicate", "spread", "computed", "malformed"),
+)
+def test_code_mode_child_exec_is_conservative_for_nonliteral_nested_commands(source, tmp_path):
+    root_path = _rollout(tmp_path, "root")
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _event("task_started", turn_id="child-turn"),
+        _custom_tool("exec", "code-mode", source),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["other"]) == (1, 1)
+    assert audit["tool_calls"]["complete"] is True
+
+
+def test_aborted_child_can_still_enumerate_observed_tool_calls_exactly(tmp_path):
+    root_path = _rollout(tmp_path, "root")
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _event("task_started", turn_id="child-turn"),
+        _tool("exec_command", "child-call", {"cmd": "tlapm Child.tla"}),
+        _event("turn_aborted", turn_id="child-turn"),
+        parent_thread_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert audit["tool_calls"]["total"] == 1
+    assert audit["tool_calls"]["tlaps"] == 1
+    assert audit["tool_calls"]["complete"] is True
+    assert audit["tool_calls"]["is_lower_bound"] is False
+
+
+def test_replayed_anonymous_child_dispatch_is_one_lower_bound_witness(tmp_path):
+    root_path = _rollout(tmp_path, "root")
+    anonymous = _tool("exec_command", None, {"cmd": "tlapm Child.tla"})
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _event("task_started", turn_id="child-turn"),
+        anonymous,
+        anonymous,
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["tlaps"]) == (1, 1)
+    assert audit["tool_calls"]["is_lower_bound"] is True
+
+
+def test_stable_child_id_dominates_anonymous_dispatch_witness(tmp_path):
+    root_path = _rollout(tmp_path, "root")
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _event("task_started", turn_id="child-turn"),
+        _tool("exec_command", "stable", {"cmd": "tlapm Child.tla"}),
+        _tool("exec_command", None, {"cmd": "tlapm Child.tla"}),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["tlaps"]) == (1, 1)
+    assert audit["tool_calls"]["complete"] is False
+    assert audit["tool_calls"]["is_lower_bound"] is True
+    assert any("child_tool_id_invalid" in warning for warning in audit["tool_calls"]["warnings"])
+
+
+def test_duplicate_native_child_dispatch_is_deduplicated_and_downgraded(tmp_path):
+    root_path = _rollout(tmp_path, "root")
+    dispatch = _tool("exec_command", "duplicate", {"cmd": "tlapm Child.tla"})
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _event("task_started", turn_id="child-turn"),
+        dispatch,
+        dispatch,
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["tlaps"]) == (1, 1)
+    assert audit["tool_calls"]["is_lower_bound"] is True
+    assert any("child_tool_id_duplicate" in warning for warning in audit["tool_calls"]["warnings"])
+
+
+def test_direct_child_preserves_tool_evidence_before_its_first_turn(tmp_path):
+    root_path = _rollout(tmp_path, "root")
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _tool("exec_command", "early", {"cmd": "tlapm Child.tla"}),
+        _event("task_started", turn_id="child-turn"),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["tlaps"]) == (1, 1)
+    assert audit["tool_calls"]["is_lower_bound"] is True
+    assert any("child_tool_lifecycle_invalid" in warning for warning in audit["tool_calls"]["warnings"])
+
+
+def test_forked_child_preserves_unmatched_prefix_tool_as_a_lower_bound(tmp_path):
+    root_path = _rollout(tmp_path, "root", *_turn("root-turn"))
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _tool("exec_command", "early-child", {"cmd": "tlapm Child.tla"}),
+        _event("task_started", turn_id="child-turn"),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+        forked_from_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["tlaps"]) == (1, 1)
+    assert audit["tool_calls"]["is_lower_bound"] is True
+    assert any("child_tool_boundary_unavailable" in warning for warning in audit["tool_calls"]["warnings"])
+
+
+def test_forked_child_does_not_double_count_ambiguous_prefix_tool(tmp_path):
+    root_path = _rollout(
+        tmp_path,
+        "root",
+        _event("task_started", turn_id="root-turn"),
+        _tool("exec_command", "parent-call", {"cmd": "tlapm Parent.tla"}),
+        _event("task_complete", turn_id="root-turn"),
+    )
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _tool("exec_command", "parent-call", {"cmd": "tlapm Conflicting.tla"}),
+        _event("task_started", turn_id="child-turn"),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+        forked_from_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert audit["tool_calls"]["total"] == 0
+    assert audit["tool_calls"]["is_lower_bound"] is True
+    assert any("child_tool_boundary_unavailable" in warning for warning in audit["tool_calls"]["warnings"])
+
+
+def test_forked_child_idless_prefix_tool_is_ambiguous_not_an_exact_zero(tmp_path):
+    root_path = _rollout(tmp_path, "root", *_turn("root-turn"))
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _tool("exec_command", None, {"cmd": "tlapm Ambiguous.tla"}),
+        _event("task_started", turn_id="child-turn"),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+        forked_from_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert audit["tool_calls"]["total"] == 0
+    assert audit["tool_calls"]["is_lower_bound"] is True
+    assert any("child_tool_boundary_unavailable" in warning for warning in audit["tool_calls"]["warnings"])
+
+
+def test_invalid_usage_telemetry_does_not_downgrade_child_tool_enumeration(tmp_path):
+    root_path = _rollout(tmp_path, "root")
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _event("task_started", turn_id="child-turn"),
+        _context("child-turn"),
+        _tool("exec_command", "child-call", {"cmd": "tlapm Child.tla"}),
+        _event("token_count", info={"total_token_usage": {"input_tokens": 1}}),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert audit["complete"] is False
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["tlaps"]) == (1, 1)
+    assert audit["tool_calls"]["complete"] is True
+
+
+def test_invalid_parent_usage_telemetry_does_not_hide_forked_child_tools(tmp_path):
+    invalid_tokens = _event("token_count", info={"total_token_usage": {"input_tokens": 1}})
+    root_path = _rollout(
+        tmp_path,
+        "root",
+        _event("task_started", turn_id="root-turn"),
+        _context("root-turn"),
+        invalid_tokens,
+        _event("task_complete", turn_id="root-turn"),
+    )
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _event("task_started", turn_id="root-turn"),
+        _event("task_complete", turn_id="root-turn"),
+        _event("task_started", turn_id="child-turn"),
+        _context("child-turn"),
+        _tool("exec_command", "child-call", {"cmd": "tlapm Child.tla"}),
+        _event("task_complete", turn_id="child-turn"),
+        parent_thread_id="root",
+        forked_from_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert (audit["tool_calls"]["total"], audit["tool_calls"]["tlaps"]) == (1, 1)
+    assert audit["tool_calls"]["complete"] is True
+
+
+def test_forked_child_without_an_own_turn_does_not_claim_exact_zero_tools(tmp_path):
+    root_path = _rollout(tmp_path, "root", *_turn("root-turn", (10, 5, 2, 1)))
+    child_path = _rollout(
+        tmp_path,
+        "child",
+        _meta("root", "root"),
+        *_turn("root-turn", (10, 5, 2, 1)),
+        parent_thread_id="root",
+        forked_from_id="root",
+    )
+
+    audit = collect_child_usage("root", (root_path, child_path))
+
+    assert audit["tool_calls"]["total"] == 0
+    assert audit["tool_calls"]["complete"] is False
+    assert audit["tool_calls"]["is_lower_bound"] is True
+    assert any("child_tool_lifecycle_invalid" in warning for warning in audit["tool_calls"]["warnings"])
+
+
 def test_wrapper_streams_codex_then_appends_one_finished_audit(tmp_path, monkeypatch, capsys):
     codex_home = tmp_path / "codex-home"
     fake_codex = tmp_path / "fake_codex.py"
@@ -540,4 +930,15 @@ print(json.dumps({"type": "turn.completed", "usage": {"input_tokens": 1, "output
         "requests": [],
         "complete": True,
         "warning_codes": [],
+        "tool_calls": {
+            "total": 0,
+            "tlaps": 0,
+            "tlc": 0,
+            "apalache": 0,
+            "other": 0,
+            "available": True,
+            "complete": True,
+            "is_lower_bound": False,
+            "warnings": [],
+        },
     }

--- a/tests/evaluator/test_continuation.py
+++ b/tests/evaluator/test_continuation.py
@@ -30,6 +30,20 @@ STARTUP = {"exit": 1, "stderr": "Error: Failed to load models\n"}
 GENUINE = {"exit": 0, "events": CLEAN_EVENTS, "out_tokens": 500}
 
 
+def _tool_calls(*, tlaps=0, tlc=0, apalache=0, other=0, available=True, complete=True, warnings=()):
+    return {
+        "total": tlaps + tlc + apalache + other,
+        "tlaps": tlaps,
+        "tlc": tlc,
+        "apalache": apalache,
+        "other": other,
+        "available": available,
+        "complete": complete,
+        "is_lower_bound": available and not complete,
+        "warnings": list(warnings),
+    }
+
+
 class _ScriptedBackend(AgenticBackend):
     """Backend whose per-call behavior is scripted (see _install_agent)."""
 
@@ -40,6 +54,7 @@ class _ScriptedBackend(AgenticBackend):
         self.out_tokens = 0  # set by the fake agent for the current call
         self.cost = 0.0
         self.submission_metadata = {}
+        self.tool_calls_by_path = {}
 
     def parse_output(self, jsonl_path):
         return ("", self.in_tokens, self.out_tokens)
@@ -58,6 +73,13 @@ class _ScriptedBackend(AgenticBackend):
             source="scripted",
             complete=True,
         )
+
+    def parse_run_metadata(self, jsonl_path):
+        summary = self.tool_calls_by_path.get(
+            jsonl_path,
+            _tool_calls(available=False, complete=False, warnings=("scripted tool-call data unavailable",)),
+        )
+        return {"tool_calls": summary}
 
     def build_command(self, workspace, result_dir):
         return ["fake-agent"]
@@ -137,6 +159,7 @@ def _install_agent(monkeypatch, backend, calls_spec):
         backend.in_tokens = spec.get("in_tokens", 0)
         backend.out_tokens = spec.get("out_tokens", 0)
         backend.cost = spec.get("cost", 0.0)
+        backend.tool_calls_by_path[agent_jsonl] = spec.get("tool_calls", _tool_calls())
         if "mutate" in spec:
             spec["mutate"](workspace)
         if "mutate_canonical" in spec:
@@ -425,6 +448,99 @@ def test_costs_accumulate_into_top_level(tmp_path, monkeypatch):
     assert result["continuations"][0]["usage"]["costs"] == [
         {"amount": 0.006, "unit": "provider_monetary", "source": "test.cost"}
     ]
+
+
+def test_tool_calls_accumulate_across_formal_continuation_rounds(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    _install_agent(
+        monkeypatch,
+        backend,
+        [
+            dict(GENUINE, tool_calls=_tool_calls(tlaps=1, other=2)),
+            dict(GENUINE, tool_calls=_tool_calls(tlc=2, apalache=1, other=1)),
+            dict(GENUINE, tool_calls=_tool_calls(tlaps=2, tlc=1, apalache=1, other=1)),
+        ],
+    )
+    _install_grader(monkeypatch, ["FAIL", "FAIL", "PASS"])
+
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=2))
+
+    assert result["tool_calls"] == _tool_calls(tlaps=3, tlc=3, apalache=2, other=4)
+    assert [round_result["tool_calls"] for round_result in result["continuations"]] == [
+        _tool_calls(tlc=2, apalache=1, other=1),
+        _tool_calls(tlaps=2, tlc=1, apalache=1, other=1),
+    ]
+
+
+def test_tool_calls_lower_bound_propagates_from_any_formal_round(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    warning = "continuation tool-call stream was truncated"
+    _install_agent(
+        monkeypatch,
+        backend,
+        [
+            dict(GENUINE, tool_calls=_tool_calls(tlaps=1)),
+            dict(
+                GENUINE,
+                tool_calls=_tool_calls(tlc=2, complete=False, warnings=(warning,)),
+            ),
+        ],
+    )
+    _install_grader(monkeypatch, ["FAIL", "PASS"])
+
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=1))
+
+    assert result["tool_calls"] == _tool_calls(
+        tlaps=1,
+        tlc=2,
+        complete=False,
+        warnings=(warning,),
+    )
+    assert result["continuations"][0]["tool_calls"] == _tool_calls(
+        tlc=2,
+        complete=False,
+        warnings=(warning,),
+    )
+
+
+def test_zero_first_attempt_then_prover_call_is_nonzero_at_top_level(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    _install_agent(
+        monkeypatch,
+        backend,
+        [
+            dict(GENUINE, tool_calls=_tool_calls()),
+            dict(GENUINE, tool_calls=_tool_calls(tlaps=1)),
+        ],
+    )
+    _install_grader(monkeypatch, ["FAIL", "PASS"])
+
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=1))
+
+    assert result["tool_calls"] == _tool_calls(tlaps=1)
+    assert result["continuations"][0]["tool_calls"] == _tool_calls(tlaps=1)
+
+
+def test_non_formal_tool_calls_follow_existing_accounting_scope(tmp_path, monkeypatch):
+    for backend_name, expected_total in (("copilot", 1), ("legacy-scripted", 3)):
+        case_dir = tmp_path / backend_name
+        backend = _ScriptedBackend()
+        backend.name = backend_name
+        _install_agent(
+            monkeypatch,
+            backend,
+            [
+                dict(GENUINE, in_tokens=10, tool_calls=_tool_calls(tlaps=1)),
+                dict(STARTUP, in_tokens=20, tool_calls=_tool_calls(other=2)),
+            ],
+        )
+        _install_grader(monkeypatch, ["FAIL", "FAIL"])
+
+        result = runner.run_single_benchmark(_work_item(case_dir, backend, max_continuations=1))
+
+        assert result["tool_calls"]["total"] == expected_total
+        assert result["input_tokens"] == (10 if backend_name == "copilot" else 30)
+        assert result["continuations"][0]["tool_calls"] == _tool_calls(other=2)
 
 
 def test_submission_metadata_cannot_replace_usage_before_continuation(tmp_path, monkeypatch):

--- a/tests/evaluator/test_cursor_backend.py
+++ b/tests/evaluator/test_cursor_backend.py
@@ -98,6 +98,42 @@ def test_cursor_trusts_zero_terminal_usage(tmp_path):
     assert (usage.input_tokens, usage.output_tokens) == (0, 0)
 
 
+def test_cursor_transcript_uses_the_tool_field_among_metadata(tmp_path):
+    output = tmp_path / "output.jsonl"
+    _write_jsonl(
+        output,
+        {
+            "type": "tool_call",
+            "subtype": "started",
+            "call_id": "outer-call",
+            "tool_call": {
+                "toolCallId": "native-call",
+                "startedAtMs": "123",
+                "shellToolCall": {"args": {"command": "tlapm --version"}},
+            },
+        },
+        {
+            "type": "tool_call",
+            "subtype": "completed",
+            "call_id": "outer-call",
+            "tool_call": {
+                "shellToolCall": {
+                    "args": {"command": "tlapm --version"},
+                    "result": "TLAPM version",
+                },
+                "completedAtMs": "456",
+                "toolCallId": "native-call",
+            },
+        },
+    )
+
+    transcript, _input_tokens, _output_tokens = CursorBackend().parse_output(str(output))
+
+    assert "[TOOL] shellToolCall tlapm --version" in transcript
+    assert "[TOOL_RESULT] TLAPM version" in transcript
+    assert "toolCallId" not in transcript
+
+
 def test_cursor_uses_dynamic_firewall_with_default_runtime_hosts(monkeypatch):
     monkeypatch.delenv("CURSOR_API_ENDPOINT", raising=False)
     backend = CursorBackend()

--- a/tests/evaluator/test_litellm_usage.py
+++ b/tests/evaluator/test_litellm_usage.py
@@ -372,3 +372,251 @@ def test_malformed_lines_make_usage_a_lower_bound(tmp_path):
     assert usage.model_requests == 1
     assert usage.status == "lower_bound"
     assert "LiteLLM JSONL contains 1 malformed nonempty line(s)" in usage.warnings
+
+
+def test_tool_metadata_counts_id_keyed_dispatches_before_terminal_usage(tmp_path):
+    path = _write(
+        tmp_path / "output.jsonl",
+        {
+            "type": "tool_call",
+            "toolCallId": "tool-1",
+            "name": "bash",
+            "args": {"command": "tlapm Foo.tla"},
+            "iteration": 1,
+        },
+        {"type": "tool_result", "toolCallId": "tool-1", "name": "bash", "result": "ok", "iteration": 1},
+        {
+            "type": "tool_call",
+            "toolCallId": "tool-2",
+            "name": "write_file",
+            "args": {"path": "Foo.tla"},
+            "iteration": 1,
+        },
+        {
+            "type": "tool_result",
+            "toolCallId": "tool-2",
+            "name": "write_file",
+            "result": "OK",
+            "iteration": 1,
+        },
+        _aggregate(input_tokens=10, output_tokens=5, model_requests=1),
+    )
+
+    assert _backend().parse_run_metadata(path)["tool_calls"] == {
+        "total": 2,
+        "tlaps": 1,
+        "tlc": 0,
+        "apalache": 0,
+        "other": 1,
+        "available": True,
+        "complete": True,
+        "is_lower_bound": False,
+        "warnings": [],
+    }
+
+
+def test_tool_metadata_counts_malformed_arguments_as_other(tmp_path):
+    path = _write(
+        tmp_path / "output.jsonl",
+        {
+            "type": "tool_call",
+            "toolCallId": "tool-1",
+            "name": "bash",
+            "args": {},
+            "arguments_valid": False,
+            "iteration": 1,
+        },
+        {"type": "tool_result", "toolCallId": "tool-1", "name": "bash", "result": "error", "iteration": 1},
+        _aggregate(input_tokens=10, output_tokens=5, model_requests=1),
+    )
+
+    summary = _backend().parse_run_metadata(path)["tool_calls"]
+
+    assert (summary["total"], summary["tlaps"], summary["other"]) == (1, 0, 1)
+    assert summary["complete"] is True
+
+
+def test_tool_metadata_deduplicates_native_call_ids(tmp_path):
+    call = {
+        "type": "tool_call",
+        "toolCallId": "tool-1",
+        "name": "bash",
+        "args": {"command": "tlapm Foo.tla"},
+        "iteration": 1,
+    }
+    path = _write(
+        tmp_path / "output.jsonl",
+        call,
+        call,
+        {"type": "tool_result", "toolCallId": "tool-1", "name": "bash", "result": "ok", "iteration": 1},
+        _aggregate(input_tokens=10, output_tokens=5, model_requests=1),
+    )
+
+    summary = _backend().parse_run_metadata(path)["tool_calls"]
+
+    assert summary["total"] == 1
+    assert summary["tlaps"] == 1
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is True
+    assert any("duplicate toolCallId" in warning for warning in summary["warnings"])
+
+
+def test_tool_metadata_scopes_reused_call_ids_by_iteration(tmp_path):
+    path = _write(
+        tmp_path / "output.jsonl",
+        {
+            "type": "tool_call",
+            "toolCallId": "reused",
+            "name": "bash",
+            "args": {"command": "tlapm First.tla"},
+            "iteration": 1,
+        },
+        {"type": "tool_result", "toolCallId": "reused", "name": "bash", "iteration": 1},
+        {
+            "type": "tool_call",
+            "toolCallId": "reused",
+            "name": "bash",
+            "args": {"command": "tlapm Second.tla"},
+            "iteration": 2,
+        },
+        {"type": "tool_result", "toolCallId": "reused", "name": "bash", "iteration": 2},
+        _aggregate(input_tokens=10, output_tokens=5, model_requests=1),
+    )
+
+    summary = _backend().parse_run_metadata(path)["tool_calls"]
+
+    assert (summary["total"], summary["tlaps"]) == (2, 2)
+    assert summary["complete"] is True
+
+
+def test_tool_metadata_merges_unknown_iteration_with_same_native_id(tmp_path):
+    path = _write(
+        tmp_path / "output.jsonl",
+        {
+            "type": "tool_call",
+            "toolCallId": "reused",
+            "name": "bash",
+            "args": {"command": "tlapm Unknown.tla"},
+        },
+        {
+            "type": "tool_call",
+            "toolCallId": "reused",
+            "name": "bash",
+            "args": {"command": "tlapm First.tla"},
+            "iteration": 1,
+        },
+        {"type": "tool_result", "toolCallId": "reused", "name": "bash", "iteration": 1},
+        {
+            "type": "tool_call",
+            "toolCallId": "reused",
+            "name": "bash",
+            "args": {"command": "tlapm Second.tla"},
+            "iteration": 2,
+        },
+        {"type": "tool_result", "toolCallId": "reused", "name": "bash", "iteration": 2},
+        _aggregate(input_tokens=10, output_tokens=5, model_requests=1),
+    )
+
+    summary = _backend().parse_run_metadata(path)["tool_calls"]
+
+    assert summary["total"] == 2
+    assert summary["is_lower_bound"] is True
+
+
+def test_tool_metadata_rejects_result_iteration_or_name_conflicts(tmp_path):
+    for suffix, result in (
+        ("iteration", {"toolCallId": "tool-1", "name": "bash", "iteration": 2}),
+        ("name", {"toolCallId": "tool-1", "name": "write_file", "iteration": 1}),
+    ):
+        path = _write(
+            tmp_path / f"output-{suffix}.jsonl",
+            {
+                "type": "tool_call",
+                "toolCallId": "tool-1",
+                "name": "bash",
+                "args": {"command": "tlapm Foo.tla"},
+                "iteration": 1,
+            },
+            {"type": "tool_result", **result},
+            _aggregate(input_tokens=10, output_tokens=5, model_requests=1),
+        )
+
+        summary = _backend().parse_run_metadata(path)["tool_calls"]
+
+        assert (summary["total"], summary["tlaps"]) == (1, 1)
+        assert summary["is_lower_bound"] is True
+
+
+def test_tool_metadata_orphan_result_is_positive_lower_bound_evidence(tmp_path):
+    path = _write(
+        tmp_path / "output.jsonl",
+        {"type": "tool_result", "toolCallId": "tool-1", "name": "bash", "result": "lost start"},
+        _aggregate(input_tokens=0, output_tokens=0, model_requests=0),
+    )
+
+    summary = _backend().parse_run_metadata(path)["tool_calls"]
+
+    assert (summary["total"], summary["other"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+def test_tool_metadata_unfinished_dispatch_is_a_lower_bound(tmp_path):
+    path = _write(
+        tmp_path / "output.jsonl",
+        {"type": "tool_call", "toolCallId": "tool-1", "name": "bash", "args": {"command": "tlapm Foo.tla"}},
+        _aggregate(input_tokens=0, output_tokens=0, model_requests=0),
+    )
+
+    summary = _backend().parse_run_metadata(path)["tool_calls"]
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+    assert any("unfinished tool execution" in warning for warning in summary["warnings"])
+
+
+def test_tool_metadata_error_then_terminal_usage_is_complete(tmp_path):
+    path = _write(
+        tmp_path / "output.jsonl",
+        {"type": "error", "message": "provider rejected the request", "iteration": 1},
+        _aggregate(input_tokens=0, output_tokens=0, model_requests=1),
+    )
+
+    summary = _backend().parse_run_metadata(path)["tool_calls"]
+
+    assert summary["total"] == 0
+    assert summary["complete"] is True
+    assert summary["is_lower_bound"] is False
+
+
+def test_tool_metadata_requires_one_final_usage_event(tmp_path):
+    missing = _write(
+        tmp_path / "missing-terminal.jsonl",
+        {
+            "type": "tool_call",
+            "toolCallId": "tool-1",
+            "name": "bash",
+            "args": {"command": "tlapm Foo.tla"},
+            "iteration": 1,
+        },
+    )
+    duplicate = _write(
+        tmp_path / "duplicate-terminal.jsonl",
+        _aggregate(input_tokens=1, output_tokens=1, model_requests=1),
+        _aggregate(input_tokens=1, output_tokens=1, model_requests=1),
+    )
+    trailing = _write(
+        tmp_path / "trailing-event.jsonl",
+        _aggregate(input_tokens=1, output_tokens=1, model_requests=1),
+        {"type": "response", "text": "late", "iteration": 1},
+    )
+
+    cases = (
+        (missing, "terminal usage event was not observed"),
+        (duplicate, "multiple terminal usage events"),
+        (trailing, "events after the terminal usage event"),
+    )
+    for path, warning in cases:
+        summary = _backend().parse_run_metadata(path)["tool_calls"]
+        assert summary["complete"] is False
+        assert summary["is_lower_bound"] is True
+        assert any(warning in item for item in summary["warnings"])

--- a/tests/evaluator/test_pi_structured_usage.py
+++ b/tests/evaluator/test_pi_structured_usage.py
@@ -1116,6 +1116,170 @@ def test_exact_pre_stream_fallback_closes_open_turn_without_model_activity(tmp_p
     assert PiBackend().retry_may_duplicate_model_work(str(output)) is False
 
 
+def test_tool_metadata_counts_native_starts_and_uses_settled_as_terminal(tmp_path):
+    output = tmp_path / "output.jsonl"
+    _write_jsonl(
+        output,
+        {
+            "type": "tool_execution_start",
+            "toolCallId": "tool-1",
+            "toolName": "bash",
+            "args": {"command": "tlapm Foo.tla"},
+        },
+        {"type": "tool_execution_end", "toolCallId": "tool-1", "toolName": "bash", "result": {}},
+        {
+            "type": "tool_execution_start",
+            "toolCallId": "tool-2",
+            "toolName": "read",
+            "args": {"path": "Foo.tla"},
+        },
+        {"type": "tool_execution_end", "toolCallId": "tool-2", "toolName": "read", "result": {}},
+        {"type": "agent_settled"},
+    )
+
+    assert PiBackend().parse_run_metadata(str(output))["tool_calls"] == {
+        "total": 2,
+        "tlaps": 1,
+        "tlc": 0,
+        "apalache": 0,
+        "other": 1,
+        "available": True,
+        "complete": True,
+        "is_lower_bound": False,
+        "warnings": [],
+    }
+
+
+def test_tool_metadata_deduplicates_native_call_ids(tmp_path):
+    output = tmp_path / "output.jsonl"
+    start = {
+        "type": "tool_execution_start",
+        "toolCallId": "tool-1",
+        "toolName": "bash",
+        "args": {"command": "tlapm Foo.tla"},
+    }
+    _write_jsonl(
+        output,
+        start,
+        start,
+        {"type": "tool_execution_end", "toolCallId": "tool-1", "toolName": "bash", "result": {}},
+        {"type": "agent_settled"},
+    )
+
+    summary = PiBackend().parse_run_metadata(str(output))["tool_calls"]
+
+    assert summary["total"] == 1
+    assert summary["tlaps"] == 1
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is True
+    assert any("duplicate toolCallId" in warning for warning in summary["warnings"])
+
+
+def test_tool_metadata_counts_orphan_lifecycle_once_as_other(tmp_path):
+    output = tmp_path / "output.jsonl"
+    _write_jsonl(
+        output,
+        {
+            "type": "tool_execution_update",
+            "toolCallId": "tool-1",
+            "toolName": "bash",
+            "args": {"command": "tlapm Foo.tla"},
+            "partialResult": {},
+        },
+        {"type": "tool_execution_end", "toolCallId": "tool-1", "toolName": "bash", "result": {}},
+        {"type": "agent_settled"},
+    )
+
+    summary = PiBackend().parse_run_metadata(str(output))["tool_calls"]
+
+    assert (summary["total"], summary["tlaps"], summary["other"]) == (1, 0, 1)
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is True
+    assert any("no matching tool_execution_start" in warning for warning in summary["warnings"])
+
+
+def test_tool_metadata_counts_anonymous_orphan_as_positive_evidence(tmp_path):
+    output = tmp_path / "output.jsonl"
+    _write_jsonl(
+        output,
+        {"type": "tool_execution_end", "toolName": "bash", "result": {}},
+        {"type": "agent_settled"},
+    )
+
+    summary = PiBackend().parse_run_metadata(str(output))["tool_calls"]
+
+    assert (summary["total"], summary["other"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+@pytest.mark.parametrize(
+    "events, warning",
+    [
+        (
+            (
+                {
+                    "type": "tool_execution_start",
+                    "toolCallId": "tool-1",
+                    "toolName": "bash",
+                    "args": {"command": "tlapm Foo.tla"},
+                },
+                {"type": "tool_execution_end", "toolCallId": "tool-1", "toolName": "bash", "result": {}},
+            ),
+            "agent_settled was not observed",
+        ),
+        (
+            (
+                {"type": "agent_settled"},
+                {
+                    "type": "tool_execution_start",
+                    "toolCallId": "tool-1",
+                    "toolName": "bash",
+                    "args": {"command": "tlapm Foo.tla"},
+                },
+                {"type": "tool_execution_end", "toolCallId": "tool-1", "toolName": "bash", "result": {}},
+            ),
+            "activity after agent_settled",
+        ),
+        (
+            (
+                {
+                    "type": "tool_execution_start",
+                    "toolCallId": "tool-1",
+                    "toolName": "bash",
+                    "args": {"command": "tlapm Foo.tla"},
+                },
+                {"type": "agent_settled"},
+            ),
+            "unfinished tool execution",
+        ),
+    ],
+    ids=("missing-settled", "activity-after-settled", "unfinished-tool"),
+)
+def test_tool_metadata_requires_a_complete_pi_lifecycle(events, warning, tmp_path):
+    output = tmp_path / "output.jsonl"
+    _write_jsonl(output, *events)
+
+    summary = PiBackend().parse_run_metadata(str(output))["tool_calls"]
+
+    assert summary["total"] == 1
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is True
+    assert any(warning in item for item in summary["warnings"])
+
+
+def test_tool_metadata_malformed_stream_is_a_lower_bound(tmp_path):
+    output = tmp_path / "output.jsonl"
+    _write_jsonl(output, "not-json", {"type": "agent_settled"})
+
+    summary = PiBackend().parse_run_metadata(str(output))["tool_calls"]
+
+    assert summary["total"] == 0
+    assert summary["available"] is True
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is True
+    assert "tool-call event stream contains malformed JSON" in summary["warnings"]
+
+
 def test_pi_cli_and_kiro_provider_installs_use_latest_releases():
     script = Path("docker/install-scripts/install-pi.sh").read_text()
 

--- a/tests/evaluator/test_toolcalls.py
+++ b/tests/evaluator/test_toolcalls.py
@@ -641,14 +641,29 @@ def test_stable_ids_dominate_anonymous_lifecycle_witnesses(
 # --- per-backend event vocabularies -----------------------------------------
 
 
-def _cursor_call(kind, command=None, subtype="started", call_id=None):
+def _cursor_call(
+    kind,
+    command=None,
+    subtype="started",
+    call_id=None,
+    *,
+    metadata=None,
+    metadata_first=False,
+    include_call_id=True,
+):
     args = {"command": command} if command is not None else {}
-    return {
+    body = {"args": args}
+    tool = {kind: body}
+    metadata = metadata or {}
+    raw_call = {**metadata, **tool} if metadata_first else {**tool, **metadata}
+    event = {
         "type": "tool_call",
         "subtype": subtype,
-        "call_id": call_id or f"{kind}:{command or ''}",
-        "tool_call": {kind: {"args": args}},
+        "tool_call": raw_call,
     }
+    if include_call_id:
+        event["call_id"] = call_id or f"{kind}:{command or ''}"
+    return event
 
 
 def test_cursor_counts_a_started_completed_pair_once(tmp_path):
@@ -664,6 +679,116 @@ def test_cursor_counts_a_started_completed_pair_once(tmp_path):
         {"type": "result", "subtype": "success", "is_error": False},
     )
     assert CursorBackend().parse_run_metadata(path) == {"tool_calls": _summary(total=3, tlaps=1, apalache=1, other=1)}
+
+
+@pytest.mark.parametrize(
+    ("started_metadata_first", "completed_metadata_first"),
+    [(False, False), (True, True), (True, False), (False, True)],
+)
+def test_cursor_ignores_tool_call_metadata_in_any_field_order(
+    tmp_path,
+    started_metadata_first,
+    completed_metadata_first,
+):
+    metadata = {
+        "hookAdditionalContexts": [],
+        "toolCallId": "native-call",
+        "startedAtMs": "123",
+    }
+    path = _write_jsonl(
+        tmp_path / "cursor-metadata.jsonl",
+        _cursor_call(
+            "shellToolCall",
+            "tlapm --version",
+            call_id="outer-call",
+            metadata=metadata,
+            metadata_first=started_metadata_first,
+        ),
+        _cursor_call(
+            "shellToolCall",
+            "tlapm --version",
+            subtype="completed",
+            call_id="outer-call",
+            metadata=metadata,
+            metadata_first=completed_metadata_first,
+        ),
+        {"type": "result", "subtype": "success", "is_error": False},
+    )
+
+    assert CursorBackend().parse_run_metadata(path)["tool_calls"] == _summary(total=1, tlaps=1)
+
+
+def test_cursor_ignores_metadata_on_non_shell_tools(tmp_path):
+    metadata = {"toolCallId": "native-edit", "completedAtMs": "456"}
+    path = _write_jsonl(
+        tmp_path / "cursor-edit-metadata.jsonl",
+        _cursor_call("editToolCall", call_id="outer-edit", metadata=metadata, metadata_first=True),
+        _cursor_call(
+            "editToolCall",
+            subtype="completed",
+            call_id="outer-edit",
+            metadata=metadata,
+        ),
+        {"type": "result", "subtype": "success", "is_error": False},
+    )
+
+    assert CursorBackend().parse_run_metadata(path)["tool_calls"] == _summary(total=1, other=1)
+
+
+@pytest.mark.parametrize(
+    "raw_call",
+    [
+        {"toolCallId": "metadata-only", "startedAtMs": "123"},
+        {
+            "shellToolCall": {"args": {"command": "tlapm Foo.tla"}},
+            "editToolCall": {"args": {"path": "Foo.tla"}},
+        },
+    ],
+    ids=("zero-tool-fields", "two-tool-fields"),
+)
+def test_cursor_damaged_tool_call_objects_are_not_guessed(raw_call, tmp_path):
+    started = {"type": "tool_call", "subtype": "started", "call_id": "damaged", "tool_call": raw_call}
+    completed = {"type": "tool_call", "subtype": "completed", "call_id": "damaged", "tool_call": raw_call}
+    path = _write_jsonl(
+        tmp_path / "cursor-damaged-call.jsonl",
+        started,
+        completed,
+        {"type": "result", "subtype": "success", "is_error": False},
+    )
+
+    summary = CursorBackend().parse_run_metadata(path)["tool_calls"]
+
+    assert (summary["total"], summary["other"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+    assert any("invalid tool_call object" in warning for warning in summary["warnings"])
+
+
+def test_cursor_does_not_substitute_inner_tool_id_for_missing_outer_call_id(tmp_path):
+    metadata = {"toolCallId": "inner-id", "startedAtMs": "123"}
+    path = _write_jsonl(
+        tmp_path / "cursor-missing-outer-id.jsonl",
+        _cursor_call(
+            "shellToolCall",
+            TLAPM,
+            metadata=metadata,
+            metadata_first=True,
+            include_call_id=False,
+        ),
+        _cursor_call(
+            "shellToolCall",
+            TLAPM,
+            subtype="completed",
+            metadata=metadata,
+            include_call_id=False,
+        ),
+        {"type": "result", "subtype": "success", "is_error": False},
+    )
+
+    summary = CursorBackend().parse_run_metadata(path)["tool_calls"]
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+    assert any("missing or invalid call_id" in warning for warning in summary["warnings"])
 
 
 def test_cursor_completion_without_start_is_counted_but_not_claimed_exact(tmp_path):

--- a/tests/evaluator/test_toolcalls.py
+++ b/tests/evaluator/test_toolcalls.py
@@ -1,0 +1,1094 @@
+"""Tool-call counting: the classifier, and each backend's event vocabulary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from evaluator import toolcalls
+from evaluator.backends.claude_code import ClaudeCodeBackend
+from evaluator.backends.codex import CodexBackend
+from evaluator.backends.copilot import CopilotBackend
+from evaluator.backends.cursor import CursorBackend
+from evaluator.backends.litellm import LiteLLMBackend
+from evaluator.backends.pi import PiBackend
+
+TLAPM = "/opt/tlapm/bin/tlapm -I /opt/tlapm/lib/tlapm/stdlib -I $COMMUNITY_LIB Foo.tla"
+TLC = "java -cp /opt/sany/lib/tla2tools.jar tlc2.TLC -deadlock -config MCFoo.cfg MCFoo.tla"
+APALACHE = "apalache-mc check --init=IndInv --inv=IndInv --length=1 APFoo.tla"
+
+
+def _write_jsonl(path: Path, *events: object) -> str:
+    path.write_text("".join(json.dumps(event) + "\n" for event in events))
+    return str(path)
+
+
+def _summary(*, total, tlaps=0, tlc=0, apalache=0, other=0, complete=True, warnings=()):
+    return {
+        "total": total,
+        "tlaps": tlaps,
+        "tlc": tlc,
+        "apalache": apalache,
+        "other": other,
+        "available": True,
+        "complete": complete,
+        "is_lower_bound": not complete,
+        "warnings": list(warnings),
+    }
+
+
+# --- classifier -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (TLAPM, toolcalls.TLAPS),
+        (TLC, toolcalls.TLC),
+        (APALACHE, toolcalls.APALACHE),
+        ("/opt/apalache/bin/apalache-mc typecheck APFoo.tla", toolcalls.APALACHE),
+        ("check_proof_bin /workspace/Foo.tla", toolcalls.TLAPS),
+        ("check_proof_bin --sany-only /workspace/Foo.tla", toolcalls.OTHER),
+        ("sed -i 's/OBVIOUS/BY DEF Foo/' Foo.tla", toolcalls.OTHER),
+        (None, toolcalls.OTHER),  # a non-shell tool: edit, read, web search
+        ("", toolcalls.OTHER),
+    ],
+)
+def test_classifier_names_the_tool_a_command_reached_for(command, expected):
+    assert toolcalls.classify_command(command) == expected
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        f"cd /workspace && {TLAPM}",  # after a directory change
+        f"{TLAPM} 2>&1 | tail -40",  # first stage of a pipeline
+        f"timeout 600 {TLAPM}",  # behind a wrapper that takes an operand
+        f"TLAPM_CACHE=/tmp {TLAPM}",  # behind an environment assignment
+        f"out=$({TLAPM} 2>&1)",  # captured by command substitution
+        f"for g in A B; do {TLAPM}; done",  # swept over goals in a loop
+        f"/bin/bash -lc {json.dumps(TLAPM)}",  # Codex's real command envelope
+    ],
+)
+def test_classifier_finds_the_prover_wherever_the_line_puts_it(command):
+    # Verbatim shapes from recorded runs: agents rarely type a bare command.
+    assert toolcalls.classify_command(command) == toolcalls.TLAPS
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (f"time (timeout 200 {TLAPM})", toolcalls.TLAPS),
+        (f"TIMEFORMAT=%R; time ({TLC})", toolcalls.TLC),
+        (f"time -p ({APALACHE})", toolcalls.APALACHE),
+        ("time (check_proof_bin --sany-only Foo.tla)", toolcalls.OTHER),
+        ("time (echo tlapm Foo.tla)", toolcalls.OTHER),
+        ("echo (tlapm Foo.tla)", toolcalls.OTHER),
+        ("foo (tlapm Foo.tla)", toolcalls.OTHER),
+        ("X=1 time (tlapm Foo.tla)", toolcalls.OTHER),
+        ("2>/dev/null time (tlapm Foo.tla)", toolcalls.OTHER),
+        ("/usr/bin/time (tlapm Foo.tla)", toolcalls.OTHER),
+        (r"\time (tlapm Foo.tla)", toolcalls.OTHER),
+    ],
+)
+def test_classifier_only_enters_compound_commands_owned_by_the_time_keyword(command, expected):
+    assert toolcalls.classify_command(command) == expected
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "grep -n tlapm notes.txt",
+        "which apalache-mc check_proof_bin",
+        "ls -la /opt/tlapm/bin/tlapm",
+        "pkill -f tlapm",
+        "command -v check_proof_bin",
+        "command -pv tlapm",
+        "env -u tlapm echo harmless",
+        "sudo -u tlapm echo harmless",
+        "stdbuf -o tlapm echo harmless",
+        "rg -n 'missing|tlapm|proof' notes.txt",
+        "bash --norc tlapm Foo.tla",
+        "function prove { tlapm Foo.tla; }",
+        "prove() { tlapm Foo.tla; }",
+    ],
+)
+def test_classifier_reads_the_executable_not_the_line(command):
+    # Naming a tool is not running it, and these are the most common ways to name one.
+    assert toolcalls.classify_command(command) == toolcalls.OTHER
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        # tla2tools.jar is four tools in one, so the main class decides.
+        ("java -cp /opt/sany/lib/tla2tools.jar tla2sany.SANY Foo.tla", toolcalls.OTHER),
+        ("java -cp /opt/sany/lib/tla2tools.jar pcal.trans Foo.tla", toolcalls.OTHER),
+        ("java -cp /opt/tlaplus/tla2tools.jar tlc2.tool.impl.SANY -module Foo", toolcalls.OTHER),
+        ("java -DTLA-Library=/opt/x -cp /opt/sany/lib/tla2tools.jar tlc2.TLC MCFoo", toolcalls.TLC),
+        # No class named: the jar's own entry point is TLC.
+        ("java -jar /opt/sany/lib/tla2tools.jar MCFoo.tla", toolcalls.TLC),
+        ("java -jar apalache.jar check Foo.tla", toolcalls.APALACHE),
+        ("java -cp tla2tools.jar tlc2.TLC ApalacheRegression.tla", toolcalls.TLC),
+        ("java -cp tla2tools.jar tlc2.TLC -jar apalache.jar", toolcalls.TLC),
+        ("java -cp tla2tools.jar tla2sany.SANY -jar tla2tools.jar", toolcalls.OTHER),
+        ("java --add-modules tlc2.TLC com.example.Main", toolcalls.OTHER),
+        ("java -m harmless/Main tlc2.TLC", toolcalls.OTHER),
+        ("java --module harmless/Main tlc2.TLC", toolcalls.OTHER),
+        ("java --describe-module harmless tlc2.TLC", toolcalls.OTHER),
+        ("java --dry-run tlc2.TLC", toolcalls.OTHER),
+        ("java --show-version tlc2.TLC", toolcalls.TLC),
+        ("javac -cp tla2tools.jar Foo.java", toolcalls.OTHER),
+        ("java -cp tla2tools.jar tla2sany.SANY Foo.tla; tlapm Foo.tla", toolcalls.TLAPS),
+    ],
+)
+def test_classifier_resolves_java_hosted_tools_by_main_class(command, expected):
+    assert toolcalls.classify_command(command) == expected
+
+
+def test_classifier_survives_an_unparseable_command():
+    assert toolcalls.classify_command('echo "unbalanced') == toolcalls.OTHER
+
+
+def test_classifier_survives_a_pathologically_deep_shell_tree():
+    command = "echo $(" * 400 + "tlapm Foo.tla" + ")" * 400
+
+    assert toolcalls.classify_command(command) == toolcalls.OTHER
+
+
+@pytest.mark.parametrize("shell", ("bash", "sh"))
+def test_shell_c_option_after_a_script_operand_is_not_unwrapped(shell):
+    assert toolcalls.classify_command(f"{shell} harmless.sh -lc tlapm") == toolcalls.OTHER
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "bash -c -- 'tlapm Foo.tla'",
+        "bash -lc -- 'tlapm Foo.tla'",
+        "bash --norc -c -- 'tlapm Foo.tla'",
+        "sh -c -- 'tlapm Foo.tla'",
+        "sh -lc -- 'tlapm Foo.tla'",
+        "dash -c -- 'tlapm Foo.tla'",
+        "dash -lc -- 'tlapm Foo.tla'",
+    ),
+)
+def test_shell_c_option_accepts_an_immediate_option_terminator(command):
+    assert toolcalls.classify_command(command) == toolcalls.TLAPS
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "bash -c --",
+        "bash -c -- 'echo tlapm Foo.tla'",
+        "bash -- -c 'tlapm Foo.tla'",
+    ),
+)
+def test_shell_option_terminator_does_not_invent_a_command_string(command):
+    assert toolcalls.classify_command(command) == toolcalls.OTHER
+
+
+def test_tool_call_summary_rejects_inconsistent_external_evidence():
+    invalid_lower_bound = _summary(total=1, other=1, complete=False)
+    invalid_lower_bound["is_lower_bound"] = False
+    unavailable_with_counts = _summary(total=1, other=1)
+    unavailable_with_counts.update(available=False, complete=False, is_lower_bound=False)
+
+    for value in (invalid_lower_bound, unavailable_with_counts):
+        summary = toolcalls.ToolCallSummary.from_dict(value)
+        assert summary.available is False
+        assert summary.total == 0
+        assert summary.warnings == ("tool-call summary has inconsistent evidence",)
+
+
+def test_tool_call_summary_rejects_invalid_field_types():
+    with pytest.raises(ValueError, match="evidence fields"):
+        toolcalls.ToolCallSummary(available=1, complete=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="warnings"):
+        toolcalls.ToolCallSummary(warnings=None)  # type: ignore[arg-type]
+
+    invalid_evidence = _summary(total=0)
+    invalid_evidence["available"] = 1
+    invalid_warnings = _summary(total=0)
+    invalid_warnings["warnings"] = ["valid", 3]
+    assert toolcalls.ToolCallSummary.from_dict(invalid_evidence).warnings == ("tool-call summary has invalid evidence",)
+    assert toolcalls.ToolCallSummary.from_dict(invalid_warnings).warnings == ("tool-call summary has invalid warnings",)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Embedded Python naming the checker: recorded verbatim from agents trying to
+        # take the grader apart. Without ignoring the body, the parenthesized path
+        # reads as a bare invocation of it.
+        "python3 <<'PY'\nfrom pathlib import Path\np = Path('/usr/local/bin/check_proof_bin')\nPY",
+        # A module written to disk, whose text happens to mention the prover.
+        "cat > Foo.tla <<EOF\n\\* run with tlapm Foo.tla\n====\nEOF",
+    ],
+)
+def test_classifier_ignores_what_a_heredoc_writes(command):
+    # A heredoc body is data the command writes, not commands it runs; if the agent
+    # later executes it, that run is a tool call of its own.
+    assert toolcalls.classify_command(command) == toolcalls.OTHER
+
+
+def test_classifier_still_sees_the_command_around_a_heredoc():
+    command = f"cat > Foo.tla <<EOF\n---- MODULE Foo ----\n====\nEOF\n{TLAPM}"
+    assert toolcalls.classify_command(command) == toolcalls.TLAPS
+
+
+def test_tally_reports_a_total_and_every_category():
+    counts = toolcalls.tally([TLAPM, None, APALACHE, TLC, "ls", TLAPM])
+    # All four keys always present: a category at 0 is a fact about the run, and a
+    # consumer should never have to distinguish "none" from "not reported".
+    assert counts == {"total": 6, "tlaps": 2, "tlc": 1, "apalache": 1, "other": 2}
+
+
+def test_tally_of_no_calls_is_all_zero():
+    assert toolcalls.tally([]) == {"total": 0, "tlaps": 0, "tlc": 0, "apalache": 0, "other": 0}
+
+
+def test_iter_events_retains_malformed_and_missing_evidence(tmp_path):
+    path = tmp_path / "partial.jsonl"
+    path.write_text('{"type":"a"}\nnot json\n[1,2]\n{"type":"b"}\n')
+    evidence = toolcalls.EventStreamEvidence()
+    assert [event["type"] for event in toolcalls.iter_events(str(path), evidence)] == ["a", "b"]
+    assert evidence.available is True
+    assert evidence.valid is False
+    assert evidence.event_count == 2
+    assert evidence.final_warnings() == (
+        "tool-call event stream contains malformed JSON",
+        "tool-call event stream contains a non-object event",
+    )
+
+    missing = toolcalls.EventStreamEvidence()
+    assert list(toolcalls.iter_events(str(tmp_path / "absent.jsonl"), missing)) == []
+    assert missing.available is False
+    assert missing.valid is False
+    assert missing.final_warnings() == ("tool-call event stream is missing or unreadable",)
+
+
+def test_iter_events_preserves_a_valid_prefix_before_invalid_utf8(tmp_path):
+    path = tmp_path / "invalid-encoding.jsonl"
+    path.write_bytes(b'{"type":"result"}\n\xff\n')
+    evidence = toolcalls.EventStreamEvidence()
+
+    assert list(toolcalls.iter_events(str(path), evidence)) == [{"type": "result"}]
+    assert evidence.available is True
+    assert evidence.valid is False
+    assert evidence.final_warnings() == ("tool-call event stream contains invalid text encoding",)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    (ValueError("integer digit limit"), RecursionError("parser stack limit")),
+    ids=("value-error", "recursion-error"),
+)
+def test_iter_events_treats_json_parser_limits_as_malformed(failure, monkeypatch, tmp_path):
+    path = tmp_path / "parser-limit.jsonl"
+    path.write_text('parser limit\n{"type":"result"}\n')
+    evidence = toolcalls.EventStreamEvidence()
+    original_loads = json.loads
+
+    def loads(raw):
+        if raw == "parser limit":
+            raise failure
+        return original_loads(raw)
+
+    monkeypatch.setattr(toolcalls.json, "loads", loads)
+
+    assert list(toolcalls.iter_events(str(path), evidence)) == [{"type": "result"}]
+    assert evidence.available is True
+    assert evidence.valid is False
+    assert evidence.final_warnings() == ("tool-call event stream contains malformed JSON",)
+
+
+def test_tool_call_summary_merge_preserves_counts_and_evidence():
+    first = toolcalls.ToolCallSummary.from_commands([TLAPM], available=True, complete=True)
+    partial = toolcalls.ToolCallSummary.from_commands(
+        [TLC, None],
+        available=True,
+        complete=False,
+        warnings=("round was truncated",),
+    )
+    assert first.merge(partial).to_dict() == _summary(
+        total=3,
+        tlaps=1,
+        tlc=1,
+        other=1,
+        complete=False,
+        warnings=("round was truncated",),
+    )
+
+
+def test_missing_stream_is_unavailable_not_an_exact_zero(tmp_path):
+    summary = ClaudeCodeBackend().parse_run_metadata(str(tmp_path / "missing.jsonl"))["tool_calls"]
+    assert summary == {
+        "total": 0,
+        "tlaps": 0,
+        "tlc": 0,
+        "apalache": 0,
+        "other": 0,
+        "available": False,
+        "complete": False,
+        "is_lower_bound": False,
+        "warnings": [
+            "tool-call event stream is missing or unreadable",
+            "Claude Code tool-call stream has no unique final result",
+        ],
+    }
+
+
+def test_malformed_prefix_preserves_observed_calls_as_a_lower_bound(tmp_path):
+    path = tmp_path / "claude-partial.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "tool_use", "id": "call-1", "name": "Bash", "input": {"command": TLAPM}}]
+                },
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "type": "user",
+                "message": {"content": [{"type": "tool_result", "tool_use_id": "call-1"}]},
+            }
+        )
+        + "\nnot-json\n"
+        + json.dumps({"type": "result", "subtype": "error_during_execution", "is_error": True})
+        + "\n"
+    )
+    summary = ClaudeCodeBackend().parse_run_metadata(str(path))["tool_calls"]
+    assert summary["total"] == 1
+    assert summary["tlaps"] == 1
+    assert summary["available"] is True
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is True
+    assert summary["warnings"] == ["tool-call event stream contains malformed JSON"]
+
+
+def test_terminal_error_can_still_be_a_complete_tool_stream(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "claude-terminal-error.jsonl",
+        {"type": "result", "subtype": "error_during_execution", "is_error": True},
+    )
+    assert ClaudeCodeBackend().parse_run_metadata(path)["tool_calls"] == _summary(total=0)
+
+
+@pytest.mark.parametrize(
+    ("backend", "terminal"),
+    [
+        (ClaudeCodeBackend(), {"type": "result", "subtype": "success"}),
+        (CursorBackend(), {"type": "result", "subtype": "success", "is_error": False}),
+        (LiteLLMBackend(), {"type": "usage"}),
+    ],
+    ids=("claude_code", "cursor", "litellm"),
+)
+def test_unknown_valid_event_after_terminal_does_not_create_a_false_gap(backend, terminal, tmp_path):
+    path = _write_jsonl(tmp_path / f"{backend.name}-future.jsonl", terminal, {"type": "future.telemetry"})
+
+    assert backend.parse_run_metadata(path)["tool_calls"] == _summary(total=0)
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [CursorBackend(), ClaudeCodeBackend(), CodexBackend(), LiteLLMBackend(), CopilotBackend(), PiBackend()],
+    ids=["cursor", "claude_code", "codex", "litellm", "copilot", "pi"],
+)
+def test_non_string_event_type_is_a_lower_bound_not_a_parser_crash(backend, tmp_path):
+    path = _write_jsonl(tmp_path / f"{backend.name}-invalid-type.jsonl", {"type": []})
+
+    summary = backend.parse_run_metadata(path)["tool_calls"]
+
+    assert summary["available"] is True
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is True
+    assert any("without a string type" in warning for warning in summary["warnings"])
+
+
+@pytest.mark.parametrize(
+    ("backend", "events", "expected_total"),
+    [
+        (
+            ClaudeCodeBackend(),
+            ({"type": "assistant", "message": {}}, {"type": "result", "subtype": "success"}),
+            0,
+        ),
+        (
+            CodexBackend(),
+            (
+                {"type": "thread.started", "thread_id": "root"},
+                {"type": "turn.started"},
+                {"type": "item.started", "item": []},
+                {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+            ),
+            0,
+        ),
+        (CopilotBackend(), ({"type": "assistant.message", "data": []}, {"type": "result"}), 0),
+    ],
+    ids=["claude-message", "codex-item", "copilot-data"],
+)
+def test_malformed_known_activity_envelope_downgrades_enumeration(backend, events, expected_total, tmp_path):
+    path = _write_jsonl(tmp_path / f"{backend.name}-bad-envelope.jsonl", *events)
+
+    summary = backend.parse_run_metadata(path)["tool_calls"]
+
+    assert summary["total"] == expected_total
+    assert summary["is_lower_bound"] is True
+
+
+@pytest.mark.parametrize(
+    ("backend", "events", "expected_total"),
+    [
+        (
+            CursorBackend(),
+            (
+                {
+                    "type": "tool_call",
+                    "subtype": [],
+                    "call_id": "call",
+                    "tool_call": {"shellToolCall": {"args": {"command": TLAPM}}},
+                },
+                {"type": "result"},
+            ),
+            1,
+        ),
+        (
+            CodexBackend(),
+            (
+                {"type": "thread.started", "thread_id": "root"},
+                {"type": "turn.started"},
+                {"type": "item.started", "item": {"id": "call", "type": []}},
+                {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+            ),
+            0,
+        ),
+        (
+            CopilotBackend(),
+            (
+                {"type": "tool.execution_start", "data": {"toolCallId": None, "toolName": []}},
+                {"type": "result"},
+            ),
+            1,
+        ),
+        (
+            LiteLLMBackend(),
+            (
+                {"type": "tool_call", "toolCallId": None, "name": [], "args": {}, "iteration": 1},
+                {"type": "tool_result", "toolCallId": None, "name": [], "iteration": 1},
+                {"type": "usage"},
+            ),
+            1,
+        ),
+        (
+            PiBackend(),
+            (
+                {"type": "tool_execution_start", "toolCallId": None, "toolName": [], "args": {}},
+                {"type": "tool_execution_end", "toolCallId": None, "toolName": []},
+                {"type": "agent_settled"},
+            ),
+            1,
+        ),
+    ],
+    ids=["cursor-subtype", "codex-item-type", "copilot-tool-name", "litellm-name", "pi-tool-name"],
+)
+def test_invalid_nested_discriminator_is_safe_and_conservative(backend, events, expected_total, tmp_path):
+    path = _write_jsonl(tmp_path / f"{backend.name}-bad-nested-type.jsonl", *events)
+
+    summary = backend.parse_run_metadata(path)["tool_calls"]
+
+    assert summary["total"] == expected_total
+    assert summary["is_lower_bound"] is True
+
+
+@pytest.mark.parametrize(
+    ("backend", "events", "expected_tlaps", "expected_other"),
+    [
+        (
+            ClaudeCodeBackend(),
+            (
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "stable",
+                                "name": "Bash",
+                                "input": {"command": TLAPM},
+                            }
+                        ]
+                    },
+                },
+                {"type": "user", "message": {"content": [{"type": "tool_result"}]}},
+                {"type": "result", "subtype": "success"},
+            ),
+            1,
+            0,
+        ),
+        (
+            CodexBackend(),
+            (
+                {"type": "thread.started", "thread_id": "root"},
+                {"type": "turn.started"},
+                {
+                    "type": "item.started",
+                    "item": {"id": "stable", "type": "command_execution", "command": TLAPM},
+                },
+                {
+                    "type": "item.completed",
+                    "item": {"type": "command_execution", "command": TLAPM},
+                },
+                {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+            ),
+            1,
+            0,
+        ),
+        (
+            CursorBackend(),
+            (
+                {
+                    "type": "tool_call",
+                    "subtype": "started",
+                    "call_id": "stable",
+                    "tool_call": {"shellToolCall": {"args": {"command": TLAPM}}},
+                },
+                {
+                    "type": "tool_call",
+                    "subtype": "completed",
+                    "tool_call": {"shellToolCall": {"args": {"command": TLAPM}}},
+                },
+                {"type": "result", "subtype": "success", "is_error": False},
+            ),
+            1,
+            0,
+        ),
+        (
+            LiteLLMBackend(),
+            (
+                {"type": "tool_call", "name": "bash", "args": {"command": TLAPM}, "iteration": 1},
+                {"type": "tool_result", "toolCallId": "stable", "name": "bash", "iteration": 1},
+                {"type": "usage"},
+            ),
+            0,
+            1,
+        ),
+        (
+            CopilotBackend(),
+            (
+                {
+                    "type": "assistant.message",
+                    "data": {
+                        "toolRequests": [
+                            {
+                                "name": "bash",
+                                "toolCallId": "stable",
+                                "arguments": {"command": TLAPM},
+                            }
+                        ]
+                    },
+                },
+                {
+                    "type": "tool.execution_start",
+                    "data": {"toolName": "bash", "arguments": {"command": TLAPM}},
+                },
+                {"type": "tool.execution_complete", "data": {"toolCallId": "stable"}},
+                {"type": "result", "exitCode": 0},
+            ),
+            1,
+            0,
+        ),
+        (
+            PiBackend(),
+            (
+                {
+                    "type": "tool_execution_start",
+                    "toolCallId": "stable",
+                    "toolName": "bash",
+                    "args": {"command": TLAPM},
+                },
+                {"type": "tool_execution_end", "toolName": "bash"},
+                {"type": "agent_settled"},
+            ),
+            1,
+            0,
+        ),
+    ],
+    ids=["claude_code", "codex", "cursor", "litellm", "copilot", "pi"],
+)
+def test_stable_ids_dominate_anonymous_lifecycle_witnesses(
+    backend,
+    events,
+    expected_tlaps,
+    expected_other,
+    tmp_path,
+):
+    path = _write_jsonl(tmp_path / f"{backend.name}-mixed-identity.jsonl", *events)
+
+    summary = backend.parse_run_metadata(path)["tool_calls"]
+
+    assert (summary["total"], summary["tlaps"], summary["other"]) == (1, expected_tlaps, expected_other)
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is True
+
+
+# --- per-backend event vocabularies -----------------------------------------
+
+
+def _cursor_call(kind, command=None, subtype="started", call_id=None):
+    args = {"command": command} if command is not None else {}
+    return {
+        "type": "tool_call",
+        "subtype": subtype,
+        "call_id": call_id or f"{kind}:{command or ''}",
+        "tool_call": {kind: {"args": args}},
+    }
+
+
+def test_cursor_counts_a_started_completed_pair_once(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "cursor.jsonl",
+        {"type": "system", "subtype": "init"},
+        _cursor_call("shellToolCall", TLAPM),
+        _cursor_call("shellToolCall", TLAPM, subtype="completed"),
+        _cursor_call("editToolCall"),
+        _cursor_call("editToolCall", subtype="completed"),
+        _cursor_call("shellToolCall", APALACHE),
+        _cursor_call("shellToolCall", APALACHE, subtype="completed"),
+        {"type": "result", "subtype": "success", "is_error": False},
+    )
+    assert CursorBackend().parse_run_metadata(path) == {"tool_calls": _summary(total=3, tlaps=1, apalache=1, other=1)}
+
+
+def test_cursor_completion_without_start_is_counted_but_not_claimed_exact(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "cursor-orphan.jsonl",
+        _cursor_call("shellToolCall", TLAPM, subtype="completed"),
+        {"type": "result", "subtype": "success", "is_error": False},
+    )
+    assert CursorBackend().parse_run_metadata(path)["tool_calls"] == _summary(
+        total=1,
+        tlaps=1,
+        complete=False,
+        warnings=("Cursor tool completion is missing its start event",),
+    )
+
+
+def test_cursor_correlates_out_of_order_lifecycle_by_native_id(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "cursor-mismatch.jsonl",
+        _cursor_call("editToolCall", subtype="started", call_id="edit"),
+        _cursor_call("shellToolCall", TLAPM, subtype="completed", call_id="shell"),
+        {"type": "result", "subtype": "success", "is_error": False},
+    )
+
+    summary = CursorBackend().parse_run_metadata(path)["tool_calls"]
+    assert (summary["total"], summary["tlaps"], summary["other"]) == (2, 1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+def test_cursor_invalid_subtype_reuses_its_valid_call_id_witness(tmp_path):
+    invalid = _cursor_call("shellToolCall", TLAPM, call_id="same")
+    invalid["subtype"] = []
+    path = _write_jsonl(
+        tmp_path / "cursor-invalid-subtype.jsonl",
+        invalid,
+        _cursor_call("shellToolCall", TLAPM, subtype="started", call_id="same"),
+        _cursor_call("shellToolCall", TLAPM, subtype="completed", call_id="same"),
+        {"type": "result"},
+    )
+
+    summary = CursorBackend().parse_run_metadata(path)["tool_calls"]
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+def test_claude_code_counts_tool_use_blocks(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "cc.jsonl",
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "checking"},
+                    {"type": "tool_use", "id": "bash-1", "name": "Bash", "input": {"command": TLAPM}},
+                    {
+                        "type": "tool_use",
+                        "id": "edit-1",
+                        "name": "Edit",
+                        "input": {"file_path": "Foo.tla"},
+                    },
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "bash-1"},
+                    {"type": "tool_result", "tool_use_id": "edit-1"},
+                ]
+            },
+        },
+        {"type": "result", "subtype": "success", "is_error": False},
+    )
+    assert ClaudeCodeBackend().parse_run_metadata(path) == {"tool_calls": _summary(total=2, tlaps=1, other=1)}
+
+
+def test_claude_only_classifies_the_native_bash_tool_as_shell(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "cc-nonshell.jsonl",
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "edit-1",
+                        "name": "Edit",
+                        "input": {"command": TLAPM},
+                    }
+                ]
+            },
+        },
+        {"type": "user", "message": {"content": [{"type": "tool_result", "tool_use_id": "edit-1"}]}},
+        {"type": "result", "subtype": "success"},
+    )
+
+    assert ClaudeCodeBackend().parse_run_metadata(path)["tool_calls"] == _summary(total=1, other=1)
+
+
+def test_claude_missing_tool_id_preserves_the_call_as_a_lower_bound(tmp_path):
+    anonymous_call = {"type": "tool_use", "name": "Bash", "input": {"command": TLAPM}}
+    path = _write_jsonl(
+        tmp_path / "cc-missing-id.jsonl",
+        {
+            "type": "assistant",
+            "message": {"content": [anonymous_call]},
+        },
+        # Replaying an ID-less event cannot establish a second distinct call.
+        {"type": "assistant", "message": {"content": [anonymous_call]}},
+        {"type": "result", "subtype": "success"},
+    )
+
+    summary = ClaudeCodeBackend().parse_run_metadata(path)["tool_calls"]
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+def test_claude_unfinished_and_orphan_tool_lifecycles_are_lower_bounds(tmp_path):
+    unfinished = _write_jsonl(
+        tmp_path / "cc-unfinished.jsonl",
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "id": "call-1", "name": "Bash", "input": {"command": TLAPM}}]},
+        },
+        {"type": "result", "subtype": "error_during_execution"},
+    )
+    orphan = _write_jsonl(
+        tmp_path / "cc-orphan.jsonl",
+        {"type": "user", "message": {"content": [{"type": "tool_result", "tool_use_id": "lost"}]}},
+        {"type": "result", "subtype": "success"},
+    )
+
+    unfinished_summary = ClaudeCodeBackend().parse_run_metadata(unfinished)["tool_calls"]
+    orphan_summary = ClaudeCodeBackend().parse_run_metadata(orphan)["tool_calls"]
+
+    assert (unfinished_summary["total"], unfinished_summary["tlaps"]) == (1, 1)
+    assert unfinished_summary["is_lower_bound"] is True
+    assert (orphan_summary["total"], orphan_summary["other"]) == (1, 1)
+    assert orphan_summary["is_lower_bound"] is True
+
+
+def test_claude_duplicate_tool_result_id_is_not_double_counted(tmp_path):
+    tool_result = {"type": "user", "message": {"content": [{"type": "tool_result", "tool_use_id": "call-1"}]}}
+    path = _write_jsonl(
+        tmp_path / "cc-duplicate-result.jsonl",
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "id": "call-1", "name": "Bash", "input": {"command": TLAPM}}]},
+        },
+        tool_result,
+        tool_result,
+        {"type": "result", "subtype": "success"},
+    )
+
+    summary = ClaudeCodeBackend().parse_run_metadata(path)["tool_calls"]
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+@pytest.mark.parametrize("result_first", [False, True])
+def test_claude_rejects_duplicate_or_out_of_order_native_ids(result_first, tmp_path):
+    tool_use = {
+        "type": "assistant",
+        "message": {"content": [{"type": "tool_use", "id": "call-1", "name": "Bash", "input": {"command": TLAPM}}]},
+    }
+    tool_result = {"type": "user", "message": {"content": [{"type": "tool_result", "tool_use_id": "call-1"}]}}
+    lifecycle = [tool_result, tool_use] if result_first else [tool_use, tool_use, tool_result]
+    path = _write_jsonl(
+        tmp_path / "cc-invalid-native-id.jsonl",
+        *lifecycle,
+        {"type": "result", "subtype": "success"},
+    )
+
+    summary = ClaudeCodeBackend().parse_run_metadata(path)["tool_calls"]
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+def test_codex_counts_acting_items_not_the_model_talking(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "codex.jsonl",
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        {"type": "item.completed", "item": {"id": "reasoning", "type": "reasoning", "text": "thinking"}},
+        {
+            "type": "item.completed",
+            "item": {"id": "message", "type": "agent_message", "text": "here goes"},
+        },
+        {"type": "item.started", "item": {"id": "command", "type": "command_execution", "command": TLC}},
+        {"type": "item.completed", "item": {"id": "command", "type": "command_execution", "command": TLC}},
+        {"type": "item.started", "item": {"id": "edit", "type": "file_change", "path": "Foo.tla"}},
+        {"type": "item.completed", "item": {"id": "edit", "type": "file_change", "path": "Foo.tla"}},
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    )
+    assert CodexBackend().parse_run_metadata(path) == {"tool_calls": _summary(total=2, tlc=1, other=1)}
+
+
+def test_litellm_counts_agent_dispatched_calls(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "litellm.jsonl",
+        {"type": "response", "text": "let me check"},
+        {"type": "tool_call", "toolCallId": "1", "name": "bash", "args": {"command": TLAPM}, "iteration": 1},
+        {"type": "tool_result", "toolCallId": "1", "name": "bash", "result": "proved", "iteration": 1},
+        {"type": "tool_call", "toolCallId": "2", "name": "write_file", "args": {"path": "Foo.tla"}, "iteration": 2},
+        {"type": "tool_result", "toolCallId": "2", "name": "write_file", "result": "OK", "iteration": 2},
+        {"type": "usage"},
+    )
+    assert LiteLLMBackend().parse_run_metadata(path) == {"tool_calls": _summary(total=2, tlaps=1, other=1)}
+
+
+def test_copilot_counts_tool_requests_on_the_assistant_message(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "copilot.jsonl",
+        {
+            "type": "assistant.message",
+            "data": {
+                "content": "running the prover",
+                "toolRequests": [
+                    {"name": "bash", "toolCallId": "1", "arguments": {"command": TLAPM}},
+                    {"name": "str_replace", "toolCallId": "2", "arguments": {"path": "Foo.tla"}},
+                ],
+            },
+        },
+        {
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "1", "toolName": "bash", "arguments": {"command": TLAPM}},
+        },
+        {"type": "tool.execution_complete", "data": {"toolCallId": "1", "success": True}},
+        {
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "2", "toolName": "str_replace", "arguments": {"path": "Foo.tla"}},
+        },
+        {"type": "tool.execution_complete", "data": {"toolCallId": "2", "success": True}},
+        {"type": "result", "exitCode": 0},
+    )
+    assert CopilotBackend().parse_run_metadata(path) == {"tool_calls": _summary(total=2, tlaps=1, other=1)}
+
+
+def test_copilot_deduplicates_repeated_request_ids(tmp_path):
+    request = {
+        "type": "assistant.message",
+        "data": {"toolRequests": [{"name": "bash", "toolCallId": "same", "arguments": {"command": TLAPM}}]},
+    }
+    path = _write_jsonl(
+        tmp_path / "copilot-duplicate.jsonl",
+        request,
+        request,
+        {
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "same", "toolName": "bash", "arguments": {"command": TLAPM}},
+        },
+        {"type": "tool.execution_complete", "data": {"toolCallId": "same", "success": True}},
+        {"type": "result", "exitCode": 1},
+    )
+    summary = CopilotBackend().parse_run_metadata(path)["tool_calls"]
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+def test_copilot_orphan_native_lifecycle_is_counted_as_a_lower_bound(tmp_path):
+    path = _write_jsonl(
+        tmp_path / "copilot-orphan.jsonl",
+        {
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "orphan", "toolName": "bash", "arguments": {"command": TLAPM}},
+        },
+        {"type": "tool.execution_complete", "data": {"toolCallId": "orphan", "success": True}},
+        {"type": "result", "exitCode": 0},
+    )
+
+    summary = CopilotBackend().parse_run_metadata(path)["tool_calls"]
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+
+
+def test_copilot_only_classifies_the_native_bash_tool_as_shell(tmp_path):
+    request = {
+        "type": "assistant.message",
+        "data": {"toolRequests": [{"name": "str_replace", "toolCallId": "edit", "arguments": {"command": TLAPM}}]},
+    }
+    path = _write_jsonl(
+        tmp_path / "copilot-nonshell.jsonl",
+        request,
+        {
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "edit", "toolName": "str_replace", "arguments": {"command": TLAPM}},
+        },
+        {"type": "tool.execution_complete", "data": {"toolCallId": "edit", "success": True}},
+        {"type": "result", "exitCode": 0},
+    )
+
+    assert CopilotBackend().parse_run_metadata(path)["tool_calls"] == _summary(total=1, other=1)
+
+
+def test_copilot_latches_activity_after_terminal_and_rejects_duplicate_terminals(tmp_path):
+    trailing = _write_jsonl(
+        tmp_path / "copilot-trailing.jsonl",
+        {"type": "result", "exitCode": 0},
+        {"type": "assistant.message", "data": {"toolRequests": []}},
+        {"type": "session.shutdown", "data": {"shutdownType": "routine"}},
+    )
+    duplicate = _write_jsonl(
+        tmp_path / "copilot-duplicate-terminal.jsonl",
+        {"type": "result", "exitCode": 0},
+        {"type": "result", "exitCode": 0},
+    )
+
+    for path in (trailing, duplicate):
+        summary = CopilotBackend().parse_run_metadata(path)["tool_calls"]
+        assert summary["complete"] is False
+        assert summary["is_lower_bound"] is True
+
+
+@pytest.mark.parametrize("order", [("start", "request", "complete"), ("request", "complete", "start")])
+def test_copilot_rejects_out_of_order_native_lifecycle(order, tmp_path):
+    events = {
+        "request": {
+            "type": "assistant.message",
+            "data": {"toolRequests": [{"name": "bash", "toolCallId": "call", "arguments": {"command": TLAPM}}]},
+        },
+        "start": {
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "call", "toolName": "bash", "arguments": {"command": TLAPM}},
+        },
+        "complete": {"type": "tool.execution_complete", "data": {"toolCallId": "call"}},
+    }
+    path = _write_jsonl(
+        tmp_path / "copilot-out-of-order.jsonl",
+        *(events[name] for name in order),
+        {"type": "result"},
+    )
+
+    summary = CopilotBackend().parse_run_metadata(path)["tool_calls"]
+
+    assert (summary["total"], summary["tlaps"]) == (1, 1)
+    assert summary["is_lower_bound"] is True
+    assert any("out-of-order" in warning for warning in summary["warnings"])
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [CursorBackend(), ClaudeCodeBackend(), CodexBackend(), LiteLLMBackend(), CopilotBackend(), PiBackend()],
+    ids=["cursor", "claude_code", "codex", "litellm", "copilot", "pi"],
+)
+def test_an_init_only_stream_reports_zero_as_a_lower_bound(backend, tmp_path):
+    path = _write_jsonl(tmp_path / f"{backend.name}-empty.jsonl", {"type": "system", "subtype": "init"})
+    summary = backend.parse_run_metadata(path)["tool_calls"]
+    assert summary["total"] == 0
+    assert summary["complete"] is False
+    assert summary["is_lower_bound"] is True
+
+
+# --- the count reaching the recorded result ---------------------------------
+
+
+class _FakeMode:
+    name = "proof-completion"
+
+    def __init__(self, bench_dir):
+        self._bench_dir = bench_dir
+
+    def benchmark_dir(self):
+        return self._bench_dir
+
+    def get_dependencies(self, benchmark_path):
+        return []
+
+    def checker_binary_path(self):
+        return "/bin/true"
+
+    def build_prompt(self, basename, tlapm_path, tlapm_lib):
+        return "prove it"
+
+
+def test_the_tally_is_recorded_in_result_json(tmp_path, monkeypatch):
+    """End to end through the runner: a real backend's count lands in the result.
+
+    Counting is worth nothing if it stops at the backend, so this drives
+    run_single_benchmark with the agent and grader faked out — no container, no CLI —
+    and reads the file a consumer would actually receive.
+    """
+    from evaluator import runner
+
+    bench_path = tmp_path / "bench" / "Foo" / "Bar.tla"
+    bench_path.parent.mkdir(parents=True)
+    bench_path.write_text("---- MODULE Bar ----\n====\n")
+    item = runner.WorkItem(
+        benchmark_path=str(bench_path),
+        output_dir=str(tmp_path / "out"),
+        timeout=10,
+        check_timeout=10,
+        backend=CursorBackend(),  # ty:ignore[invalid-argument-type]
+        mode=_FakeMode(str(tmp_path / "bench")),  # ty:ignore[invalid-argument-type]
+        tlapm_path="/bin/true",
+        tlapm_lib="",
+    )
+
+    def fake_agent(item_, backend_, mode, workspace, agent_dir, agent_jsonl, prompt, result, checker, canonical=None):
+        _write_jsonl(
+            Path(agent_jsonl),
+            {"type": "system", "subtype": "init", "model": "Composer 2.5"},
+            _cursor_call("shellToolCall", TLAPM),
+            _cursor_call("shellToolCall", TLAPM, subtype="completed"),
+            _cursor_call("shellToolCall", APALACHE),
+            _cursor_call("shellToolCall", APALACHE, subtype="completed"),
+            _cursor_call("editToolCall"),
+            _cursor_call("editToolCall", subtype="completed"),
+            {"type": "result", "subtype": "success", "is_error": False, "result": "done"},
+        )
+        result["agent_exit"] = 0
+
+    def fake_grader(item_, workspace, basename, grading_dir, check_result_path, result, canonical_dir=None):
+        result["check_verdict"] = "FAIL"
+
+    monkeypatch.setattr(runner, "_run_backend_local", fake_agent)
+    monkeypatch.setattr(runner, "_run_grader_local", fake_grader)
+
+    result = runner.run_single_benchmark(item)
+    expected = _summary(total=3, tlaps=1, apalache=1, other=1)
+    assert result["tool_calls"] == expected
+
+    written = json.loads((Path(item.output_dir) / "Foo" / "Bar" / "result.json").read_text())
+    assert written["tool_calls"] == expected

--- a/uv.lock
+++ b/uv.lock
@@ -1633,6 +1633,9 @@ dependencies = [
     { name = "pytest" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-bash" },
+    { name = "tree-sitter-javascript" },
 ]
 
 [package.metadata]
@@ -1643,6 +1646,9 @@ requires-dist = [
     { name = "pytest" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff" },
+    { name = "tree-sitter", specifier = ">=0.25.2" },
+    { name = "tree-sitter-bash", specifier = ">=0.25.1" },
+    { name = "tree-sitter-javascript", specifier = ">=0.25.0" },
 ]
 
 [[package]]
@@ -1682,6 +1688,70 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/03/5600b84aff2e6c4fe80cfebb4063fe2f50299521befe5f6092ab8c082f4a/tree_sitter-0.26.0.tar.gz", hash = "sha256:b40c219edccc4564530c96f8f1556f6202b37cda964d1cbd7bd2b7e68b40a245", size = 191423, upload-time = "2026-06-30T12:14:27.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/ca/565702c44815393e3a973552ad546db4e5ca081ca8698640b4e93d809f51/tree_sitter-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6cb2bd20efb2544c19ac54486ab7cb8ec7b36f913bbe1ce95df84acb96743d9c", size = 148934, upload-time = "2026-06-30T12:14:01.188Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6f/8bb61957f16ec1b1d92410a006cdc84a952b6352a7313b2ad299f2d21484/tree_sitter-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:918d89529786873f0982a0f59c2a303cd065fbfd1b903d71a8e4e1584f67b42e", size = 140820, upload-time = "2026-06-30T12:14:02.087Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0a/8a6f08559182643a814a4ab559948ae817b2851890fd9b995a4fff6541ce/tree_sitter-0.26.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30a88be89ff1f2755297f81e8080d88b795dd98720c3f9fa2acf93873182cc95", size = 638844, upload-time = "2026-06-30T12:14:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2f/6e6781b31677231366cb3cf27bc8269157f6d4b03c9032865a4f5f2bbe7e/tree_sitter-0.26.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a6b333b0282d8bb0af741f9b018bd2523d4eecb2686bf6717066a625fecfaa4", size = 667487, upload-time = "2026-06-30T12:14:04.669Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0b/0483078c8567445557a7015b0e5b187f6d7d4fda73464df9c4bdea7f7f3c/tree_sitter-0.26.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3f3c44339dd34fe8eb2b8d5aa7610660499a795f70376b130bbee7a437337280", size = 647975, upload-time = "2026-06-30T12:14:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/27/68/da83ca72c984e96ab4eb3bee0db1a6ffb5de1c8c455f92bd9f420cde7f0e/tree_sitter-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:94550e13b6ae576969da40246f4c4abb206380b5375ad43f26dd9151d55438e3", size = 665018, upload-time = "2026-06-30T12:14:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/36/4d67927fd47b89af4a00f65f55a7370e28778cd50e972c2430487e3ecc27/tree_sitter-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:ca89e361a276dbc934b28a43dd881199e25d34ff5493ee0ce45f3c52a6124a37", size = 129619, upload-time = "2026-06-30T12:14:08.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/72/cdefad523eb78710679c6da6a79e3d90f5afd32b1c6aa5a17bac7eef99f6/tree_sitter-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:bc6cb01d5ee75c85424aa1f1c72a82d8f07fd52539a0f3c4a6ed3e8721079b84", size = 116545, upload-time = "2026-06-30T12:14:09.273Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b0/465257cf8f972ad9f9812ec1cbaa8ec210ebebb601ade9a15881aa2436b4/tree_sitter-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ed0889dbed843ce45ede9f5169c0b2dea2222f12685844a03fadb81f12705867", size = 148893, upload-time = "2026-06-30T12:14:10.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/19d093e854b45e807fecfdd26105c266f43aeecc39c4dc97992a7074ad5a/tree_sitter-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6189c6c340c7384357711e3d92645e96bfb79f7a502f86de1ebdb23eb43f7dab", size = 140829, upload-time = "2026-06-30T12:14:11.626Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ee/87e74671ed63a837e7a1f17ab94aa3913871e033b27523d8e7b83d6f7ad0/tree_sitter-0.26.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ff2e0750b7daa722302838356d7b65e303829b7eb73c915df127ddba115e1d1", size = 639334, upload-time = "2026-06-30T12:14:12.836Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e7/f7e04cd9dff6b6ac0adf23922796fbc76accd4cf4bcda50542748d485679/tree_sitter-0.26.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7075ef857ef86f327dbb72d1e2574dda78db5754b3a1fca6506acd7fe5d561a7", size = 668102, upload-time = "2026-06-30T12:14:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/90/0bfb16b7894fea728c774a89d5af421a9368a2f913bbd4e8dcab7caaecfb/tree_sitter-0.26.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:26c996c1edfee86e977bb3f5462e74fcec0d0b0db1e85a3c475875763caa03be", size = 648560, upload-time = "2026-06-30T12:14:15.302Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e6/0fe05ba396e9623b0ae40ccf34171336b8701ec8d7bd0ee9f5224d638665/tree_sitter-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00289bfe7978f3e0dc0ce69813a20fa9f44ea4c100b3ec62043e5eb74ccfc3a2", size = 665121, upload-time = "2026-06-30T12:14:16.403Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/a944b1ca35bed6068dc84a9967aaf3049d8cc0b7a36179eea8787270a6ab/tree_sitter-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:93e220cab7e6a823efeb2046c49171427de92ef71c7c681c01820d14d8d3721f", size = 129615, upload-time = "2026-06-30T12:14:17.463Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ef/c7ca48293580d2249f36940c4eed5b4ddeb9ce75baf9a4ef30621987e0c7/tree_sitter-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:b31a8195d2f224224c530ac814632d98c1dcc123d227442c07c736e86b70d564", size = 116525, upload-time = "2026-06-30T12:14:18.53Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/7a/4d84e6f6ae2c3e757490dd84de251712c31e293dfe31f28da1ec019cefa2/tree_sitter-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5a3c93a352b7e6f70f73e121bbfa2d0117ba7478bd51114ed35c91b0b78814fa", size = 148901, upload-time = "2026-06-30T12:14:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d9/efe62ec65dc9d096e834d27b8c058127e2146e42ff3380b822a233f016a6/tree_sitter-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5fc2f41bf246ff2f70a9cc3690be35ec7580a4923151873d898c8bcb1a4503d3", size = 140805, upload-time = "2026-06-30T12:14:20.478Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2c/c82326b7b97e3c485c18679883b16f89e5e913c639d3b219d3da70c9e67e/tree_sitter-0.26.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8ea92a255c91671a7ec4625aba3ab7bb5220c423630ffbf83c45d7312abe084", size = 640586, upload-time = "2026-06-30T12:14:21.527Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/7a/f56e7d8282859452611024c7cbc623bfba5b24b8cb9b8f8bc88c5219fe9a/tree_sitter-0.26.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f665510f0fcf4636fb9696f1f7853bed7a3bd764b7bb0cb8494e619c14ed5a0c", size = 668300, upload-time = "2026-06-30T12:14:22.728Z" },
+    { url = "https://files.pythonhosted.org/packages/91/51/240ee81b9d5e9ca0a6cb1528e8605ffa70ab58c89ce126631be96d3e4bae/tree_sitter-0.26.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:253df7ab82cc0a9d311cd65f06e9f99fb3eac55996ae9fc94da22f123a861b90", size = 649627, upload-time = "2026-06-30T12:14:23.819Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/54/760035cefedf9eb44f0f84c4ac22f1322e73155853e272576ee876336312/tree_sitter-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ff80d4833d330a73184a3ac5132abe93c575d2dea31975c6f15c0d21fef238aa", size = 664885, upload-time = "2026-06-30T12:14:25.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1b/0b36fe2a984ecedc4ce6aefd5d56447a6626a8e9b595c4e48658510ce8f8/tree_sitter-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:a4033fecc8f606c7f2e8b8014d0057b74668a7f0152763606f7bc25c5f9ec64c", size = 132688, upload-time = "2026-06-30T12:14:26.106Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/74/ebc041a13fbf40144afdb0d4b447e48e0b4012ca866c63de8b48f801f0c1/tree_sitter-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:823251c4b6725a7c03ed497a339135ede7ae4bdde75bb8be7ef5e305aeb4ff52", size = 120287, upload-time = "2026-06-30T12:14:26.991Z" },
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/0e/f0108be910f1eef6499eabce517e79fe3b12057280ed398da67ce2426cba/tree_sitter_bash-0.25.1.tar.gz", hash = "sha256:bfc0bdaa77bc1e86e3c6652e5a6e140c40c0a16b84185c2b63ad7cd809b88f14", size = 419703, upload-time = "2025-12-02T17:01:08.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/8e/37e7364d9c9c58da89e05c510671d8c45818afd7b31c6939ab72f8dc6c04/tree_sitter_bash-0.25.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0e6235f59e366d220dde7d830196bed597d01e853e44d8ccd1a82c5dd2500acf", size = 194160, upload-time = "2025-12-02T17:00:59.047Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bb/2d2cfbb1f89aaeb1ec892624f069d92d058d06bb66f16b9ec9fb5873ab60/tree_sitter_bash-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f4a34a6504c7c5b2a9b8c5c4065531dea19ca2c35026e706cf2eeeebe2c92512", size = 202659, upload-time = "2025-12-02T17:01:00.275Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f0/1bb25519be27460255d3899db677313cfa1e6306988fbf456a3d7e211bbb/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e76c4cfb20b076552406782b7f8c2a3946835993df0a44df006de54b7030c7dc", size = 230596, upload-time = "2025-12-02T17:01:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/22/9f70bc3d3b942ab9fc0f89c1dc9e087519a3a94f64ae6b7377aae3a7a0f0/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3f484c4bb8796cde7a87ca351e6116f09653edac0eb3c6d238566359dd28b117", size = 231981, upload-time = "2025-12-02T17:01:02.859Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c3/f1540e42cd41b323c6821e45e52e1aed6ed386209aad52db996f05703963/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5e76af6df46d958c7f5b6d5884c9743218e3902a00ccb493ec92728b1084430b", size = 228364, upload-time = "2025-12-02T17:01:03.997Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/c3050a6277dfcac8c480f514dc4fe49f3f65f0eac68b4702cbaca2584e85/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a3332d71c7b7d5f78259b19d02d0ea111fcb82b72712ee4a93aaa5b226d3f0a8", size = 230074, upload-time = "2025-12-02T17:01:05.05Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0f/203fe6b27211387f4b9ba8c4a321567ca4ded2624dae6ccdbd2b6e940e17/tree_sitter_bash-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:52a6802d9218f86278aa3e8b459c3abdad67eed0fde1f9f13aca5b6c634217a6", size = 195574, upload-time = "2025-12-02T17:01:06.412Z" },
+    { url = "https://files.pythonhosted.org/packages/47/75/4ca1a9fabd8fb5aea78cea70f7837ce4dbf2afae115f62051e5fa99cba1c/tree_sitter_bash-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:59115057ec2bae319e8082ff29559861045002964c3431ccb0fc92aa4bc9bccb", size = 191196, upload-time = "2025-12-02T17:01:07.486Z" },
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/e0/e63103c72a9d3dfd89a31e02e660263ad84b7438e5f44ee82e443e65bbde/tree_sitter_javascript-0.25.0.tar.gz", hash = "sha256:329b5414874f0588a98f1c291f1b28138286617aa907746ffe55adfdcf963f38", size = 132338, upload-time = "2025-09-01T07:13:44.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/df/5106ac250cd03661ebc3cc75da6b3d9f6800a3606393a0122eca58038104/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b70f887fb269d6e58c349d683f59fa647140c410cfe2bee44a883b20ec92e3dc", size = 64052, upload-time = "2025-09-01T07:13:36.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/8f/6b4b2bc90d8ab3955856ce852cc9d1e82c81d7ab9646385f0e75ffd5b5d3/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8264a996b8845cfce06965152a013b5d9cbb7d199bc3503e12b5682e62bb1de1", size = 66440, upload-time = "2025-09-01T07:13:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c4/7da74ecdcd8a398f88bd003a87c65403b5fe0e958cdd43fbd5fd4a398fcf/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dc04ba91fc8583344e57c1f1ed5b2c97ecaaf47480011b92fbeab8dda96db75", size = 99728, upload-time = "2025-09-01T07:13:38.755Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c8/97da3af4796495e46421e9344738addb3602fa6426ea695be3fcbadbee37/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:199d09985190852e0912da2b8d26c932159be314bc04952cf917ed0e4c633e6b", size = 106072, upload-time = "2025-09-01T07:13:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/13/be/c964e8130be08cc9bd6627d845f0e4460945b158429d39510953bbcb8fcc/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dfcf789064c58dc13c0a4edb550acacfc6f0f280577f1e7a00de3e89fc7f8ddc", size = 104388, upload-time = "2025-09-01T07:13:40.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e5ed840f5bd4a3f0272e441d19429b26eedc257abe5574c8546da6b556865e3c", size = 62975, upload-time = "2025-09-01T07:13:42.828Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1f/f9eba1038b7d4394410f3c0a6ec2122b590cd7acb03f196e52fa57ebbe72/tree_sitter_javascript-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:622a69d677aa7f6ee2931d8c77c981a33f0ebb6d275aa9d43d3397c879a9bb0b", size = 61668, upload-time = "2025-09-01T07:13:43.803Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Record how many tools an agent called, and which TLA+ tool each reached for.

Every agentic backend now reports a tally through the parse_run_metadata hook the runner already merges into result.json:

    "tool_calls": {"total": 88, "tlaps": 38, "tlc": 0, "apalache": 0,
                   "other": 50}

The split answers a second question the data could not: whether agents reach for the checkers the container ships. Across 659 recorded sessions here they called tlapm 46022 times, Apalache 35, and TLC twice.

Recognition works on the executable of each command in a pipeline, not a substring of the line, so `grep tlapm notes.txt` is not a prover run; command substitution and shell keywords are boundaries too, because `out=$(tlapm ...)` and `for g in ...; do tlapm ...; done` are how agents actually invoke it. Java-hosted tools resolve by main class, since tla2tools.jar holds TLC, the SANY parser and the PlusCal translator alike.