### PR TITLE
Detect fatal Copilot session errors

### DIFF
--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -209,6 +209,12 @@ def claude_code_result_error(ctx: TerminationContext) -> str | None:
     return None
 
 
+def _copilot_shutdown_type(event: dict) -> object:
+    data = event.get("data")
+    nested = data.get("shutdownType") if isinstance(data, dict) else None
+    return event.get("shutdownType", nested)
+
+
 def copilot_session_error(ctx: TerminationContext) -> str | None:
     """copilot rule: the run did not reach a clean terminal.
 
@@ -237,15 +243,14 @@ def copilot_session_error(ctx: TerminationContext) -> str | None:
         if ev.get("agentId") is not None:
             continue
         t = ev.get("type")
-        root_error = t in {"session.error", "abort"} or (t == "session.shutdown" and ev.get("shutdownType") == "error")
+        shutdown_type = _copilot_shutdown_type(ev)
+        root_error = t in {"session.error", "abort"} or (t == "session.shutdown" and shutdown_type == "error")
         if root_error:
             reached_clean_terminal = False
             root_error_pending = True
         elif t == "assistant.message":
             root_error_pending = False
-        elif not root_error_pending and (
-            t == "result" or (t == "session.shutdown" and ev.get("shutdownType") != "error")
-        ):
+        elif not root_error_pending and (t == "result" or (t == "session.shutdown" and shutdown_type != "error")):
             reached_clean_terminal = True
     if reached_clean_terminal:
         return None

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -219,14 +219,12 @@ def copilot_session_error(ctx: TerminationContext) -> str | None:
     ``"quota"``), an ``abort``, or ``session.shutdown`` with
     ``shutdownType == "error"``.
 
-    We flag INFRA_ERROR only on a WHOLESALE failure — the run reached no clean
-    terminal event. An intermittent ``session.error`` the agent then recovered
-    from (followed by a clean terminal) is NOT flagged. A per-tool failure
-    (``tool.execution_complete`` with ``success: false`` — e.g. tlapm rejecting
-    a proof) and a non-zero ``result`` ``exitCode`` (the proof simply not
-    verifying) are normal parts of an attempt and never count. (Event vocabulary
-    per the Copilot SDK streaming-events docs; no recorded copilot runs yet to
-    validate against.)
+    A ``result`` is only the CLI's terminal envelope: Copilot may emit one with
+    ``exitCode: 1`` immediately after an unrecovered root ``session.error``.
+    Such a result is not clean. A later root ``assistant.message`` followed by a
+    terminal event proves recovery; errors carrying ``agentId`` belong to a
+    subagent and do not poison a completed root run. Per-tool failures and a
+    non-zero result without a root session error remain genuine attempts.
     """
     if ctx.backend != "copilot":
         return None
@@ -234,9 +232,20 @@ def copilot_session_error(ctx: TerminationContext) -> str | None:
     if not events:
         return None
     reached_clean_terminal = False
+    root_error_pending = False
     for ev in events:
+        if ev.get("agentId") is not None:
+            continue
         t = ev.get("type")
-        if t == "result" or (t == "session.shutdown" and ev.get("shutdownType") != "error"):
+        root_error = t in {"session.error", "abort"} or (t == "session.shutdown" and ev.get("shutdownType") == "error")
+        if root_error:
+            reached_clean_terminal = False
+            root_error_pending = True
+        elif t == "assistant.message":
+            root_error_pending = False
+        elif not root_error_pending and (
+            t == "result" or (t == "session.shutdown" and ev.get("shutdownType") != "error")
+        ):
             reached_clean_terminal = True
     if reached_clean_terminal:
         return None

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -1079,10 +1079,10 @@ CP_ABORT = [
     {"type": "abort"},
 ]
 CP_SHUTDOWN_ERROR = [
-    {"type": "session.shutdown", "shutdownType": "error", "errorReason": "stream closed"},
+    {"type": "session.shutdown", "data": {"shutdownType": "error", "errorReason": "stream closed"}},
 ]
 CP_SHUTDOWN_OK = [
-    {"type": "session.shutdown", "shutdownType": "routine"},
+    {"type": "session.shutdown", "data": {"shutdownType": "routine"}},
 ]
 CP_RECOVERED = [  # intermittent session.error, then recovered to a clean terminal
     {"type": "assistant.message", "data": {"content": "hi"}},
@@ -1145,6 +1145,15 @@ def test_copilot_shutdown_error_is_infra(tmp_path):
 def test_copilot_shutdown_routine_is_ok(tmp_path):
     p = _write_jsonl(tmp_path / "sdok.jsonl", CP_SHUTDOWN_OK)
     assert classify(_ctx(p, backend="copilot")) == TerminationReason.OK
+
+
+@pytest.mark.parametrize(
+    ("shutdown_type", "expected"),
+    [("error", TerminationReason.INFRA_ERROR), ("routine", TerminationReason.OK)],
+)
+def test_copilot_legacy_top_level_shutdown_type_is_supported(tmp_path, shutdown_type, expected):
+    p = _write_jsonl(tmp_path / "legacy-shutdown.jsonl", [{"type": "session.shutdown", "shutdownType": shutdown_type}])
+    assert classify(_ctx(p, backend="copilot")) == expected
 
 
 def test_copilot_recovered_session_error_is_ok(tmp_path):

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -1063,8 +1063,8 @@ def test_cursor_rule_only_applies_to_cursor(tmp_path):
 
 # --- copilot rule (event vocabulary per Copilot SDK streaming-events docs) ---
 
-# A clean run: per-tool failure is normal (tlapm rejecting a proof), terminal
-# `result` with a non-zero exitCode is the proof failing — neither is infra.
+# A clean run: per-tool failure is normal (tlapm rejecting a proof), and a
+# terminal `result` with a non-zero exitCode can be a genuine proof failure.
 CP_COMPLETED = [
     {"type": "assistant.message", "data": {"content": "hi"}},
     {"type": "tool.execution_complete", "data": {"result": {"success": False}}},
@@ -1090,6 +1090,32 @@ CP_RECOVERED = [  # intermittent session.error, then recovered to a clean termin
     {"type": "assistant.message", "data": {"content": "retrying"}},
     {"type": "result", "exitCode": 0, "usage": {"premiumRequests": 2}},
 ]
+CP_ERROR_THEN_RESULT = [  # Copilot emits a result envelope after a fatal root error
+    {"type": "assistant.message", "data": {"content": "working"}},
+    {
+        "type": "model.call_failure",
+        "data": {"model": "gpt-5.6-sol", "source": "top_level", "errorMessage": "ETIMEDOUT"},
+    },
+    {"type": "assistant.turn_end", "data": {"turnId": "20"}},
+    {
+        "type": "session.error",
+        "data": {"errorType": "query", "message": "Failed to get response from the AI model"},
+    },
+    {"type": "assistant.idle", "data": {}},
+    {"type": "result", "exitCode": 1, "usage": {"premiumRequests": 0}},
+]
+CP_SUBAGENT_ERROR_THEN_RESULT = [
+    {"type": "assistant.message", "data": {"content": "working"}},
+    {
+        "type": "session.error",
+        "agentId": "call_rubber_duck",
+        "data": {"errorType": "query", "message": "subagent ETIMEDOUT"},
+    },
+    {"type": "subagent.failed", "agentId": "call_rubber_duck", "data": {"error": "No response generated"}},
+    {"type": "assistant.message", "data": {"content": "finished without the subagent"}},
+    {"type": "assistant.turn_end", "data": {"turnId": "41"}},
+    {"type": "result", "exitCode": 1, "usage": {"premiumRequests": 0}},
+]
 CP_TRUNCATED = [  # cut off before any terminal event
     {"type": "assistant.message", "data": {"content": "working"}},
     {"type": "tool.execution_start", "data": {}},
@@ -1098,7 +1124,7 @@ CP_TRUNCATED = [  # cut off before any terminal event
 
 def test_copilot_completed_is_ok(tmp_path):
     p = _write_jsonl(tmp_path / "done.jsonl", CP_COMPLETED)
-    assert classify(_ctx(p, backend="copilot")) == TerminationReason.OK
+    assert classify(_ctx(p, backend="copilot", agent_exit=1)) == TerminationReason.OK
 
 
 def test_copilot_session_error_is_infra(tmp_path):
@@ -1126,6 +1152,26 @@ def test_copilot_recovered_session_error_is_ok(tmp_path):
     # (followed by a clean terminal) must NOT be flagged.
     p = _write_jsonl(tmp_path / "recov.jsonl", CP_RECOVERED)
     assert classify(_ctx(p, backend="copilot")) == TerminationReason.OK
+
+
+def test_copilot_root_session_error_is_infra_even_with_terminal_result(tmp_path):
+    p = _write_jsonl(tmp_path / "root-error-result.jsonl", CP_ERROR_THEN_RESULT)
+    assert classify(_ctx(p, backend="copilot", agent_exit=1)) == TerminationReason.INFRA_ERROR
+
+
+def test_copilot_subagent_error_does_not_poison_completed_root_run(tmp_path):
+    p = _write_jsonl(tmp_path / "subagent-error-result.jsonl", CP_SUBAGENT_ERROR_THEN_RESULT)
+    assert classify(_ctx(p, backend="copilot", agent_exit=1)) == TerminationReason.OK
+
+
+def test_copilot_subagent_activity_does_not_recover_root_session_error(tmp_path):
+    events = [
+        *CP_ERROR_THEN_RESULT[:-1],
+        {"type": "assistant.message", "agentId": "call_subagent", "data": {"content": "still working"}},
+        CP_ERROR_THEN_RESULT[-1],
+    ]
+    p = _write_jsonl(tmp_path / "root-error-subagent-activity.jsonl", events)
+    assert classify(_ctx(p, backend="copilot", agent_exit=1)) == TerminationReason.INFRA_ERROR
 
 
 def test_copilot_truncated_is_infra(tmp_path):


### PR DESCRIPTION
## Summary

- keep an unrecovered root Copilot `session.error` classified as `INFRA_ERROR` even when the CLI later emits a `result` envelope
- read `session.shutdown` lifecycle data from the real nested event envelope while retaining legacy top-level compatibility
- preserve genuine completed runs after root recovery or subagent-only errors
- add regression coverage based on the observed Copilot event sequences
