### PR TITLE
Add specification-equal scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ uv run tlaps-bench run --jobs 10 --timeout 7200
 uv run tlaps-bench run --mode proof-from-scratch --jobs 10
 ```
 
-Each run writes `results.json` and `summary.md` (with the headline pass rate);
-`uv run tlaps-bench score` (re)computes and compares pass rates. Use `--resume`
-with a fixed `--output-dir` to skip tasks already recorded as PASS, and
-`--force-build` to rebuild the image after changing source.
+Each run writes `results.json` and `summary.md` (with specification-macro as the
+primary score and task-micro as a diagnostic); `uv run tlaps-bench score`
+(re)computes and compares scores. See the [scoring documentation](docs/USAGE.md#tlaps-bench-score)
+for the grouping rule and formulas. Use `--resume` with a fixed `--output-dir` to
+skip tasks already recorded as PASS, and `--force-build` to rebuild the image
+after changing source.
 
 Choosing an agent (`--backend` / `--model`) and its credentials, the full CLI
 reference, and native (`--no-container`) setup are covered in the

--- a/benchmark/proof-completion/manifest.json
+++ b/benchmark/proof-completion/manifest.json
@@ -1,198 +1,236 @@
 {
   "Allocator/Allocator_AllocateMutex.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_AllocateMutexScaffold.tla"
     ]
   },
   "Allocator/Allocator_AllocateTypeInvariant.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_AllocateTypeInvariantScaffold.tla"
     ]
   },
   "Allocator/Allocator_InitMutex.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_InitMutexScaffold.tla"
     ]
   },
   "Allocator/Allocator_InitTypeInvariant.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_InitTypeInvariantScaffold.tla"
     ]
   },
   "Allocator/Allocator_NextMutex.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_NextMutexScaffold.tla"
     ]
   },
   "Allocator/Allocator_NextTypeInvariant.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_NextTypeInvariantScaffold.tla"
     ]
   },
   "Allocator/Allocator_RequestMutexBis.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_RequestMutexBisScaffold.tla"
     ]
   },
   "Allocator/Allocator_RequestTypeInvariant.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_RequestTypeInvariantScaffold.tla"
     ]
   },
   "Allocator/Allocator_ReturnMutex.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_ReturnMutexScaffold.tla"
     ]
   },
   "Allocator/Allocator_ReturnTypeInvariant.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_ReturnTypeInvariantScaffold.tla"
     ]
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_AfterPrime.tla": {
+    "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_AfterPrimeScaffold.tla"
     ]
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_GGIrreflexive.tla": {
+    "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_GGIrreflexiveScaffold.tla"
     ]
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_InductiveInvariant.tla": {
+    "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_InductiveInvariantScaffold.tla"
     ]
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_InitImpliesTypeOK.tla": {
+    "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_InitImpliesTypeOKScaffold.tla"
     ]
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_InitInv.tla": {
+    "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_InitInvScaffold.tla"
     ]
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_InvExclusion.tla": {
+    "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_InvExclusionScaffold.tla"
     ]
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_Safety.tla": {
+    "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_SafetyScaffold.tla"
     ]
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_TypeOKInvariant.tla": {
+    "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_TypeOKInvariantScaffold.tla"
     ]
   },
   "BubbleSort/BubbleSort_CompositionAssociative.tla": {
+    "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_CompositionAssociativeScaffold.tla"
     ]
   },
   "BubbleSort/BubbleSort_CompositionOfPerms.tla": {
+    "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_CompositionOfPermsScaffold.tla"
     ]
   },
   "BubbleSort/BubbleSort_ExchangeAPerm.tla": {
+    "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_ExchangeAPermScaffold.tla"
     ]
   },
   "BubbleSort/BubbleSort_IdAPerm.tla": {
+    "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IdAPermScaffold.tla"
     ]
   },
   "BubbleSort/BubbleSort_IdIdentity.tla": {
+    "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IdIdentityScaffold.tla"
     ]
   },
   "BubbleSort/BubbleSort_IsPermOfExchange.tla": {
+    "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IsPermOfExchangeScaffold.tla"
     ]
   },
   "BubbleSort/BubbleSort_IsPermOfReflexive.tla": {
+    "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IsPermOfReflexiveScaffold.tla"
     ]
   },
   "BubbleSort/BubbleSort_IsPermOfTransitive.tla": {
+    "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IsPermOfTransitiveScaffold.tla"
     ]
   },
   "Cantor/Cantor10_Cantor.tla": {
+    "spec_id": "Cantor/Cantor10.tla",
     "context": [
       "Cantor/Cantor10_CantorScaffold.tla"
     ]
   },
   "Cantor/Cantor10_NoSetContainsAllValues.tla": {
+    "spec_id": "Cantor/Cantor10.tla",
     "context": [
       "Cantor/Cantor10_NoSetContainsAllValuesScaffold.tla"
     ]
   },
   "Cantor/Cantor1_cantor.tla": {
+    "spec_id": "Cantor/Cantor1.tla",
     "context": [
       "Cantor/Cantor1_cantorScaffold.tla"
     ]
   },
   "Cantor/Cantor2_cantor.tla": {
+    "spec_id": "Cantor/Cantor2.tla",
     "context": [
       "Cantor/Cantor2_cantorScaffold.tla"
     ]
   },
   "Cantor/Cantor3_cantor.tla": {
+    "spec_id": "Cantor/Cantor3.tla",
     "context": [
       "Cantor/Cantor3_cantorScaffold.tla"
     ]
   },
   "Cantor/Cantor4_cantor.tla": {
+    "spec_id": "Cantor/Cantor4.tla",
     "context": [
       "Cantor/Cantor4_cantorScaffold.tla"
     ]
   },
   "Cantor/Cantor5_cantor.tla": {
+    "spec_id": "Cantor/Cantor5.tla",
     "context": [
       "Cantor/Cantor5_cantorScaffold.tla"
     ]
   },
   "Cantor/Cantor6_cantor.tla": {
+    "spec_id": "Cantor/Cantor6.tla",
     "context": [
       "Cantor/Cantor6_cantorScaffold.tla"
     ]
   },
   "Cantor/Cantor7_cantor.tla": {
+    "spec_id": "Cantor/Cantor7.tla",
     "context": [
       "Cantor/Cantor7_cantorScaffold.tla"
     ]
   },
   "Cantor/Cantor8_Cantor.tla": {
+    "spec_id": "Cantor/Cantor8.tla",
     "context": [
       "Cantor/Cantor8_CantorScaffold.tla"
     ]
   },
   "Cantor/Cantor9_Cantor.tla": {
+    "spec_id": "Cantor/Cantor9.tla",
     "context": [
       "Cantor/Cantor9_CantorScaffold.tla"
     ]
   },
   "Consensus/Consensus_Invariance.tla": {
+    "spec_id": "Consensus/Consensus.tla",
     "context": [
       "Consensus/ConsensusModel.tla",
       "Consensus/Consensus_InvarianceScaffold.tla",
@@ -200,6 +238,7 @@
     ]
   },
   "Consensus/PaxosProof_WFmsgs.tla": {
+    "spec_id": "Consensus/PaxosProof.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/PaxosProof_WFmsgsScaffold.tla",
@@ -209,6 +248,7 @@
     ]
   },
   "Consensus/PaxosProof_struct_lemma.tla": {
+    "spec_id": "Consensus/PaxosProof.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/PaxosProof_struct_lemmaScaffold.tla",
@@ -218,6 +258,7 @@
     ]
   },
   "Consensus/PaxosProof_typing.tla": {
+    "spec_id": "Consensus/PaxosProof.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/PaxosProof_typingScaffold.tla",
@@ -227,6 +268,7 @@
     ]
   },
   "Consensus/Voting_AllSafeAtZero.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/Sets.tla",
@@ -235,6 +277,7 @@
     ]
   },
   "Consensus/Voting_ChoosableThm.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/Sets.tla",
@@ -243,6 +286,7 @@
     ]
   },
   "Consensus/Voting_Consistent.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/Sets.tla",
@@ -251,6 +295,7 @@
     ]
   },
   "Consensus/Voting_Invariant.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/Sets.tla",
@@ -259,6 +304,7 @@
     ]
   },
   "Consensus/Voting_OneVoteThm.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/Sets.tla",
@@ -267,6 +313,7 @@
     ]
   },
   "Consensus/Voting_QuorumNonEmpty.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/Sets.tla",
@@ -275,6 +322,7 @@
     ]
   },
   "Consensus/Voting_Refinement.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/Sets.tla",
@@ -283,6 +331,7 @@
     ]
   },
   "Consensus/Voting_ShowsSafety.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/Sets.tla",
@@ -291,6 +340,7 @@
     ]
   },
   "Consensus/Voting_VotesSafeImpliesConsistency.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Consensus.tla",
       "Consensus/Sets.tla",
@@ -299,164 +349,194 @@
     ]
   },
   "Data/GraphTheorem_AtLeastTwo.tla": {
+    "spec_id": "Data/GraphTheorem.tla",
     "context": [
       "Data/GraphTheorem_AtLeastTwoScaffold.tla",
       "Data/Sets.tla"
     ]
   },
   "Data/GraphTheorem_EdgesAxiom.tla": {
+    "spec_id": "Data/GraphTheorem.tla",
     "context": [
       "Data/GraphTheorem_EdgesAxiomScaffold.tla",
       "Data/Sets.tla"
     ]
   },
   "Data/SequencesTheorems_RemoveSeq.tla": {
+    "spec_id": "Data/SequencesTheorems.tla",
     "context": [
       "Data/SequencesTheorems_RemoveSeqScaffold.tla"
     ]
   },
   "Data/Sets_CardinalityInNat.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityInNatScaffold.tla"
     ]
   },
   "Data/Sets_CardinalityOne.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityOneScaffold.tla"
     ]
   },
   "Data/Sets_CardinalityOneConverse.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityOneConverseScaffold.tla"
     ]
   },
   "Data/Sets_CardinalityPlusOne.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityPlusOneScaffold.tla"
     ]
   },
   "Data/Sets_CardinalitySetMinus.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalitySetMinusScaffold.tla"
     ]
   },
   "Data/Sets_CardinalityTwo.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityTwoScaffold.tla"
     ]
   },
   "Data/Sets_CardinalityZero.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityZeroScaffold.tla"
     ]
   },
   "Data/Sets_FiniteSubset.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_FiniteSubsetScaffold.tla"
     ]
   },
   "Data/Sets_IntervalCardinality.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_IntervalCardinalityScaffold.tla"
     ]
   },
   "Data/Sets_IsBijectionInverse.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_IsBijectionInverseScaffold.tla"
     ]
   },
   "Data/Sets_IsBijectionTransitive.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_IsBijectionTransitiveScaffold.tla"
     ]
   },
   "Data/Sets_PigeonHole.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_PigeonHoleScaffold.tla"
     ]
   },
   "EWD840/EWD840_Inv_implies_Termination.tla": {
+    "spec_id": "EWD840/EWD840.tla",
     "context": [
       "EWD840/EWD840Model.tla",
       "EWD840/EWD840_Inv_implies_TerminationScaffold.tla"
     ]
   },
   "EWD840/EWD840_TypeOK_inv.tla": {
+    "spec_id": "EWD840/EWD840.tla",
     "context": [
       "EWD840/EWD840Model.tla",
       "EWD840/EWD840_TypeOK_invScaffold.tla"
     ]
   },
   "Euclid/Euclid_Correctness.tla": {
+    "spec_id": "Euclid/Euclid-TLAPS-Example/Euclid.tla",
     "context": [
       "Euclid/EuclidModel_2.tla",
       "Euclid/Euclid_CorrectnessScaffold.tla"
     ]
   },
   "Euclid/Euclid_InitProperty.tla": {
+    "spec_id": "Euclid/Euclid-TLAPS-Example/Euclid.tla",
     "context": [
       "Euclid/EuclidModel.tla",
       "Euclid/Euclid_InitPropertyScaffold.tla"
     ]
   },
   "Euclid/Euclid_NextProperty.tla": {
+    "spec_id": "Euclid/Euclid-TLAPS-Example/Euclid.tla",
     "context": [
       "Euclid/EuclidModel_2.tla",
       "Euclid/Euclid_NextPropertyScaffold.tla"
     ]
   },
   "Euclid/GCD_GCD1.tla": {
+    "spec_id": "Euclid/Euclid-Hyperbook/GCD.tla",
     "context": [
       "Euclid/GCD_GCD1Scaffold.tla"
     ]
   },
   "Euclid/GCD_GCD2.tla": {
+    "spec_id": "Euclid/Euclid-Hyperbook/GCD.tla",
     "context": [
       "Euclid/GCD_GCD2Scaffold.tla"
     ]
   },
   "Euclid/GCD_GCD3.tla": {
+    "spec_id": "Euclid/Euclid-Hyperbook/GCD.tla",
     "context": [
       "Euclid/GCD_GCD3Scaffold.tla"
     ]
   },
   "OpenAddressing/OpenAddressing_proof_CompleteSafety.tla": {
+    "spec_id": "OpenAddressing/OpenAddressing_proof.tla",
     "context": [
       "OpenAddressing/OpenAddressing.tla",
       "OpenAddressing/OpenAddressing_proof_CompleteSafetyScaffold.tla"
     ]
   },
   "Paxos/PaxosHistVar_Consistent.tla": {
+    "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_ConsistentScaffold.tla"
     ]
   },
   "Paxos/PaxosHistVar_Invariant.tla": {
+    "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_InvariantScaffold.tla"
     ]
   },
   "Paxos/PaxosHistVar_SafeAtStable.tla": {
+    "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_SafeAtStableScaffold.tla"
     ]
   },
   "Paxos/PaxosHistVar_VotedInv.tla": {
+    "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_VotedInvScaffold.tla"
     ]
   },
   "Paxos/PaxosHistVar_VotedOnce.tla": {
+    "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_VotedOnceScaffold.tla"
     ]
   },
   "Paxos/Paxos_Consistent.tla": {
+    "spec_id": "Paxos/Paxos.tla",
     "context": [
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
@@ -464,6 +544,7 @@
     ]
   },
   "Paxos/Paxos_Invariant.tla": {
+    "spec_id": "Paxos/Paxos.tla",
     "context": [
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
@@ -471,6 +552,7 @@
     ]
   },
   "Paxos/Paxos_NoneNotAValue.tla": {
+    "spec_id": "Paxos/Paxos.tla",
     "context": [
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_2.tla",
@@ -478,6 +560,7 @@
     ]
   },
   "Paxos/Paxos_QuorumNonEmpty.tla": {
+    "spec_id": "Paxos/Paxos.tla",
     "context": [
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel.tla",
@@ -485,6 +568,7 @@
     ]
   },
   "Paxos/Paxos_Refinement.tla": {
+    "spec_id": "Paxos/Paxos.tla",
     "context": [
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
@@ -492,6 +576,7 @@
     ]
   },
   "Paxos/Paxos_SafeAtStable.tla": {
+    "spec_id": "Paxos/Paxos.tla",
     "context": [
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
@@ -499,6 +584,7 @@
     ]
   },
   "Paxos/Paxos_VotedInv.tla": {
+    "spec_id": "Paxos/Paxos.tla",
     "context": [
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
@@ -506,6 +592,7 @@
     ]
   },
   "Paxos/Paxos_VotedOnce.tla": {
+    "spec_id": "Paxos/Paxos.tla",
     "context": [
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
@@ -513,36 +600,42 @@
     ]
   },
   "SimpleMutex/SimpleMutex_Initialization.tla": {
+    "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutexModel.tla",
       "SimpleMutex/SimpleMutex_InitializationScaffold.tla"
     ]
   },
   "SimpleMutex/SimpleMutex_Invariance.tla": {
+    "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutexModel.tla",
       "SimpleMutex/SimpleMutex_InvarianceScaffold.tla"
     ]
   },
   "SimpleMutex/SimpleMutex_Mutex.tla": {
+    "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutexModel.tla",
       "SimpleMutex/SimpleMutex_MutexScaffold.tla"
     ]
   },
   "SimpleMutex/SimpleMutex_Safety.tla": {
+    "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutexModel.tla",
       "SimpleMutex/SimpleMutex_SafetyScaffold.tla"
     ]
   },
   "SimpleMutex/SimpleMutex_TLAInvariance.tla": {
+    "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutexModel.tla",
       "SimpleMutex/SimpleMutex_TLAInvarianceScaffold.tla"
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ALL_Card.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -552,6 +645,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Agreement.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -561,6 +655,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DiffPos.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -570,6 +665,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleGtNplusTImplGt3T.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -579,6 +675,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleGtNplusTImplTplusOne.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -588,6 +685,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleLeFromNotGtMono.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -597,6 +695,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleLtTplusOneLeNplusT.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -606,6 +705,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleNotGtLe.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -615,6 +715,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_NotAllFaulty.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -624,6 +725,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_NotLtTplusOneGe.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -633,6 +735,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_OtherLtFromStrictOverlap.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -642,6 +745,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_SupportedQuorumGeContrad.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -651,6 +755,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_TplusOneNotFaulty.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -660,6 +765,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_CardUnion2LeSum.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -669,6 +775,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_CardUnion3LeSum.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -678,6 +785,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_CorrectD2Exists.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -687,6 +795,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_CrossRoundStrictQuorum.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -696,6 +805,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_D2Fixed_CardLeSenders.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -705,6 +815,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_D2PSetFinite.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -714,6 +825,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_D2SetFinite.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -723,6 +835,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DQuorumDominatesMajorityD.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -732,6 +845,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DQuorumDominatesSupported.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -741,6 +855,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvFaultyMono.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -750,6 +865,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvInjective.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -759,6 +875,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvPInjective.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -768,6 +885,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvPSenderWitness.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -777,6 +895,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvSenderWitness.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -786,6 +905,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvStep2Mono.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -795,6 +915,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_EarlyMajorityM1HasCorrect.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -804,6 +925,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_EarlyTplusOneHasCorrect.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -813,6 +935,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_FaultyBound.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -822,6 +945,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_FaultyD2Bound.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -831,6 +955,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_FaultyD2Injective.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -840,6 +965,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_FaultyMsgs2AddedFaulty.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -849,6 +975,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_FaultyStepProps.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -858,6 +985,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_HighWeightReceivedL11Witness.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -867,6 +995,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Inductive.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -876,6 +1005,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_InitInd.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -885,6 +1015,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LaterQuorumGivesTotalBefore.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -894,6 +1025,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Lemma3_D2D2SameCorrect.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -903,6 +1035,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Lemma3_Q2D2Faulty.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -912,6 +1045,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockLemma.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -921,6 +1055,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockedFullCorrectType2Strict.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -930,6 +1065,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockedNextCorrectD2Value.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -939,6 +1075,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockedNextNoCorrectQ2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -948,6 +1085,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockedReceiveCorrectType2Strict.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -957,6 +1095,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockedReceiveStrictD.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -966,6 +1105,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LowWeightsReceivedL11Witness.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -975,6 +1115,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LowWeightsReceivedL8Witness.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -984,6 +1125,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LowWeightsSupportedEmpty.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -993,6 +1135,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_MajCardBound.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1002,6 +1145,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_MajorityIntersect.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1011,6 +1155,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_MajorityM1HasCorrect.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1020,6 +1165,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs1AddOneRep.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1029,6 +1175,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs1DomR.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1038,6 +1185,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs1Shape.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1047,6 +1195,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2AddDRep.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1056,6 +1205,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2AddQRep.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1065,6 +1215,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2Decomp.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1074,6 +1225,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2DomR.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1083,6 +1235,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2FaultyMono.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1092,6 +1245,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2Finite.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1101,6 +1255,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeDecomp.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1110,6 +1265,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeFinite.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1119,6 +1275,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeQSrcInAll.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1128,6 +1285,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeRShape.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1137,6 +1295,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeShape.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1146,6 +1305,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeSrcInAll.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1155,6 +1315,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeVInValues.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1164,6 +1325,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2QSrcInAll.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1173,6 +1335,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2RShape.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1182,6 +1345,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2SenderPartitionBound.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1191,6 +1355,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2Shape.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1200,6 +1365,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2SrcInAll.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1209,6 +1375,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2Step2Mono.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1218,6 +1385,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2VInValues.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1227,6 +1395,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1236,6 +1405,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1245,6 +1415,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1254,6 +1425,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1263,6 +1435,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1272,6 +1445,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1281,6 +1455,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1290,6 +1465,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1299,6 +1475,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1308,6 +1485,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1317,6 +1495,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1326,6 +1505,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1335,6 +1515,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1344,6 +1525,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1353,6 +1535,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1362,6 +1545,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1371,6 +1555,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1380,6 +1565,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1389,6 +1575,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1398,6 +1585,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1407,6 +1595,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1416,6 +1605,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1425,6 +1615,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1434,6 +1625,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1443,6 +1635,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S3_DecidedCarry.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1452,6 +1645,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1461,6 +1655,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1470,6 +1665,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1479,6 +1675,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1488,6 +1685,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1497,6 +1695,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1506,6 +1705,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1515,6 +1715,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1524,6 +1725,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1533,6 +1735,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1542,6 +1745,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1551,6 +1755,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1560,6 +1765,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1569,6 +1775,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1578,6 +1785,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1587,6 +1795,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1596,6 +1805,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1605,6 +1815,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1614,6 +1825,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1623,6 +1835,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1632,6 +1845,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1641,6 +1855,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1650,6 +1865,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1659,6 +1875,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1668,6 +1885,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1677,6 +1895,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1686,6 +1905,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1695,6 +1915,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1704,6 +1925,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1713,6 +1935,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1722,6 +1945,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1731,6 +1955,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1740,6 +1965,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1749,6 +1975,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1758,6 +1985,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1767,6 +1995,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1776,6 +2005,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_F.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1785,6 +2015,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_S1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1794,6 +2025,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_S2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1803,6 +2035,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_S3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1812,6 +2045,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_ST.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1821,6 +2055,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1830,6 +2065,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma10.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1839,6 +2075,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma11.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1848,6 +2085,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma12.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1857,6 +2095,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma13.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1866,6 +2105,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1875,6 +2115,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma3.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1884,6 +2125,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma4.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1893,6 +2135,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma5.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1902,6 +2145,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma6.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1911,6 +2155,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma7.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1920,6 +2165,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma8.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1929,6 +2175,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma9.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1938,6 +2185,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Q2Fixed_CardLeSenders.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1947,6 +2195,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Q2SetFinite.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1956,6 +2205,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QFaultyMono.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1965,6 +2215,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QInjective.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1974,6 +2225,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QPInjective.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1983,6 +2235,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QPSetFinite.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -1992,6 +2245,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QStep2Mono.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2001,6 +2255,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QuorumDominatesSupported.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2010,6 +2265,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QuorumHasCorrectM1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2019,6 +2275,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QuorumHasM1Majority.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2028,6 +2285,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QuorumIntersect.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2037,6 +2295,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QuorumUnique.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2046,6 +2305,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ReceivedDQuorumDominatesSupported.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2055,6 +2315,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ReplicaPredRoundHasTotal.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2064,6 +2325,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_RoundPos.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2073,6 +2335,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_RoundPredInRounds.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2082,6 +2345,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders1_Mono.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2091,6 +2355,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders1_Sub.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2100,6 +2365,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_CardLeSet.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2109,6 +2375,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_Mono.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2118,6 +2385,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_Sub.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2127,6 +2395,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_Witness.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2136,6 +2405,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SetEqHelper.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2145,6 +2415,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeFromExists.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2154,6 +2425,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelper.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2163,6 +2435,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperR.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2172,6 +2445,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperSrc.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2181,6 +2455,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperSrcQ.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2190,6 +2465,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperV.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2199,6 +2475,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeRFromExists.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2208,6 +2485,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeSrcFromExists.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2217,6 +2495,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeSrcQFromExists.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2226,6 +2505,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeVFromExists.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2235,6 +2515,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumCarriesToQuorumRound.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2244,6 +2525,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumFewOthers.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2253,6 +2535,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumNextCorrectType2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2262,6 +2545,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumNextReceiveStrictD.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2271,6 +2555,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumNextStrictQuorum.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2280,6 +2565,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumSenderStrict.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2289,6 +2575,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumSupportedSingleton.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2298,6 +2585,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SubAll_Finite.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2307,6 +2595,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedFromTotalAndFewOthers.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2316,6 +2605,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedInReceivedQuorum.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2325,6 +2615,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedPHasOldCorrectD2.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2334,6 +2625,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedPToOldWhenTotal.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2343,6 +2635,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedSingletonNextQuorum.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2352,6 +2645,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedSingletonNextSupported.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2361,6 +2655,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedSingletonPinsNextM1.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2370,6 +2665,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedUnique.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2379,6 +2675,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedValuesPFrame.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2388,6 +2685,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedValuesPrimeIsP.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2397,6 +2695,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_TplusOneHasCorrect.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2406,6 +2705,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_TypeOKPrimeIntro.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2415,6 +2715,7 @@
     ]
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_TypePres.tla": {
+    "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
     "context": [
       "apalache_examples_ben-or83/Ben_or83.tla",
       "apalache_examples_ben-or83/Ben_or83_inductive.tla",
@@ -2424,306 +2725,357 @@
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_BoundedMaxExists.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_BoundedMaxExistsScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Inductive.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_InductiveScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_MaxReachedProps.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_MaxReachedPropsScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_OnRoundCatchupGivesSender.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_OnRoundCatchupGivesSenderScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCAllMonotone.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCAllMonotoneScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetFlip.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetFlipScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetPFlip.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetPFlipScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetSubset.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetSubsetScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetFlip.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetFlipScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetPFlip.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetPFlipScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetPFlipCard.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetPFlipCardScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetQuorumMonotone.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetQuorumMonotoneScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetSubset.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetSubsetScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PastStartRoundOperator.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PastStartRoundOperatorScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PastStartRoundQuorumMonotone.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PastStartRoundQuorumMonotoneScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PostPrecommitByCorrectGivesPostPrevoteQuorum.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PostPrecommitByCorrectGivesPostPrevoteQuorumScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PostPrecommitLocksLaterPrevotesOp.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PostPrecommitLocksLaterPrevotesOpScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitByCorrectGivesPrevoteQuorum.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitByCorrectGivesPrevoteQuorumScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitLockContra.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitLockContraScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitLocksLaterPrevotesOp.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitLocksLaterPrevotesOpScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitRecTyped.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitRecTypedScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitSenderSetCardinalityMonotone.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitSenderSetCardinalityMonotoneScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitsLockValueOp.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitsLockValueOpScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_AllValidAndLockedRoundBounded.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_AllValidAndLockedRoundBoundedScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_Faulty.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_FaultyScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_InsertProposal.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_InsertProposalScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_OnQuorumOfNilPrevotes.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_OnQuorumOfNilPrevotesScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_OnTimeoutPropose.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_OnTimeoutProposeScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInPrecommitNoDecision.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInPrecommitNoDecisionScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInPrevoteOrCommitAndPrevote.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInPrevoteOrCommitAndPrevoteScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInPropose.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInProposeScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInProposeAndPrevote.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInProposeAndPrevoteScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponQuorumOfPrecommitsAny.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponQuorumOfPrecommitsAnyScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponQuorumOfPrevotesAny.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponQuorumOfPrevotesAnyScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_PrecommitLocksLaterPrevotes.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_PrecommitLocksLaterPrevotesScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteAllSenderSetCardinalityMonotone.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteAllSenderSetCardinalityMonotoneScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteEvidenceSenderSetCardinalityLeAllSenders.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteEvidenceSenderSetCardinalityLeAllSendersScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteRecTyped.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteRecTypedScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteSenderSetCardinalityMonotone.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteSenderSetCardinalityMonotoneScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteValueSenderSetCardinalityLeAllSenders.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteValueSenderSetCardinalityLeAllSendersScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_ProposeRecTyped.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_ProposeRecTypedScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Q3UnionMonotone.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Q3UnionMonotoneScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_QuorumHasCorrect.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_QuorumHasCorrectScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_QuorumsIntersectInCorrect.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_QuorumsIntersectInCorrectScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_SmallQuorumHasCorrect.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_SmallQuorumHasCorrectScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_StepChangeChar.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_StepChangeCharScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_SubsetCFFinite.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_SubsetCFFiniteScaffold.tla"
     ]
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_SubsetCardGeq.tla": {
+    "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_SubsetCardGeqScaffold.tla"
     ]
   },
   "tlaplus_examples_Bakery-Boulangerie/Bakery_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_Bakery-Boulangerie/Bakery.tla",
     "context": [
       "tlaplus_examples_Bakery-Boulangerie/BakeryModel.tla",
       "tlaplus_examples_Bakery-Boulangerie/Bakery_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_Bakery-Boulangerie/Boulanger_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_Bakery-Boulangerie/Boulanger.tla",
     "context": [
       "tlaplus_examples_Bakery-Boulangerie/BoulangerModel.tla",
       "tlaplus_examples_Bakery-Boulangerie/Boulanger_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs_EmptySeqRange.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueFair.tla",
@@ -2732,6 +3084,7 @@
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs_ITypeInv.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueFair.tla",
@@ -2740,6 +3093,7 @@
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_DeadlockFreedom.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit.tla",
@@ -2747,6 +3101,7 @@
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_IInvRefines.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit.tla",
@@ -2754,6 +3109,7 @@
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_ITypeInv.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit.tla",
@@ -2761,6 +3117,7 @@
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_Implements.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit.tla",
@@ -2768,84 +3125,98 @@
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueue_proofs_DeadlockFreedom.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueue_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueue_proofs_DeadlockFreedomScaffold.tla"
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueue_proofs_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueue_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueue_proofs_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneCorrect.tla": {
+    "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneViaSmokingSet.tla": {
+    "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneViaSmokingSetScaffold.tla"
     ]
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_OffersFact.tla": {
+    "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_OffersFactScaffold.tla"
     ]
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_SmokingSetFinite.tla": {
+    "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_SmokingSetFiniteScaffold.tla"
     ]
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_StartSmokingSmokingSet.tla": {
+    "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_StartSmokingSmokingSetScaffold.tla"
     ]
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_StopSmokingSmokingSet.tla": {
+    "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_StopSmokingSmokingSetScaffold.tla"
     ]
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_UniqueComplement2.tla": {
+    "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_UniqueComplement2Scaffold.tla"
     ]
   },
   "tlaplus_examples_CoffeeCan/CoffeeCan_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_CoffeeCan/CoffeeCan_proof.tla",
     "context": [
       "tlaplus_examples_CoffeeCan/CoffeeCan.tla",
       "tlaplus_examples_CoffeeCan/CoffeeCan_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_DieHard/DieHard_proof_MinNat.tla": {
+    "spec_id": "tlaplus_examples_DieHard/DieHard_proof.tla",
     "context": [
       "tlaplus_examples_DieHard/DieHard.tla",
       "tlaplus_examples_DieHard/DieHard_proof_MinNatScaffold.tla"
     ]
   },
   "tlaplus_examples_DieHard/DieHard_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_DieHard/DieHard_proof.tla",
     "context": [
       "tlaplus_examples_DieHard/DieHard.tla",
       "tlaplus_examples_DieHard/DieHard_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_EnabledGossip.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2853,6 +3224,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_GossipDecreasesMeasure.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2860,6 +3232,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_GossipDoesntIncreaseMeasure.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2867,6 +3240,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_MeasureIsZero.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2874,6 +3248,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_MeasureType.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2881,6 +3256,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_MeasureTypePrime.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2888,6 +3264,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_OGLiveness.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel_2.tla",
@@ -2895,6 +3272,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_Safe.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2902,6 +3280,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumIsSumFunction.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2909,6 +3288,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumIsZero.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2916,6 +3296,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumStronglyMonotonic.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2923,6 +3304,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumType.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2930,6 +3312,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumWeaklyMonotonic.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2937,6 +3320,7 @@
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
@@ -2944,176 +3328,208 @@
     ]
   },
   "tlaplus_examples_KeyValueStore/KeyValueStore_proof_TypeAndLifecycle.tla": {
+    "spec_id": "tlaplus_examples_KeyValueStore/KeyValueStore_proof.tla",
     "context": [
       "tlaplus_examples_KeyValueStore/KeyValueStore.tla",
       "tlaplus_examples_KeyValueStore/KeyValueStore_proof_TypeAndLifecycleScaffold.tla"
     ]
   },
   "tlaplus_examples_LearnProofs/AddTwo_TypeInvariant.tla": {
+    "spec_id": "tlaplus_examples_LearnProofs/AddTwo.tla",
     "context": [
       "tlaplus_examples_LearnProofs/AddTwoModel.tla",
       "tlaplus_examples_LearnProofs/AddTwo_TypeInvariantScaffold.tla"
     ]
   },
   "tlaplus_examples_LearnProofs/FindHighest_DoneIndexValueThm.tla": {
+    "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_DoneIndexValueThmScaffold.tla"
     ]
   },
   "tlaplus_examples_LearnProofs/FindHighest_InductiveInvariantHolds.tla": {
+    "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_InductiveInvariantHoldsScaffold.tla"
     ]
   },
   "tlaplus_examples_LearnProofs/FindHighest_IsCorrect.tla": {
+    "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_IsCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_LearnProofs/FindHighest_TypeInvariantHolds.tla": {
+    "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_TypeInvariantHoldsScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/BinarySearch_SortedLess.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/BinarySearch.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/BinarySearch_SortedLessScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/Quicksort_AutomorphismsCompose.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_AutomorphismsComposeScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/Quicksort_IntervalMinMax.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_IntervalMinMaxScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/Quicksort_MaxIsMax.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_MaxIsMaxScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/Quicksort_MinIsMin.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_MinIsMinScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/Quicksort_NonemptyMax.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_NonemptyMaxScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/Quicksort_NonemptyMin.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_NonemptyMinScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/Quicksort_PartitionsLemma.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_PartitionsLemmaScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/Quicksort_PermsOfLemma.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_PermsOfLemmaScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/Quicksort_PermsOfPermsOf.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_PermsOfPermsOfScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/SumSequence_FrontDef.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_FrontDefScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/SumSequence_Lemma1_Proof.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_Lemma1_ProofScaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/SumSequence_Lemma2.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_Lemma2Scaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/SumSequence_Lemma3.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_Lemma3Scaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/SumSequence_Lemma4.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_Lemma4Scaffold.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/SumSequence_Lemma5_Proof.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_Lemma5_ProofScaffold.tla"
     ]
   },
   "tlaplus_examples_Majority/MajorityProof_Correctness.tla": {
+    "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_CorrectnessScaffold.tla"
     ]
   },
   "tlaplus_examples_Majority/MajorityProof_OccurrencesOne.tla": {
+    "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_OccurrencesOneScaffold.tla"
     ]
   },
   "tlaplus_examples_Majority/MajorityProof_OccurrencesPlusOne.tla": {
+    "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_OccurrencesPlusOneScaffold.tla"
     ]
   },
   "tlaplus_examples_Majority/MajorityProof_OccurrencesType.tla": {
+    "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_OccurrencesTypeScaffold.tla"
     ]
   },
   "tlaplus_examples_Majority/MajorityProof_PositionsFinite.tla": {
+    "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_PositionsFiniteScaffold.tla"
     ]
   },
   "tlaplus_examples_Majority/MajorityProof_PositionsOne.tla": {
+    "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_PositionsOneScaffold.tla"
     ]
   },
   "tlaplus_examples_Majority/MajorityProof_PositionsPlusOne.tla": {
+    "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_PositionsPlusOneScaffold.tla"
     ]
   },
   "tlaplus_examples_Majority/MajorityProof_PositionsType.tla": {
+    "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_PositionsTypeScaffold.tla"
     ]
   },
   "tlaplus_examples_Majority/MajorityProof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_MisraReachability/ParReachProofs_TypeInvariant.tla": {
+    "spec_id": "tlaplus_examples_MisraReachability/ParReachProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/ParReach.tla",
       "tlaplus_examples_MisraReachability/ParReachProofs_TypeInvariantScaffold.tla",
@@ -3122,30 +3538,35 @@
     ]
   },
   "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable0.tla": {
+    "spec_id": "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable0Scaffold.tla"
     ]
   },
   "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable1.tla": {
+    "spec_id": "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable1Scaffold.tla"
     ]
   },
   "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable2.tla": {
+    "spec_id": "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable2Scaffold.tla"
     ]
   },
   "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable3.tla": {
+    "spec_id": "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable3Scaffold.tla"
     ]
   },
   "tlaplus_examples_MisraReachability/ReachableProofs_Thm1.tla": {
+    "spec_id": "tlaplus_examples_MisraReachability/ReachableProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
@@ -3154,6 +3575,7 @@
     ]
   },
   "tlaplus_examples_MisraReachability/ReachableProofs_Thm2.tla": {
+    "spec_id": "tlaplus_examples_MisraReachability/ReachableProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
@@ -3162,6 +3584,7 @@
     ]
   },
   "tlaplus_examples_MisraReachability/ReachableProofs_Thm3.tla": {
+    "spec_id": "tlaplus_examples_MisraReachability/ReachableProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
@@ -3170,6 +3593,7 @@
     ]
   },
   "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proof.tla",
     "context": [
       "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals.tla",
       "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proofModel.tla",
@@ -3177,84 +3601,98 @@
     ]
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_DirectionInElevatorDirectionState.tla": {
+    "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_DirectionInElevatorDirectionStateScaffold.tla"
     ]
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_ElevatorCallFields.tla": {
+    "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_ElevatorCallFieldsScaffold.tla"
     ]
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_GetDirectionType.tla": {
+    "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_GetDirectionTypeScaffold.tla"
     ]
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_InitImpliesInv1.tla": {
+    "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_InitImpliesInv1Scaffold.tla"
     ]
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_InitImpliesInv2.tla": {
+    "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_InitImpliesInv2Scaffold.tla"
     ]
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_Inv1Next.tla": {
+    "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_Inv1NextScaffold.tla"
     ]
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_SafetyCorrect.tla": {
+    "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_SafetyCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_StationaryInElevatorDirectionState.tla": {
+    "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_StationaryInElevatorDirectionStateScaffold.tla"
     ]
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_Paxos/Consensus_Invariance.tla": {
+    "spec_id": "tlaplus_examples_Paxos/Consensus.tla",
     "context": [
       "tlaplus_examples_Paxos/ConsensusModel.tla",
       "tlaplus_examples_Paxos/Consensus_InvarianceScaffold.tla"
     ]
   },
   "tlaplus_examples_Paxos/Consensus_LivenessTheorem.tla": {
+    "spec_id": "tlaplus_examples_Paxos/Consensus.tla",
     "context": [
       "tlaplus_examples_Paxos/ConsensusModel_2.tla",
       "tlaplus_examples_Paxos/Consensus_LivenessTheoremScaffold.tla"
     ]
   },
   "tlaplus_examples_Paxos/Voting_QuorumNonEmpty.tla": {
+    "spec_id": "tlaplus_examples_Paxos/Voting.tla",
     "context": [
       "tlaplus_examples_Paxos/Consensus.tla",
       "tlaplus_examples_Paxos/Voting_QuorumNonEmptyScaffold.tla"
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Consensus_Invariance.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/ConsensusModel.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus_InvarianceScaffold.tla"
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_Implementation.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/VotingModel.tla",
@@ -3262,6 +3700,7 @@
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_Invariance.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/VotingModel.tla",
@@ -3269,6 +3708,7 @@
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_AllSafeAtZero_T.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
@@ -3276,6 +3716,7 @@
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ChoosableThm_T.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
@@ -3283,6 +3724,7 @@
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_OneValuePerBallotApply.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
@@ -3290,6 +3732,7 @@
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_QuorumIntersect.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
@@ -3297,6 +3740,7 @@
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_QuorumNonEmpty.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
@@ -3304,6 +3748,7 @@
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ShowsSafety_T.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
@@ -3311,42 +3756,49 @@
     ]
   },
   "tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyCorrect.tla": {
+    "spec_id": "tlaplus_examples_ReadersWriters/ReadersWriters_proof.tla",
     "context": [
       "tlaplus_examples_ReadersWriters/ReadersWriters.tla",
       "tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyStep.tla": {
+    "spec_id": "tlaplus_examples_ReadersWriters/ReadersWriters_proof.tla",
     "context": [
       "tlaplus_examples_ReadersWriters/ReadersWriters.tla",
       "tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyStepScaffold.tla"
     ]
   },
   "tlaplus_examples_ReadersWriters/ReadersWriters_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_ReadersWriters/ReadersWriters_proof.tla",
     "context": [
       "tlaplus_examples_ReadersWriters/ReadersWriters.tla",
       "tlaplus_examples_ReadersWriters/ReadersWriters_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_SpanningTree/SpanTree_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpanningTree/SpanTree_proof.tla",
     "context": [
       "tlaplus_examples_SpanningTree/SpanTree.tla",
       "tlaplus_examples_SpanningTree/SpanTree_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface.tla",
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel.tla",
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_InvInductive.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory.tla",
       "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_InvInductiveScaffold.tla",
@@ -3354,6 +3806,7 @@
     ]
   },
   "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory.tla",
       "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_TypeCorrectScaffold.tla",
@@ -3361,6 +3814,7 @@
     ]
   },
   "tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_FIFO/Channel.tla",
       "tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO.tla",
@@ -3368,204 +3822,238 @@
     ]
   },
   "tlaplus_examples_SpecifyingSystems_HourClock/HourClock_proof_HCini_Invariant.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_HourClock/HourClock_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_HourClock/HourClock.tla",
       "tlaplus_examples_SpecifyingSystems_HourClock/HourClock_proof_HCini_InvariantScaffold.tla"
     ]
   },
   "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit.tla",
       "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegularModel.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_CorrectnessScaffold.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness2.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegularModel.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness2Scaffold.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_InvInvariant.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegular.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_InvInvariantScaffold.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegular.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/Simple_Correctness.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/Simple.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleModel.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_CorrectnessScaffold.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/Simple_Correctness2.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/Simple.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleModel.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_Correctness2Scaffold.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/Simple_proof_InvInvariant.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/Simple_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/Simple.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_proof_InvInvariantScaffold.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/Simple_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/Simple_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/Simple.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_AcceptMsgInv.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_AcceptMsgInvScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_Consistent.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_ConsistentScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_Invariant.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_InvariantScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_MaxBigger.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_MaxBiggerScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_MaxTypeOK.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_MaxTypeOKScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_MsgNotLost.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_MsgNotLostScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_NoneNotAValue.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_NoneNotAValueScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageAccInv.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageAccInvScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageBiggerProperty.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageBiggerPropertyScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageMsgInv.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageMsgInvScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_PrepareMsgInv.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_PrepareMsgInvScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_SafeAtStable.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_SafeAtStableScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateBiggerProperty.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateBiggerPropertyScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateMsgInv.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateMsgInvScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateTypeOKProperty.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateTypeOKPropertyScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateValue.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateValueScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateViewValue.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateViewValueScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_VotedInv.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_VotedInvScaffold.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_VotedOnce.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_VotedOnceScaffold.tla"
     ]
   },
   "tlaplus_examples_Termination/Termination_proof_Invariant1.tla": {
+    "spec_id": "tlaplus_examples_Termination/Termination_proof.tla",
     "context": [
       "tlaplus_examples_Termination/Termination.tla",
       "tlaplus_examples_Termination/Termination_proof_Invariant1Scaffold.tla"
     ]
   },
   "tlaplus_examples_Termination/Termination_proof_Invariant2.tla": {
+    "spec_id": "tlaplus_examples_Termination/Termination_proof.tla",
     "context": [
       "tlaplus_examples_Termination/Termination.tla",
       "tlaplus_examples_Termination/Termination_proof_Invariant2Scaffold.tla"
     ]
   },
   "tlaplus_examples_Termination/Termination_proof_Invariant3.tla": {
+    "spec_id": "tlaplus_examples_Termination/Termination_proof.tla",
     "context": [
       "tlaplus_examples_Termination/Termination.tla",
       "tlaplus_examples_Termination/Termination_proof_Invariant3Scaffold.tla"
     ]
   },
   "tlaplus_examples_Termination/Termination_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_Termination/Termination_proof.tla",
     "context": [
       "tlaplus_examples_Termination/Termination.tla",
       "tlaplus_examples_Termination/Termination_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_TwoPhase/TwoPhase_Implementation.tla": {
+    "spec_id": "tlaplus_examples_TwoPhase/TwoPhase.tla",
     "context": [
       "tlaplus_examples_TwoPhase/Alternate.tla",
       "tlaplus_examples_TwoPhase/TwoPhaseModel.tla",
@@ -3573,6 +4061,7 @@
     ]
   },
   "tlaplus_examples_allocator/AllocatorImplementation_proof_DropType.tla": {
+    "spec_id": "tlaplus_examples_allocator/AllocatorImplementation_proof.tla",
     "context": [
       "tlaplus_examples_allocator/AllocatorImplementation.tla",
       "tlaplus_examples_allocator/AllocatorImplementation_proof_DropTypeScaffold.tla",
@@ -3580,6 +4069,7 @@
     ]
   },
   "tlaplus_examples_allocator/AllocatorImplementation_proof_PermSeqsType.tla": {
+    "spec_id": "tlaplus_examples_allocator/AllocatorImplementation_proof.tla",
     "context": [
       "tlaplus_examples_allocator/AllocatorImplementation.tla",
       "tlaplus_examples_allocator/AllocatorImplementation_proof_PermSeqsTypeScaffold.tla",
@@ -3587,6 +4077,7 @@
     ]
   },
   "tlaplus_examples_allocator/AllocatorImplementation_proof_PermsFnRec.tla": {
+    "spec_id": "tlaplus_examples_allocator/AllocatorImplementation_proof.tla",
     "context": [
       "tlaplus_examples_allocator/AllocatorImplementation.tla",
       "tlaplus_examples_allocator/AllocatorImplementation_proof_PermsFnRecScaffold.tla",
@@ -3594,6 +4085,7 @@
     ]
   },
   "tlaplus_examples_allocator/AllocatorImplementation_proof_PermsRecNonempty.tla": {
+    "spec_id": "tlaplus_examples_allocator/AllocatorImplementation_proof.tla",
     "context": [
       "tlaplus_examples_allocator/AllocatorImplementation.tla",
       "tlaplus_examples_allocator/AllocatorImplementation_proof_PermsRecNonemptyScaffold.tla",
@@ -3601,6 +4093,7 @@
     ]
   },
   "tlaplus_examples_allocator/AllocatorImplementation_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_allocator/AllocatorImplementation_proof.tla",
     "context": [
       "tlaplus_examples_allocator/AllocatorImplementation.tla",
       "tlaplus_examples_allocator/AllocatorImplementation_proof_TypeCorrectScaffold.tla",
@@ -3608,60 +4101,70 @@
     ]
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_DropType.tla": {
+    "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_DropTypeScaffold.tla"
     ]
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_Mutex.tla": {
+    "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_MutexScaffold.tla"
     ]
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_PermSeqsIsPermsFn.tla": {
+    "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_PermSeqsIsPermsFnScaffold.tla"
     ]
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_PermSeqsType.tla": {
+    "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_PermSeqsTypeScaffold.tla"
     ]
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_PermsFnRec.tla": {
+    "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_PermsFnRecScaffold.tla"
     ]
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_PermsRecNonempty.tla": {
+    "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_PermsRecNonemptyScaffold.tla"
     ]
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_allocator/SimpleAllocator_proof_Mutex.tla": {
+    "spec_id": "tlaplus_examples_allocator/SimpleAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SimpleAllocator.tla",
       "tlaplus_examples_allocator/SimpleAllocator_proof_MutexScaffold.tla"
     ]
   },
   "tlaplus_examples_allocator/SimpleAllocator_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_allocator/SimpleAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SimpleAllocator.tla",
       "tlaplus_examples_allocator/SimpleAllocator_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_barriers/Barriers_AllProcsInRdv.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
@@ -3669,6 +4172,7 @@
     ]
   },
   "tlaplus_examples_barriers/Barriers_AllProcsNotInRdv.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
@@ -3676,6 +4180,7 @@
     ]
   },
   "tlaplus_examples_barriers/Barriers_BarrierExclusion.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
@@ -3683,6 +4188,7 @@
     ]
   },
   "tlaplus_examples_barriers/Barriers_BarrierExclusion2.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
@@ -3690,6 +4196,7 @@
     ]
   },
   "tlaplus_examples_barriers/Barriers_FS_NonEmptySet.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
@@ -3697,6 +4204,7 @@
     ]
   },
   "tlaplus_examples_barriers/Barriers_FS_TwoElements.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
@@ -3704,6 +4212,7 @@
     ]
   },
   "tlaplus_examples_barriers/Barriers_FlushInvariant.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
@@ -3711,6 +4220,7 @@
     ]
   },
   "tlaplus_examples_barriers/Barriers_Invariant.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
@@ -3718,6 +4228,7 @@
     ]
   },
   "tlaplus_examples_barriers/Barriers_LockExclusion.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
@@ -3725,6 +4236,7 @@
     ]
   },
   "tlaplus_examples_barriers/Barriers_ProcSetSubSetsBound.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
@@ -3732,6 +4244,7 @@
     ]
   },
   "tlaplus_examples_barriers/Barriers_Typing.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
@@ -3739,90 +4252,105 @@
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcastScaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast_TLC.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast_TLCScaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_Init.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_InitScaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_InitNoBcast.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_InitNoBcastScaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_Next.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_NextScaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_SpecNoBcast.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_SpecNoBcastScaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_NTFRel.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_NTFRelScaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_ProcProp.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_ProcPropScaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_UMFS_CardinalityType.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_UMFS_CardinalityTypeScaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_Unforg_Step1.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_Unforg_Step1Scaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_Unforg_Step2.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_Unforg_Step2Scaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_Unforg_Step3.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_Unforg_Step3Scaffold.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_Unforg_Step4.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_Unforg_Step4Scaffold.tla"
     ]
   },
   "tlaplus_examples_byihive/VoucherLifeCycle_proof_Spec_TypeOK_Consistent.tla": {
+    "spec_id": "tlaplus_examples_byihive/VoucherLifeCycle_proof.tla",
     "context": [
       "tlaplus_examples_byihive/VoucherLifeCycle.tla",
       "tlaplus_examples_byihive/VoucherLifeCycle_proof_Spec_TypeOK_ConsistentScaffold.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_BMessageLemma.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel.tla",
       "tlaplus_examples_byzpaxos/BPConProof_BMessageLemmaScaffold.tla",
@@ -3832,6 +4360,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_FiniteMsgsLemma.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_FiniteMsgsLemmaScaffold.tla",
@@ -3841,6 +4370,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_FiniteSetHasMax.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_FiniteSetHasMaxScaffold.tla",
@@ -3850,6 +4380,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_Invariance.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_InvarianceScaffold.tla",
@@ -3859,6 +4390,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_KnowsSafeAtDef.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_KnowsSafeAtDefScaffold.tla",
@@ -3868,6 +4400,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_MaxBallotLemma1.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_MaxBallotLemma1Scaffold.tla",
@@ -3877,6 +4410,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_MaxBallotLemma2.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_MaxBallotLemma2Scaffold.tla",
@@ -3886,6 +4420,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_MaxBallotProp.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_MaxBallotPropScaffold.tla",
@@ -3895,6 +4430,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_MsgsLemma.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_MsgsLemmaScaffold.tla",
@@ -3904,6 +4440,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_MsgsTypeLemma.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_MsgsTypeLemmaScaffold.tla",
@@ -3913,6 +4450,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_MsgsTypeLemmaPrime.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_MsgsTypeLemmaPrimeScaffold.tla",
@@ -3922,6 +4460,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_NextDef.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_NextDefScaffold.tla",
@@ -3931,6 +4470,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_PMaxBalLemma3.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_PMaxBalLemma3Scaffold.tla",
@@ -3940,6 +4480,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_PNextDef.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_PNextDefScaffold.tla",
@@ -3949,6 +4490,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma1.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma1Scaffold.tla",
@@ -3958,6 +4500,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma2.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma2Scaffold.tla",
@@ -3967,6 +4510,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma4.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma4Scaffold.tla",
@@ -3976,6 +4520,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma5.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma5Scaffold.tla",
@@ -3985,6 +4530,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_QuorumTheorem.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel_2.tla",
       "tlaplus_examples_byzpaxos/BPConProof_QuorumTheoremScaffold.tla",
@@ -3994,36 +4540,42 @@
     ]
   },
   "tlaplus_examples_byzpaxos/Consensus_EnabledDef.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel_2.tla",
       "tlaplus_examples_byzpaxos/Consensus_EnabledDefScaffold.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/Consensus_InductiveInvariance.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel.tla",
       "tlaplus_examples_byzpaxos/Consensus_InductiveInvarianceScaffold.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/Consensus_Invariance.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel.tla",
       "tlaplus_examples_byzpaxos/Consensus_InvarianceScaffold.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/Consensus_LiveSpecEquals.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel_2.tla",
       "tlaplus_examples_byzpaxos/Consensus_LiveSpecEqualsScaffold.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/Consensus_Liveness.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel_2.tla",
       "tlaplus_examples_byzpaxos/Consensus_LivenessScaffold.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/PConProof_NextDef.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/PConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof_NextDefScaffold.tla",
@@ -4031,6 +4583,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_FiniteSetHasMax.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_4.tla",
@@ -4038,6 +4591,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_InductiveInvariance.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_3.tla",
@@ -4045,6 +4599,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_InitImpliesInv.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_3.tla",
@@ -4052,6 +4607,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_Liveness.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_4.tla",
@@ -4059,6 +4615,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_NextDef.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_3.tla",
@@ -4066,6 +4623,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_QuorumNonEmpty.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel.tla",
@@ -4073,6 +4631,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_SafeAtProp.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
@@ -4080,6 +4639,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_SafeAtPropPrime.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
@@ -4087,6 +4647,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_SafeLemma.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
@@ -4094,6 +4655,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT0.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
@@ -4101,6 +4663,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT0Prime.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
@@ -4108,6 +4671,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT1.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
@@ -4115,6 +4679,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT1Prime.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
@@ -4122,6 +4687,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT2.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_3.tla",
@@ -4129,6 +4695,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT3.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_3.tla",
@@ -4136,6 +4703,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT4.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_4.tla",
@@ -4143,42 +4711,49 @@
     ]
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_Invariant1.tla": {
+    "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_Invariant1Scaffold.tla"
     ]
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_NotAnEdgeNoEdge.tla": {
+    "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_NotAnEdgeNoEdgeScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_Safety.tla": {
+    "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_SafetyScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_Thm_CountersConsistent.tla": {
+    "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_Thm_CountersConsistentScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_TreeInvariant.tla": {
+    "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_TreeInvariantScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd840/EWD840_proof_EnabledSystem.tla": {
+    "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/EWD840.tla",
       "tlaplus_examples_ewd840/EWD840_proofModel.tla",
@@ -4187,6 +4762,7 @@
     ]
   },
   "tlaplus_examples_ewd840/EWD840_proof_Invariant.tla": {
+    "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/EWD840.tla",
       "tlaplus_examples_ewd840/EWD840_proofModel.tla",
@@ -4195,6 +4771,7 @@
     ]
   },
   "tlaplus_examples_ewd840/EWD840_proof_Live.tla": {
+    "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/EWD840.tla",
       "tlaplus_examples_ewd840/EWD840_proofModel_2.tla",
@@ -4203,6 +4780,7 @@
     ]
   },
   "tlaplus_examples_ewd840/EWD840_proof_Round1.tla": {
+    "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/EWD840.tla",
       "tlaplus_examples_ewd840/EWD840_proofModel_2.tla",
@@ -4211,6 +4789,7 @@
     ]
   },
   "tlaplus_examples_ewd840/EWD840_proof_Round2.tla": {
+    "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/EWD840.tla",
       "tlaplus_examples_ewd840/EWD840_proofModel_2.tla",
@@ -4219,6 +4798,7 @@
     ]
   },
   "tlaplus_examples_ewd840/EWD840_proof_Round3.tla": {
+    "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/EWD840.tla",
       "tlaplus_examples_ewd840/EWD840_proofModel_2.tla",
@@ -4227,6 +4807,7 @@
     ]
   },
   "tlaplus_examples_ewd840/EWD840_proof_Safety.tla": {
+    "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/EWD840.tla",
       "tlaplus_examples_ewd840/EWD840_proofModel.tla",
@@ -4235,6 +4816,7 @@
     ]
   },
   "tlaplus_examples_ewd840/EWD840_proof_SpecLive.tla": {
+    "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/EWD840.tla",
       "tlaplus_examples_ewd840/EWD840_proofModel_2.tla",
@@ -4243,6 +4825,7 @@
     ]
   },
   "tlaplus_examples_ewd840/EWD840_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/EWD840.tla",
       "tlaplus_examples_ewd840/EWD840_proofModel.tla",
@@ -4251,66 +4834,77 @@
     ]
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_CorrectDetection.tla": {
+    "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_CorrectDetectionScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Enabled_ST.tla": {
+    "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Enabled_STScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Live.tla": {
+    "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_LiveScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Quiescent.tla": {
+    "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_QuiescentScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_EnabledDT.tla": {
+    "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_EnabledDTScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Liveness.tla": {
+    "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_LivenessScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Safety.tla": {
+    "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_SafetyScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Stability.tla": {
+    "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_StabilityScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagAddDom.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4319,6 +4913,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagAddOfMsg.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4327,6 +4922,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagAddPreservesToks.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4335,6 +4931,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagAdd_pl_increments.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4343,6 +4940,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagAdd_tok_preserves_pl.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4351,6 +4949,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemoveDom.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4359,6 +4958,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemoveOfMsg.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4367,6 +4967,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemovePreservesToks.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4375,6 +4976,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemove_pl_decrements.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4383,6 +4985,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemove_tok_preserves_pl.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4391,6 +4994,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_EmptyBagDom.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4399,6 +5003,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitNetworkOK.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4407,6 +5012,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitNetworkUniqueTok.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4415,6 +5021,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitPending.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4423,6 +5030,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitRefinement.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4431,6 +5039,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitToken.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4439,6 +5048,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitTypeOK.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4447,6 +5057,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitiatorIsZero.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4455,6 +5066,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_NewTokInMsg.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4463,6 +5075,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_NodeFact.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4471,6 +5084,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_PendingIsPlCount.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4479,6 +5093,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_PlMsgInMsg.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4487,6 +5102,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_SetToBagSingleton.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4495,6 +5111,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4503,6 +5120,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_TypeOK_Step.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4511,6 +5129,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_B0NoMessagePending.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4519,6 +5138,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_Detection.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4527,6 +5147,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_EnabledAtMaster.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4535,6 +5156,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_EnabledSystem.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4543,6 +5165,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_Invariance.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4551,6 +5174,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_Live.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4559,6 +5183,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_NodeIsFinite.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4567,6 +5192,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_NodeIsNode.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4575,6 +5201,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_PlusACI.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4583,6 +5210,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_Refinement.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4591,6 +5219,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_Round1.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4599,6 +5228,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_Round2.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4607,6 +5237,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_Round3.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4615,6 +5246,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_Safety.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4623,6 +5255,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_SpecLive.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4631,6 +5264,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_SumEmpty.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4639,6 +5273,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_SumIsInt.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4647,6 +5282,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_SumIsNat.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4655,6 +5291,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_SumSingleton.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4663,6 +5300,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_SumZero.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4671,6 +5309,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_TerminationDetectionInv.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4679,6 +5318,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998.tla",
@@ -4687,30 +5327,35 @@
     ]
   },
   "tlaplus_examples_glowingRaccoon/clean_proof_NatMinNat.tla": {
+    "spec_id": "tlaplus_examples_glowingRaccoon/clean_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/clean_proof_NatMinNatScaffold.tla"
     ]
   },
   "tlaplus_examples_glowingRaccoon/clean_proof_Preservation.tla": {
+    "spec_id": "tlaplus_examples_glowingRaccoon/clean_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/clean_proof_PreservationScaffold.tla"
     ]
   },
   "tlaplus_examples_glowingRaccoon/clean_proof_PrimerPositive.tla": {
+    "spec_id": "tlaplus_examples_glowingRaccoon/clean_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/clean_proof_PrimerPositiveScaffold.tla"
     ]
   },
   "tlaplus_examples_glowingRaccoon/clean_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_glowingRaccoon/clean_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/clean_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_glowingRaccoon/stages_proof_NatMinNat.tla": {
+    "spec_id": "tlaplus_examples_glowingRaccoon/stages_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/stages.tla",
@@ -4718,6 +5363,7 @@
     ]
   },
   "tlaplus_examples_glowingRaccoon/stages_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_glowingRaccoon/stages_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/stages.tla",
@@ -4725,126 +5371,147 @@
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneHead.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneHeadScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneSend.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneSendScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneTail.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneTailScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BasicInvariant.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BasicInvariantScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedFromAtMostOne.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedFromAtMostOneScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedNetworkInv.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedNetworkInvScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BroadcastType.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BroadcastTypeScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ClockInvariant.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ClockInvariantScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ContainsSend.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ContainsSendScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ContainsTail.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ContainsTailScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_MessageTypeInThree.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_MessageTypeInThreeScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsAtMostOne.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsAtMostOneScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsPrecedes.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsPrecedesScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsSend.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsSendScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesHead.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesHeadScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesInTail.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesInTailScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesSend.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesSendScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesTail.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesTailScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_Safety.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_SafetyScaffold.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/LockHS_AddingVariables.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/LockHS.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
       "tlaplus_examples_locks_auxiliary_vars/LockHSModel.tla",
@@ -4854,6 +5521,7 @@
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/LockHS_IndInvHS.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/LockHS.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
       "tlaplus_examples_locks_auxiliary_vars/LockHSModel.tla",
@@ -4863,6 +5531,7 @@
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/LockHS_MutualExclusionHS.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/LockHS.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
       "tlaplus_examples_locks_auxiliary_vars/LockHSModel.tla",
@@ -4872,6 +5541,7 @@
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/LockHS_TypingHS.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/LockHS.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
       "tlaplus_examples_locks_auxiliary_vars/LockHSModel.tla",
@@ -4881,18 +5551,21 @@
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/Lock_MutualExclusion.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/LockModel.tla",
       "tlaplus_examples_locks_auxiliary_vars/Lock_MutualExclusionScaffold.tla"
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/Lock_Typing.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/LockModel.tla",
       "tlaplus_examples_locks_auxiliary_vars/Lock_TypingScaffold.tla"
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/Peterson_IndInvariant.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
       "tlaplus_examples_locks_auxiliary_vars/PetersonModel.tla",
@@ -4900,6 +5573,7 @@
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/Peterson_Refinement.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
       "tlaplus_examples_locks_auxiliary_vars/PetersonModel.tla",
@@ -4907,6 +5581,7 @@
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/Peterson_Typing.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
       "tlaplus_examples_locks_auxiliary_vars/PetersonModel.tla",
@@ -4914,119 +5589,139 @@
     ]
   },
   "tlaplus_examples_spanning/spanning_proof_SntMsgInv.tla": {
+    "spec_id": "tlaplus_examples_spanning/spanning_proof.tla",
     "context": [
       "tlaplus_examples_spanning/spanning.tla",
       "tlaplus_examples_spanning/spanning_proof_SntMsgInvScaffold.tla"
     ]
   },
   "tlaplus_examples_spanning/spanning_proof_SntMsgStep.tla": {
+    "spec_id": "tlaplus_examples_spanning/spanning_proof.tla",
     "context": [
       "tlaplus_examples_spanning/spanning.tla",
       "tlaplus_examples_spanning/spanning_proof_SntMsgStepScaffold.tla"
     ]
   },
   "tlaplus_examples_sums_even/sums_even_T1.tla": {
+    "spec_id": "tlaplus_examples_sums_even/sums_even.tla",
     "context": [
       "tlaplus_examples_sums_even/sums_even_T1Scaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvInit.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvInitScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvIsInductive.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvIsInductiveScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvReset.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvResetScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvStutter.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvStutterScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvSystem.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvSystemScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvUser.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvUserScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_InvInit.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_InvInitScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_InvIsAB.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_InvIsABScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_NetworkType.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_NetworkTypeScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_PeersAB.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_PeersABScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_PrefixOneNonEmpty.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_PrefixOneNonEmptyScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_PrefixTwoNonEmpty.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_PrefixTwoNonEmptyScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_SpecImpliesIndInv.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_SpecImpliesIndInvScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_SpecImpliesInv.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_SpecImpliesInvScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_TypeCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_TypeOKInductive.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_TypeOKInductiveScaffold.tla"
     ]
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_InitInv.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_InitInvScaffold.tla",
@@ -5034,6 +5729,7 @@
     ]
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_MajorityNonEmpty.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_MajorityNonEmptyScaffold.tla",
@@ -5041,6 +5737,7 @@
     ]
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaxFnRec.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaxFnRecScaffold.tla",
@@ -5048,6 +5745,7 @@
     ]
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaximumIsMaxFn.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaximumIsMaxFnScaffold.tla",
@@ -5055,6 +5753,7 @@
     ]
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaximumProp.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaximumPropScaffold.tla",
@@ -5062,6 +5761,7 @@
     ]
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_NextInv.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_NextInvScaffold.tla",
@@ -5069,6 +5769,7 @@
     ]
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_Init.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_InitScaffold.tla",
@@ -5076,6 +5777,7 @@
     ]
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_Invariant.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_InvariantScaffold.tla",
@@ -5083,12 +5785,14 @@
     ]
   },
   "tlaplus_examples_transaction_commit/TCommit_proof_TCorrect.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/TCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/TCommit.tla",
       "tlaplus_examples_transaction_commit/TCommit_proof_TCorrectScaffold.tla"
     ]
   },
   "tlaplus_examples_transaction_commit/TwoPhase_proof_Consistency.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/TwoPhase_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/TCommit.tla",
       "tlaplus_examples_transaction_commit/TwoPhase.tla",
@@ -5096,6 +5800,7 @@
     ]
   },
   "tlaplus_examples_transaction_commit/TwoPhase_proof_InvInductive.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/TwoPhase_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/TCommit.tla",
       "tlaplus_examples_transaction_commit/TwoPhase.tla",
@@ -5103,6 +5808,7 @@
     ]
   },
   "tlaplus_examples_transaction_commit/TwoPhase_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/TwoPhase_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/TCommit.tla",
       "tlaplus_examples_transaction_commit/TwoPhase.tla",

--- a/benchmark/proof-from-scratch/manifest.json
+++ b/benchmark/proof-from-scratch/manifest.json
@@ -1,109 +1,130 @@
 {
   "Allocator/Allocator_InitMutex.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_InitMutexDefs.tla"
     ]
   },
   "Allocator/Allocator_InitTypeInvariant.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_InitTypeInvariantDefs.tla"
     ]
   },
   "Allocator/Allocator_NextMutex.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_NextMutexDefs.tla"
     ]
   },
   "Allocator/Allocator_NextTypeInvariant.tla": {
+    "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_NextTypeInvariantDefs.tla"
     ]
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_Safety.tla": {
+    "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_SafetyDefs.tla"
     ]
   },
   "AtomicBakery/AtomicBakery_MutualExclusion.tla": {
+    "spec_id": "AtomicBakery/AtomicBakery.tla",
     "context": [
       "AtomicBakery/AtomicBakeryModel.tla",
       "AtomicBakery/AtomicBakery_MutualExclusionDefs.tla"
     ]
   },
   "Bakery/Bakery_MutualExclusion.tla": {
+    "spec_id": "Bakery/Bakery.tla",
     "context": [
       "Bakery/BakeryModel.tla",
       "Bakery/Bakery_MutualExclusionDefs.tla"
     ]
   },
   "BubbleSort/BubbleSort_IsPermOfExchange.tla": {
+    "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IsPermOfExchangeDefs.tla"
     ]
   },
   "BubbleSort/BubbleSort_IsPermOfTransitive.tla": {
+    "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IsPermOfTransitiveDefs.tla"
     ]
   },
   "BubbleSort/BubbleSort_line202.tla": {
+    "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSortModel.tla",
       "BubbleSort/BubbleSort_line202Defs.tla"
     ]
   },
   "Cantor/Cantor10_NoSetContainsAllValues.tla": {
+    "spec_id": "Cantor/Cantor10.tla",
     "context": [
       "Cantor/Cantor10_NoSetContainsAllValuesDefs.tla"
     ]
   },
   "Cantor/Cantor1_cantor.tla": {
+    "spec_id": "Cantor/Cantor1.tla",
     "context": [
       "Cantor/Cantor1_cantorDefs.tla"
     ]
   },
   "Cantor/Cantor2_cantor.tla": {
+    "spec_id": "Cantor/Cantor2.tla",
     "context": [
       "Cantor/Cantor2_cantorDefs.tla"
     ]
   },
   "Cantor/Cantor3_cantor.tla": {
+    "spec_id": "Cantor/Cantor3.tla",
     "context": [
       "Cantor/Cantor3_cantorDefs.tla"
     ]
   },
   "Cantor/Cantor4_cantor.tla": {
+    "spec_id": "Cantor/Cantor4.tla",
     "context": [
       "Cantor/Cantor4_cantorDefs.tla"
     ]
   },
   "Cantor/Cantor5_cantor.tla": {
+    "spec_id": "Cantor/Cantor5.tla",
     "context": [
       "Cantor/Cantor5_cantorDefs.tla"
     ]
   },
   "Cantor/Cantor6_cantor.tla": {
+    "spec_id": "Cantor/Cantor6.tla",
     "context": [
       "Cantor/Cantor6_cantorDefs.tla"
     ]
   },
   "Cantor/Cantor7_cantor.tla": {
+    "spec_id": "Cantor/Cantor7.tla",
     "context": [
       "Cantor/Cantor7_cantorDefs.tla"
     ]
   },
   "Cantor/Cantor8_Cantor.tla": {
+    "spec_id": "Cantor/Cantor8.tla",
     "context": [
       "Cantor/Cantor8_CantorDefs.tla"
     ]
   },
   "Cantor/Cantor9_Cantor.tla": {
+    "spec_id": "Cantor/Cantor9.tla",
     "context": [
       "Cantor/Cantor9_CantorDefs.tla"
     ]
   },
   "Consensus/Consensus_Invariance.tla": {
+    "spec_id": "Consensus/Consensus.tla",
     "context": [
       "Consensus/ConsensusModel.tla",
       "Consensus/Consensus_Invariance/Sets.tla",
@@ -111,6 +132,7 @@
     ]
   },
   "Consensus/PaxosProof_StructOK1.tla": {
+    "spec_id": "Consensus/PaxosProof.tla",
     "context": [
       "Consensus/PaxosProof_StructOK1/Consensus.tla",
       "Consensus/PaxosProof_StructOK1/PaxosTuple.tla",
@@ -120,6 +142,7 @@
     ]
   },
   "Consensus/PaxosProof_line130.tla": {
+    "spec_id": "Consensus/PaxosProof.tla",
     "context": [
       "Consensus/PaxosProof_line130/Consensus.tla",
       "Consensus/PaxosProof_line130/PaxosTuple.tla",
@@ -129,6 +152,7 @@
     ]
   },
   "Consensus/PaxosProof_line91.tla": {
+    "spec_id": "Consensus/PaxosProof.tla",
     "context": [
       "Consensus/PaxosProof_line91/Consensus.tla",
       "Consensus/PaxosProof_line91/PaxosTuple.tla",
@@ -138,33 +162,39 @@
     ]
   },
   "Consensus/Voting_AllSafeAtZero.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Voting_AllSafeAtZeroDefs.tla"
     ]
   },
   "Consensus/Voting_ChoosableThm.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Voting_ChoosableThmDefs.tla"
     ]
   },
   "Consensus/Voting_Consistent.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/VotingModel.tla",
       "Consensus/Voting_ConsistentDefs.tla"
     ]
   },
   "Consensus/Voting_Invariant.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/VotingModel.tla",
       "Consensus/Voting_InvariantDefs.tla"
     ]
   },
   "Consensus/Voting_QuorumNonEmpty.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/Voting_QuorumNonEmptyDefs.tla"
     ]
   },
   "Consensus/Voting_Refinement.tla": {
+    "spec_id": "Consensus/Voting.tla",
     "context": [
       "Consensus/VotingModel.tla",
       "Consensus/Voting_Refinement/Consensus.tla",
@@ -173,58 +203,69 @@
     ]
   },
   "Data/GraphTheorem_line62.tla": {
+    "spec_id": "Data/GraphTheorem.tla",
     "context": [
       "Data/GraphTheorem_line62/Sets.tla",
       "Data/GraphTheorem_line62Defs.tla"
     ]
   },
   "Data/SequencesTheorems_RemoveSeq.tla": {
+    "spec_id": "Data/SequencesTheorems.tla",
     "context": [
       "Data/SequencesTheorems_RemoveSeqDefs.tla"
     ]
   },
   "Data/Sets_CardinalityOneConverse.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityOneConverseDefs.tla"
     ]
   },
   "Data/Sets_CardinalityTwo.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityTwoDefs.tla"
     ]
   },
   "Data/Sets_FiniteSubset.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_FiniteSubsetDefs.tla"
     ]
   },
   "Data/Sets_IntervalCardinality.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_IntervalCardinalityDefs.tla"
     ]
   },
   "Data/Sets_IsBijectionInverse.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_IsBijectionInverseDefs.tla"
     ]
   },
   "Data/Sets_IsBijectionTransitive.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_IsBijectionTransitiveDefs.tla"
     ]
   },
   "Data/Sets_PigeonHole.tla": {
+    "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_PigeonHoleDefs.tla"
     ]
   },
   "EWD840/EWD840_TerminationDetection.tla": {
+    "spec_id": "EWD840/EWD840.tla",
     "context": [
       "EWD840/EWD840Model.tla",
       "EWD840/EWD840_TerminationDetectionDefs.tla"
     ]
   },
   "Euclid/EuclidEx_PartialCorrectness.tla": {
+    "spec_id": "Euclid/Euclid-Hyperbook/EuclidEx.tla",
     "context": [
       "Euclid/EuclidExModel.tla",
       "Euclid/EuclidEx_PartialCorrectness/GCD.tla",
@@ -232,87 +273,102 @@
     ]
   },
   "Euclid/Euclid_Correctness.tla": {
+    "spec_id": "Euclid/Euclid-TLAPS-Example/Euclid.tla",
     "context": [
       "Euclid/EuclidModel.tla",
       "Euclid/Euclid_CorrectnessDefs.tla"
     ]
   },
   "Euclid/GCD_GCD1.tla": {
+    "spec_id": "Euclid/Euclid-Hyperbook/GCD.tla",
     "context": [
       "Euclid/GCD_GCD1Defs.tla"
     ]
   },
   "Euclid/GCD_GCD2.tla": {
+    "spec_id": "Euclid/Euclid-Hyperbook/GCD.tla",
     "context": [
       "Euclid/GCD_GCD2Defs.tla"
     ]
   },
   "Euclid/GCD_GCD3.tla": {
+    "spec_id": "Euclid/Euclid-Hyperbook/GCD.tla",
     "context": [
       "Euclid/GCD_GCD3Defs.tla"
     ]
   },
   "OpenAddressing/OpenAddressing_CompleteAsSafety.tla": {
+    "spec_id": "OpenAddressing/OpenAddressing.tla",
     "context": [
       "OpenAddressing/OpenAddressingModel.tla",
       "OpenAddressing/OpenAddressing_CompleteAsSafetyDefs.tla"
     ]
   },
   "OpenAddressing/OpenAddressing_Consistent.tla": {
+    "spec_id": "OpenAddressing/OpenAddressing.tla",
     "context": [
       "OpenAddressing/OpenAddressingModel.tla",
       "OpenAddressing/OpenAddressing_ConsistentDefs.tla"
     ]
   },
   "OpenAddressing/OpenAddressing_Contains.tla": {
+    "spec_id": "OpenAddressing/OpenAddressing.tla",
     "context": [
       "OpenAddressing/OpenAddressingModel.tla",
       "OpenAddressing/OpenAddressing_ContainsDefs.tla"
     ]
   },
   "OpenAddressing/OpenAddressing_Duplicates.tla": {
+    "spec_id": "OpenAddressing/OpenAddressing.tla",
     "context": [
       "OpenAddressing/OpenAddressingModel.tla",
       "OpenAddressing/OpenAddressing_DuplicatesDefs.tla"
     ]
   },
   "OpenAddressing/OpenAddressing_Sorted.tla": {
+    "spec_id": "OpenAddressing/OpenAddressing.tla",
     "context": [
       "OpenAddressing/OpenAddressingModel.tla",
       "OpenAddressing/OpenAddressing_SortedDefs.tla"
     ]
   },
   "Paxos/Consensus_Inv.tla": {
+    "spec_id": "Paxos/Consensus.tla",
     "context": [
       "Paxos/ConsensusModel.tla",
       "Paxos/Consensus_InvDefs.tla"
     ]
   },
   "Paxos/PaxosHistVar_Consistent.tla": {
+    "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_ConsistentDefs.tla"
     ]
   },
   "Paxos/PaxosHistVar_Invariant.tla": {
+    "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_InvariantDefs.tla"
     ]
   },
   "Paxos/Paxos_Consistent.tla": {
+    "spec_id": "Paxos/Paxos.tla",
     "context": [
       "Paxos/PaxosModel.tla",
       "Paxos/Paxos_ConsistentDefs.tla"
     ]
   },
   "Paxos/Paxos_Invariant.tla": {
+    "spec_id": "Paxos/Paxos.tla",
     "context": [
       "Paxos/PaxosModel.tla",
       "Paxos/Paxos_InvariantDefs.tla"
     ]
   },
   "Paxos/Paxos_Refinement.tla": {
+    "spec_id": "Paxos/Paxos.tla",
     "context": [
       "Paxos/PaxosModel.tla",
       "Paxos/Paxos_Refinement/Consensus.tla",
@@ -320,17 +376,20 @@
     ]
   },
   "Peterson/Peterson_Liveness.tla": {
+    "spec_id": "Peterson/Peterson.tla",
     "context": [
       "Peterson/Peterson_LivenessDefs.tla"
     ]
   },
   "Peterson/Peterson_MutualExclusion.tla": {
+    "spec_id": "Peterson/Peterson.tla",
     "context": [
       "Peterson/PetersonModel.tla",
       "Peterson/Peterson_MutualExclusionDefs.tla"
     ]
   },
   "Record/Record_SV_Spec.tla": {
+    "spec_id": "Record/Record.tla",
     "context": [
       "Record/RecordModel.tla",
       "Record/Record_SV_Spec/SimpleVoting.tla",
@@ -338,77 +397,90 @@
     ]
   },
   "SimpleMutex/SimpleMutex_Safety.tla": {
+    "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutexModel.tla",
       "SimpleMutex/SimpleMutex_SafetyDefs.tla"
     ]
   },
   "SimpleMutex/SimpleMutex_line140.tla": {
+    "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutex_line140Defs.tla"
     ]
   },
   "SumAndMax/SumAndMax_Correctness.tla": {
+    "spec_id": "SumAndMax/SumAndMax.tla",
     "context": [
       "SumAndMax/SumAndMaxModel.tla",
       "SumAndMax/SumAndMax_CorrectnessDefs.tla"
     ]
   },
   "ZooKeeper/Zab_Agreement.tla": {
+    "spec_id": "ZooKeeper/Zab.tla",
     "context": [
       "ZooKeeper/ZabModel.tla",
       "ZooKeeper/Zab_AgreementDefs.tla"
     ]
   },
   "ZooKeeper/Zab_GlobalPrimaryOrder.tla": {
+    "spec_id": "ZooKeeper/Zab.tla",
     "context": [
       "ZooKeeper/ZabModel.tla",
       "ZooKeeper/Zab_GlobalPrimaryOrderDefs.tla"
     ]
   },
   "ZooKeeper/Zab_Integrity.tla": {
+    "spec_id": "ZooKeeper/Zab.tla",
     "context": [
       "ZooKeeper/ZabModel.tla",
       "ZooKeeper/Zab_IntegrityDefs.tla"
     ]
   },
   "ZooKeeper/Zab_Leadership1.tla": {
+    "spec_id": "ZooKeeper/Zab.tla",
     "context": [
       "ZooKeeper/ZabModel.tla",
       "ZooKeeper/Zab_Leadership1Defs.tla"
     ]
   },
   "ZooKeeper/Zab_Leadership2.tla": {
+    "spec_id": "ZooKeeper/Zab.tla",
     "context": [
       "ZooKeeper/ZabModel.tla",
       "ZooKeeper/Zab_Leadership2Defs.tla"
     ]
   },
   "ZooKeeper/Zab_LocalPrimaryOrder.tla": {
+    "spec_id": "ZooKeeper/Zab.tla",
     "context": [
       "ZooKeeper/ZabModel.tla",
       "ZooKeeper/Zab_LocalPrimaryOrderDefs.tla"
     ]
   },
   "ZooKeeper/Zab_PrefixConsistency.tla": {
+    "spec_id": "ZooKeeper/Zab.tla",
     "context": [
       "ZooKeeper/ZabModel.tla",
       "ZooKeeper/Zab_PrefixConsistencyDefs.tla"
     ]
   },
   "ZooKeeper/Zab_PrimaryIntegrity.tla": {
+    "spec_id": "ZooKeeper/Zab.tla",
     "context": [
       "ZooKeeper/ZabModel.tla",
       "ZooKeeper/Zab_PrimaryIntegrityDefs.tla"
     ]
   },
   "ZooKeeper/Zab_TotalOrder.tla": {
+    "spec_id": "ZooKeeper/Zab.tla",
     "context": [
       "ZooKeeper/ZabModel.tla",
       "ZooKeeper/Zab_TotalOrderDefs.tla"
     ]
   },
   "ZooKeeper_LowLevel/ZkV3_7_0_Agreement.tla": {
+    "spec_id": "ZooKeeper_LowLevel/ZkV3_7_0.tla",
     "context": [
       "ZooKeeper_LowLevel/ZkV3_7_0Model.tla",
       "ZooKeeper_LowLevel/ZkV3_7_0_Agreement/FastLeaderElection.tla",
@@ -416,6 +488,7 @@
     ]
   },
   "ZooKeeper_LowLevel/ZkV3_7_0_GlobalPrimaryOrder.tla": {
+    "spec_id": "ZooKeeper_LowLevel/ZkV3_7_0.tla",
     "context": [
       "ZooKeeper_LowLevel/ZkV3_7_0Model.tla",
       "ZooKeeper_LowLevel/ZkV3_7_0_GlobalPrimaryOrder/FastLeaderElection.tla",
@@ -423,6 +496,7 @@
     ]
   },
   "ZooKeeper_LowLevel/ZkV3_7_0_Integrity.tla": {
+    "spec_id": "ZooKeeper_LowLevel/ZkV3_7_0.tla",
     "context": [
       "ZooKeeper_LowLevel/ZkV3_7_0Model.tla",
       "ZooKeeper_LowLevel/ZkV3_7_0_Integrity/FastLeaderElection.tla",
@@ -430,6 +504,7 @@
     ]
   },
   "ZooKeeper_LowLevel/ZkV3_7_0_Leadership1.tla": {
+    "spec_id": "ZooKeeper_LowLevel/ZkV3_7_0.tla",
     "context": [
       "ZooKeeper_LowLevel/ZkV3_7_0Model.tla",
       "ZooKeeper_LowLevel/ZkV3_7_0_Leadership1/FastLeaderElection.tla",
@@ -437,6 +512,7 @@
     ]
   },
   "ZooKeeper_LowLevel/ZkV3_7_0_Leadership2.tla": {
+    "spec_id": "ZooKeeper_LowLevel/ZkV3_7_0.tla",
     "context": [
       "ZooKeeper_LowLevel/ZkV3_7_0Model.tla",
       "ZooKeeper_LowLevel/ZkV3_7_0_Leadership2/FastLeaderElection.tla",
@@ -444,6 +520,7 @@
     ]
   },
   "ZooKeeper_LowLevel/ZkV3_7_0_LocalPrimaryOrder.tla": {
+    "spec_id": "ZooKeeper_LowLevel/ZkV3_7_0.tla",
     "context": [
       "ZooKeeper_LowLevel/ZkV3_7_0Model.tla",
       "ZooKeeper_LowLevel/ZkV3_7_0_LocalPrimaryOrder/FastLeaderElection.tla",
@@ -451,6 +528,7 @@
     ]
   },
   "ZooKeeper_LowLevel/ZkV3_7_0_PrefixConsistency.tla": {
+    "spec_id": "ZooKeeper_LowLevel/ZkV3_7_0.tla",
     "context": [
       "ZooKeeper_LowLevel/ZkV3_7_0Model.tla",
       "ZooKeeper_LowLevel/ZkV3_7_0_PrefixConsistency/FastLeaderElection.tla",
@@ -458,6 +536,7 @@
     ]
   },
   "ZooKeeper_LowLevel/ZkV3_7_0_PrimaryIntegrity.tla": {
+    "spec_id": "ZooKeeper_LowLevel/ZkV3_7_0.tla",
     "context": [
       "ZooKeeper_LowLevel/ZkV3_7_0Model.tla",
       "ZooKeeper_LowLevel/ZkV3_7_0_PrimaryIntegrity/FastLeaderElection.tla",
@@ -465,6 +544,7 @@
     ]
   },
   "ZooKeeper_LowLevel/ZkV3_7_0_TotalOrder.tla": {
+    "spec_id": "ZooKeeper_LowLevel/ZkV3_7_0.tla",
     "context": [
       "ZooKeeper_LowLevel/ZkV3_7_0Model.tla",
       "ZooKeeper_LowLevel/ZkV3_7_0_TotalOrder/FastLeaderElection.tla",
@@ -472,145 +552,170 @@
     ]
   },
   "etcd_raft/etcd_raft_CommittedIsDurable.tla": {
+    "spec_id": "etcd_raft/etcd_raft.tla",
     "context": [
       "etcd_raft/etcd_raftModel.tla",
       "etcd_raft/etcd_raft_CommittedIsDurableDefs.tla"
     ]
   },
   "etcd_raft/etcd_raft_ElectionSafety.tla": {
+    "spec_id": "etcd_raft/etcd_raft.tla",
     "context": [
       "etcd_raft/etcd_raftModel.tla",
       "etcd_raft/etcd_raft_ElectionSafetyDefs.tla"
     ]
   },
   "etcd_raft/etcd_raft_LeaderCompleteness.tla": {
+    "spec_id": "etcd_raft/etcd_raft.tla",
     "context": [
       "etcd_raft/etcd_raftModel.tla",
       "etcd_raft/etcd_raft_LeaderCompletenessDefs.tla"
     ]
   },
   "etcd_raft/etcd_raft_LogInv.tla": {
+    "spec_id": "etcd_raft/etcd_raft.tla",
     "context": [
       "etcd_raft/etcd_raftModel.tla",
       "etcd_raft/etcd_raft_LogInvDefs.tla"
     ]
   },
   "etcd_raft/etcd_raft_LogMatching.tla": {
+    "spec_id": "etcd_raft/etcd_raft.tla",
     "context": [
       "etcd_raft/etcd_raftModel.tla",
       "etcd_raft/etcd_raft_LogMatchingDefs.tla"
     ]
   },
   "etcd_raft/etcd_raft_MoreThanOneLeader.tla": {
+    "spec_id": "etcd_raft/etcd_raft.tla",
     "context": [
       "etcd_raft/etcd_raftModel.tla",
       "etcd_raft/etcd_raft_MoreThanOneLeaderDefs.tla"
     ]
   },
   "etcd_raft/etcd_raft_MoreUpToDate.tla": {
+    "spec_id": "etcd_raft/etcd_raft.tla",
     "context": [
       "etcd_raft/etcd_raftModel.tla",
       "etcd_raft/etcd_raft_MoreUpToDateDefs.tla"
     ]
   },
   "etcd_raft/etcd_raft_QuorumLog.tla": {
+    "spec_id": "etcd_raft/etcd_raft.tla",
     "context": [
       "etcd_raft/etcd_raftModel.tla",
       "etcd_raft/etcd_raft_QuorumLogDefs.tla"
     ]
   },
   "ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocol_Liveness.tla": {
+    "spec_id": "ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocol.tla",
     "context": [
       "ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocolModel.tla",
       "ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocol_LivenessDefs.tla"
     ]
   },
   "ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocol_Safety.tla": {
+    "spec_id": "ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocol.tla",
     "context": [
       "ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocolModel.tla",
       "ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocol_SafetyDefs.tla"
     ]
   },
   "ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_CorrectnessLiveness.tla": {
+    "spec_id": "ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa.tla",
     "context": [
       "ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_CorrectnessLivenessDefs.tla"
     ]
   },
   "ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_RelayLiveness.tla": {
+    "spec_id": "ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa.tla",
     "context": [
       "ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_RelayLivenessDefs.tla"
     ]
   },
   "ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_Safety.tla": {
+    "spec_id": "ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa.tla",
     "context": [
       "ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisaModel.tla",
       "ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_SafetyDefs.tla"
     ]
   },
   "ivy_examples_split_queue_2_new/ivy_examples_split_queue_2_new_Liveness.tla": {
+    "spec_id": "ivy_examples_split_queue_2_new/ivy_examples_split_queue_2_new.tla",
     "context": [
       "ivy_examples_split_queue_2_new/ivy_examples_split_queue_2_newModel.tla",
       "ivy_examples_split_queue_2_new/ivy_examples_split_queue_2_new_LivenessDefs.tla"
     ]
   },
   "ivy_examples_ticket/ivy_examples_ticket_Liveness.tla": {
+    "spec_id": "ivy_examples_ticket/ivy_examples_ticket.tla",
     "context": [
       "ivy_examples_ticket/ivy_examples_ticket_LivenessDefs.tla"
     ]
   },
   "ivy_examples_ticket/ivy_examples_ticket_Safety.tla": {
+    "spec_id": "ivy_examples_ticket/ivy_examples_ticket.tla",
     "context": [
       "ivy_examples_ticket/ivy_examples_ticketModel.tla",
       "ivy_examples_ticket/ivy_examples_ticket_SafetyDefs.tla"
     ]
   },
   "ivy_examples_ticket_nested/ivy_examples_ticket_nested_Liveness.tla": {
+    "spec_id": "ivy_examples_ticket_nested/ivy_examples_ticket_nested.tla",
     "context": [
       "ivy_examples_ticket_nested/ivy_examples_ticket_nested_LivenessDefs.tla"
     ]
   },
   "ivy_examples_ticket_nested/ivy_examples_ticket_nested_Safety.tla": {
+    "spec_id": "ivy_examples_ticket_nested/ivy_examples_ticket_nested.tla",
     "context": [
       "ivy_examples_ticket_nested/ivy_examples_ticket_nestedModel.tla",
       "ivy_examples_ticket_nested/ivy_examples_ticket_nested_SafetyDefs.tla"
     ]
   },
   "ivy_examples_tlb/ivy_examples_tlb_Liveness.tla": {
+    "spec_id": "ivy_examples_tlb/ivy_examples_tlb.tla",
     "context": [
       "ivy_examples_tlb/ivy_examples_tlb_LivenessDefs.tla"
     ]
   },
   "ivy_examples_tlb/ivy_examples_tlb_Safety.tla": {
+    "spec_id": "ivy_examples_tlb/ivy_examples_tlb.tla",
     "context": [
       "ivy_examples_tlb/ivy_examples_tlbModel.tla",
       "ivy_examples_tlb/ivy_examples_tlb_SafetyDefs.tla"
     ]
   },
   "tlaplus_examples_Bakery-Boulangerie/Bakery_MutualExclusion.tla": {
+    "spec_id": "tlaplus_examples_Bakery-Boulangerie/Bakery.tla",
     "context": [
       "tlaplus_examples_Bakery-Boulangerie/BakeryModel.tla",
       "tlaplus_examples_Bakery-Boulangerie/Bakery_MutualExclusionDefs.tla"
     ]
   },
   "tlaplus_examples_Bakery-Boulangerie/Bakery_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_Bakery-Boulangerie/Bakery.tla",
     "context": [
       "tlaplus_examples_Bakery-Boulangerie/BakeryModel.tla",
       "tlaplus_examples_Bakery-Boulangerie/Bakery_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_Bakery-Boulangerie/Boulanger_MutualExclusion.tla": {
+    "spec_id": "tlaplus_examples_Bakery-Boulangerie/Boulanger.tla",
     "context": [
       "tlaplus_examples_Bakery-Boulangerie/BoulangerModel.tla",
       "tlaplus_examples_Bakery-Boulangerie/Boulanger_MutualExclusionDefs.tla"
     ]
   },
   "tlaplus_examples_Bakery-Boulangerie/Boulanger_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_Bakery-Boulangerie/Boulanger.tla",
     "context": [
       "tlaplus_examples_Bakery-Boulangerie/BoulangerModel.tla",
       "tlaplus_examples_Bakery-Boulangerie/Boulanger_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs_BQS_Spec.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs_BQS_Spec/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs_BQS_Spec/BlockingQueueFair.tla",
@@ -619,6 +724,7 @@
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_DeadlockFreedom.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_DeadlockFreedom/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_DeadlockFreedom/BlockingQueueSplit.tla",
@@ -626,6 +732,7 @@
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_IInvRefines.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_IInvRefines/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_IInvRefines/BlockingQueueSplit.tla",
@@ -633,6 +740,7 @@
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_Implements.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_Implements/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_Implements/BlockingQueueSplit.tla",
@@ -640,48 +748,56 @@
     ]
   },
   "tlaplus_examples_BlockingQueue/BlockingQueue_proofs_DeadlockFreedom.tla": {
+    "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueue_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueue_proofs_DeadlockFreedom/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueue_proofs_DeadlockFreedomDefs.tla"
     ]
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneCorrect.tla": {
+    "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneCorrect/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_TypeCorrect/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_CoffeeCan/CoffeeCan_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_CoffeeCan/CoffeeCan_proof.tla",
     "context": [
       "tlaplus_examples_CoffeeCan/CoffeeCan_proof_TypeCorrect/CoffeeCan.tla",
       "tlaplus_examples_CoffeeCan/CoffeeCan_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_DieHard/DieHard_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_DieHard/DieHard_proof.tla",
     "context": [
       "tlaplus_examples_DieHard/DieHard_proof_TypeCorrect/DieHard.tla",
       "tlaplus_examples_DieHard/DieHard_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_Convergence.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_Convergence/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_ConvergenceDefs.tla"
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_Monotonicity.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_Monotonicity/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_MonotonicityDefs.tla"
     ]
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_OGLiveness.tla": {
+    "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
     "context": [
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_OGLiveness/CRDT.tla",
@@ -689,132 +805,154 @@
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_CacheDataCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_CacheDataCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_CacheStateCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_CacheStateCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_DirProgressCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_DirProgressCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_InvProgressCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_InvProgressCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_1_Correct.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_1_CorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_2_Correct.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_2_CorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_3_Correct.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_3_CorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_4_Correct.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_4_CorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_5_Correct.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_5_CorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_MemDataCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_MemDataCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_NakcProgressCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_NakcProgressCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_ReqProgressCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_ReqProgressCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_RpProgressCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_RpProgressCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_ShWbProgressCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_ShWbProgressCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_UniProgressCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_UniProgressCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_FlashProtocol/FlashWithMutex_WbProgressCorrect.tla": {
+    "spec_id": "tlaplus_examples_FlashProtocol/FlashWithMutex.tla",
     "context": [
       "tlaplus_examples_FlashProtocol/FlashWithMutexModel.tla",
       "tlaplus_examples_FlashProtocol/FlashWithMutex_WbProgressCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_GermanProtocol/GermanControlBenchmarks_Coherence.tla": {
+    "spec_id": "tlaplus_examples_GermanProtocol/GermanControlBenchmarks.tla",
     "context": [
       "tlaplus_examples_GermanProtocol/GermanControlBenchmarks_Coherence/GermanControl.tla",
       "tlaplus_examples_GermanProtocol/GermanControlBenchmarks_CoherenceDefs.tla"
     ]
   },
   "tlaplus_examples_GermanProtocol/GermanData_DataProp.tla": {
+    "spec_id": "tlaplus_examples_GermanProtocol/GermanData.tla",
     "context": [
       "tlaplus_examples_GermanProtocol/GermanDataModel.tla",
       "tlaplus_examples_GermanProtocol/GermanData_DataPropDefs.tla"
     ]
   },
   "tlaplus_examples_GermanProtocol/GermanData_DirectoryAccurate.tla": {
+    "spec_id": "tlaplus_examples_GermanProtocol/GermanData.tla",
     "context": [
       "tlaplus_examples_GermanProtocol/GermanDataModel.tla",
       "tlaplus_examples_GermanProtocol/GermanData_DirectoryAccurateDefs.tla"
     ]
   },
   "tlaplus_examples_GermanProtocol/GermanData_ExclusiveIsolation.tla": {
+    "spec_id": "tlaplus_examples_GermanProtocol/GermanData.tla",
     "context": [
       "tlaplus_examples_GermanProtocol/GermanDataModel.tla",
       "tlaplus_examples_GermanProtocol/GermanData_ExclusiveIsolationDefs.tla"
     ]
   },
   "tlaplus_examples_GermanProtocol/GermanData_Refinement.tla": {
+    "spec_id": "tlaplus_examples_GermanProtocol/GermanData.tla",
     "context": [
       "tlaplus_examples_GermanProtocol/GermanDataModel.tla",
       "tlaplus_examples_GermanProtocol/GermanData_Refinement/GermanControl.tla",
@@ -822,78 +960,91 @@
     ]
   },
   "tlaplus_examples_GermanProtocol/GermanData_TransactionConsistency.tla": {
+    "spec_id": "tlaplus_examples_GermanProtocol/GermanData.tla",
     "context": [
       "tlaplus_examples_GermanProtocol/GermanDataModel.tla",
       "tlaplus_examples_GermanProtocol/GermanData_TransactionConsistencyDefs.tla"
     ]
   },
   "tlaplus_examples_GermanProtocol/GermanData_WritebackCarriesLatest.tla": {
+    "spec_id": "tlaplus_examples_GermanProtocol/GermanData.tla",
     "context": [
       "tlaplus_examples_GermanProtocol/GermanDataModel.tla",
       "tlaplus_examples_GermanProtocol/GermanData_WritebackCarriesLatestDefs.tla"
     ]
   },
   "tlaplus_examples_KeyValueStore/KeyValueStore_proof_TypeAndLifecycle.tla": {
+    "spec_id": "tlaplus_examples_KeyValueStore/KeyValueStore_proof.tla",
     "context": [
       "tlaplus_examples_KeyValueStore/KeyValueStore_proof_TypeAndLifecycle/KeyValueStore.tla",
       "tlaplus_examples_KeyValueStore/KeyValueStore_proof_TypeAndLifecycleDefs.tla"
     ]
   },
   "tlaplus_examples_LearnProofs/AddTwo_Even.tla": {
+    "spec_id": "tlaplus_examples_LearnProofs/AddTwo.tla",
     "context": [
       "tlaplus_examples_LearnProofs/AddTwoModel.tla",
       "tlaplus_examples_LearnProofs/AddTwo_EvenDefs.tla"
     ]
   },
   "tlaplus_examples_LearnProofs/AddTwo_TypeInvariant.tla": {
+    "spec_id": "tlaplus_examples_LearnProofs/AddTwo.tla",
     "context": [
       "tlaplus_examples_LearnProofs/AddTwoModel.tla",
       "tlaplus_examples_LearnProofs/AddTwo_TypeInvariantDefs.tla"
     ]
   },
   "tlaplus_examples_LearnProofs/FindHighest_DoneIndexValueThm.tla": {
+    "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_DoneIndexValueThmDefs.tla"
     ]
   },
   "tlaplus_examples_LearnProofs/FindHighest_InductiveInvariantHolds.tla": {
+    "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_InductiveInvariantHoldsDefs.tla"
     ]
   },
   "tlaplus_examples_LearnProofs/FindHighest_IsCorrect.tla": {
+    "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_IsCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_LearnProofs/FindHighest_TypeInvariantHolds.tla": {
+    "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_TypeInvariantHoldsDefs.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/BinarySearch_resultCorrect.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/BinarySearch.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/BinarySearchModel.tla",
       "tlaplus_examples_LoopInvariance/BinarySearch_resultCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/Quicksort_PCorrect.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/QuicksortModel.tla",
       "tlaplus_examples_LoopInvariance/Quicksort_PCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_LoopInvariance/SumSequence_PCorrect.tla": {
+    "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequenceModel.tla",
       "tlaplus_examples_LoopInvariance/SumSequence_PCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_MisraReachability/ParReachProofs_line18.tla": {
+    "spec_id": "tlaplus_examples_MisraReachability/ParReachProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/ParReachProofs_line18/ParReach.tla",
       "tlaplus_examples_MisraReachability/ParReachProofs_line18/Reachability.tla",
@@ -902,6 +1053,7 @@
     ]
   },
   "tlaplus_examples_MisraReachability/ReachableProofs_line197.tla": {
+    "spec_id": "tlaplus_examples_MisraReachability/ReachableProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/ReachableProofs_line197/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachableProofs_line197/ReachabilityProofs.tla",
@@ -910,6 +1062,7 @@
     ]
   },
   "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proof.tla",
     "context": [
       "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proofModel.tla",
       "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proof_TypeCorrect/MissionariesAndCannibals.tla",
@@ -917,30 +1070,35 @@
     ]
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_SafetyCorrect.tla": {
+    "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator_proof_SafetyCorrect/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_SafetyCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator_proof_TypeCorrect/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_Paxos/Consensus_Invariance.tla": {
+    "spec_id": "tlaplus_examples_Paxos/Consensus.tla",
     "context": [
       "tlaplus_examples_Paxos/ConsensusModel.tla",
       "tlaplus_examples_Paxos/Consensus_InvarianceDefs.tla"
     ]
   },
   "tlaplus_examples_Paxos/Consensus_LivenessTheorem.tla": {
+    "spec_id": "tlaplus_examples_Paxos/Consensus.tla",
     "context": [
       "tlaplus_examples_Paxos/ConsensusModel.tla",
       "tlaplus_examples_Paxos/Consensus_LivenessTheoremDefs.tla"
     ]
   },
   "tlaplus_examples_Paxos/Voting_C_Spec.tla": {
+    "spec_id": "tlaplus_examples_Paxos/Voting.tla",
     "context": [
       "tlaplus_examples_Paxos/VotingModel.tla",
       "tlaplus_examples_Paxos/Voting_C_Spec/Consensus.tla",
@@ -948,17 +1106,20 @@
     ]
   },
   "tlaplus_examples_Paxos/Voting_QuorumNonEmpty.tla": {
+    "spec_id": "tlaplus_examples_Paxos/Voting.tla",
     "context": [
       "tlaplus_examples_Paxos/Voting_QuorumNonEmptyDefs.tla"
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Consensus_Invariance.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/ConsensusModel.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus_InvarianceDefs.tla"
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_Implementation.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/VotingModel.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_Implementation/Consensus.tla",
@@ -966,12 +1127,14 @@
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_Invariance.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/VotingModel.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_InvarianceDefs.tla"
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_AllSafeAtZero_T.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_AllSafeAtZero_T/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_AllSafeAtZero_T/Voting.tla",
@@ -979,6 +1142,7 @@
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ChoosableThm_T.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ChoosableThm_T/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ChoosableThm_T/Voting.tla",
@@ -986,6 +1150,7 @@
     ]
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ShowsSafety_T.tla": {
+    "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ShowsSafety_T/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ShowsSafety_T/Voting.tla",
@@ -993,36 +1158,42 @@
     ]
   },
   "tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyCorrect.tla": {
+    "spec_id": "tlaplus_examples_ReadersWriters/ReadersWriters_proof.tla",
     "context": [
       "tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyCorrect/ReadersWriters.tla",
       "tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_ReadersWriters/ReadersWriters_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_ReadersWriters/ReadersWriters_proof.tla",
     "context": [
       "tlaplus_examples_ReadersWriters/ReadersWriters_proof_TypeCorrect/ReadersWriters.tla",
       "tlaplus_examples_ReadersWriters/ReadersWriters_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_SpanningTree/SpanTree_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpanningTree/SpanTree_proof.tla",
     "context": [
       "tlaplus_examples_SpanningTree/SpanTree_proof_TypeCorrect/SpanTree.tla",
       "tlaplus_examples_SpanningTree/SpanTree_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof_TypeCorrect/AsynchInterface.tla",
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof_TypeCorrect/Channel.tla",
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_TypeCorrect/InternalMemory.tla",
       "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_TypeCorrect/MemoryInterface.tla",
@@ -1030,12 +1201,14 @@
     ]
   },
   "tlaplus_examples_SpecifyingSystems_Composing/HourClock_proof_HCini_Invariant.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_Composing/HourClock_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_Composing/HourClock_proof_HCini_Invariant/HourClock.tla",
       "tlaplus_examples_SpecifyingSystems_Composing/HourClock_proof_HCini_InvariantDefs.tla"
     ]
   },
   "tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO_proof_TypeCorrect/Channel.tla",
       "tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO_proof_TypeCorrect/InnerFIFO.tla",
@@ -1043,78 +1216,91 @@
     ]
   },
   "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof_TypeCorrect/AlternatingBit.tla",
       "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegularModel.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_CorrectnessDefs.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness2.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegularModel.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness2Defs.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_InvInvariant.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_InvInvariant/SimpleRegular.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_InvInvariantDefs.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_TypeCorrect/SimpleRegular.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/Simple_Correctness.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/Simple.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleModel.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_CorrectnessDefs.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/Simple_Correctness2.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/Simple.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleModel.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_Correctness2Defs.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/Simple_proof_InvInvariant.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/Simple_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/Simple_proof_InvInvariant/Simple.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_proof_InvInvariantDefs.tla"
     ]
   },
   "tlaplus_examples_TeachingConcurrency/Simple_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_TeachingConcurrency/Simple_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/Simple_proof_TypeCorrect/Simple.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_Consistent.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_ConsistentDefs.tla"
     ]
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_Invariant.tla": {
+    "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_InvariantDefs.tla"
     ]
   },
   "tlaplus_examples_Termination/Termination_proof_Safety.tla": {
+    "spec_id": "tlaplus_examples_Termination/Termination_proof.tla",
     "context": [
       "tlaplus_examples_Termination/Termination_proof_Safety/Termination.tla",
       "tlaplus_examples_Termination/Termination_proof_SafetyDefs.tla"
     ]
   },
   "tlaplus_examples_TwoPhase/TwoPhase_Implementation.tla": {
+    "spec_id": "tlaplus_examples_TwoPhase/TwoPhase.tla",
     "context": [
       "tlaplus_examples_TwoPhase/TwoPhaseModel.tla",
       "tlaplus_examples_TwoPhase/TwoPhase_Implementation/Alternate.tla",
@@ -1122,6 +1308,7 @@
     ]
   },
   "tlaplus_examples_TwoPhase/TwoPhase_proof_line17.tla": {
+    "spec_id": "tlaplus_examples_TwoPhase/TwoPhase_proof.tla",
     "context": [
       "tlaplus_examples_TwoPhase/TwoPhase_proof_line17/Alternate.tla",
       "tlaplus_examples_TwoPhase/TwoPhase_proof_line17/TwoPhase.tla",
@@ -1129,6 +1316,7 @@
     ]
   },
   "tlaplus_examples_allocator/AllocatorImplementation_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_allocator/AllocatorImplementation_proof.tla",
     "context": [
       "tlaplus_examples_allocator/AllocatorImplementation_proof_TypeCorrect/AllocatorImplementation.tla",
       "tlaplus_examples_allocator/AllocatorImplementation_proof_TypeCorrect/SchedulingAllocator.tla",
@@ -1136,30 +1324,35 @@
     ]
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_Mutex.tla": {
+    "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator_proof_Mutex/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_MutexDefs.tla"
     ]
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator_proof_TypeCorrect/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_allocator/SimpleAllocator_proof_Mutex.tla": {
+    "spec_id": "tlaplus_examples_allocator/SimpleAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SimpleAllocator_proof_Mutex/SimpleAllocator.tla",
       "tlaplus_examples_allocator/SimpleAllocator_proof_MutexDefs.tla"
     ]
   },
   "tlaplus_examples_allocator/SimpleAllocator_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_allocator/SimpleAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SimpleAllocator_proof_TypeCorrect/SimpleAllocator.tla",
       "tlaplus_examples_allocator/SimpleAllocator_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_barriers/Barriers_B_Spec.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_B_Spec/Barrier.tla",
@@ -1167,67 +1360,79 @@
     ]
   },
   "tlaplus_examples_barriers/Barriers_BarrierExclusion.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barriers_BarrierExclusionDefs.tla"
     ]
   },
   "tlaplus_examples_barriers/Barriers_BarrierExclusion2.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/Barriers_BarrierExclusion2Defs.tla"
     ]
   },
   "tlaplus_examples_barriers/Barriers_FlushInvariant.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_FlushInvariantDefs.tla"
     ]
   },
   "tlaplus_examples_barriers/Barriers_Invariant.tla": {
+    "spec_id": "tlaplus_examples_barriers/Barriers.tla",
     "context": [
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_InvariantDefs.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcastDefs.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast_TLC.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast_TLCDefs.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_Init.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_InitDefs.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_SpecNoBcast.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_SpecNoBcastDefs.tla"
     ]
   },
   "tlaplus_examples_bcastByz/bcastByz_Unforg_Step4.tla": {
+    "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_Unforg_Step4Defs.tla"
     ]
   },
   "tlaplus_examples_byihive/VoucherLifeCycle_proof_Spec_TypeOK_Consistent.tla": {
+    "spec_id": "tlaplus_examples_byihive/VoucherLifeCycle_proof.tla",
     "context": [
       "tlaplus_examples_byihive/VoucherLifeCycle_proof_Spec_TypeOK_Consistent/VoucherLifeCycle.tla",
       "tlaplus_examples_byihive/VoucherLifeCycle_proof_Spec_TypeOK_ConsistentDefs.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_Invariance.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel.tla",
       "tlaplus_examples_byzpaxos/BPConProof_InvarianceDefs.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_P_Spec.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProofModel.tla",
       "tlaplus_examples_byzpaxos/BPConProof_P_Spec/Consensus.tla",
@@ -1237,6 +1442,7 @@
     ]
   },
   "tlaplus_examples_byzpaxos/BPConProof_line2170.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/BPConProof_line2170/Consensus.tla",
       "tlaplus_examples_byzpaxos/BPConProof_line2170/PConProof.tla",
@@ -1245,45 +1451,53 @@
     ]
   },
   "tlaplus_examples_byzpaxos/Consensus_Invariance.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel.tla",
       "tlaplus_examples_byzpaxos/Consensus_InvarianceDefs.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/Consensus_LiveSpecEquals.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/Consensus_LiveSpecEqualsDefs.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/Consensus_Liveness.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel.tla",
       "tlaplus_examples_byzpaxos/Consensus_LivenessDefs.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/PConProof_NextDef.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/PConProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/PConProof_NextDefDefs.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_Liveness.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/VoteProof_Liveness/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProof_LivenessDefs.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_VInv1.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/VoteProof_VInv1Defs.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT2.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/VoteProofModel.tla",
       "tlaplus_examples_byzpaxos/VoteProof_VT2Defs.tla"
     ]
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT3.tla": {
+    "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
     "context": [
       "tlaplus_examples_byzpaxos/VoteProofModel.tla",
       "tlaplus_examples_byzpaxos/VoteProof_VT3/Consensus.tla",
@@ -1291,24 +1505,28 @@
     ]
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_Safety.tla": {
+    "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a_proof_Safety/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_SafetyDefs.tla"
     ]
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_Thm_CountersConsistent.tla": {
+    "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a_proof_Thm_CountersConsistent/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_Thm_CountersConsistentDefs.tla"
     ]
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a_proof_TypeCorrect/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_ewd840/EWD840_proof_Safety.tla": {
+    "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/EWD840_proof_Safety/EWD840.tla",
       "tlaplus_examples_ewd840/EWD840_proof_Safety/SyncTerminationDetection.tla",
@@ -1316,6 +1534,7 @@
     ]
   },
   "tlaplus_examples_ewd840/EWD840_proof_TD_Spec.tla": {
+    "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/EWD840_proof_TD_Spec/EWD840.tla",
       "tlaplus_examples_ewd840/EWD840_proof_TD_Spec/SyncTerminationDetection.tla",
@@ -1323,42 +1542,49 @@
     ]
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_CorrectDetection.tla": {
+    "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_CorrectDetection/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_CorrectDetectionDefs.tla"
     ]
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Live.tla": {
+    "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Live/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_LiveDefs.tla"
     ]
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Quiescent.tla": {
+    "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Quiescent/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_QuiescentDefs.tla"
     ]
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Liveness.tla": {
+    "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Liveness/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_LivenessDefs.tla"
     ]
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Safety.tla": {
+    "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Safety/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_SafetyDefs.tla"
     ]
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Stability.tla": {
+    "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Stability/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_StabilityDefs.tla"
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitRefinement.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/EWD998PCal_proof_InitRefinement/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_InitRefinement/EWD998.tla",
@@ -1367,6 +1593,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/EWD998PCal_proof_TypeCorrect/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_TypeCorrect/EWD998.tla",
@@ -1375,6 +1602,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_Refinement.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/EWD998_proof_Refinement/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998_proof_Refinement/EWD998.tla",
@@ -1382,6 +1610,7 @@
     ]
   },
   "tlaplus_examples_ewd998/EWD998_proof_TerminationDetectionInv.tla": {
+    "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/EWD998_proof_TerminationDetectionInv/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/EWD998_proof_TerminationDetectionInv/EWD998.tla",
@@ -1389,18 +1618,21 @@
     ]
   },
   "tlaplus_examples_glowingRaccoon/clean_proof_Preservation.tla": {
+    "spec_id": "tlaplus_examples_glowingRaccoon/clean_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean_proof_Preservation/clean.tla",
       "tlaplus_examples_glowingRaccoon/clean_proof_PreservationDefs.tla"
     ]
   },
   "tlaplus_examples_glowingRaccoon/clean_proof_PrimerPositive.tla": {
+    "spec_id": "tlaplus_examples_glowingRaccoon/clean_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean_proof_PrimerPositive/clean.tla",
       "tlaplus_examples_glowingRaccoon/clean_proof_PrimerPositiveDefs.tla"
     ]
   },
   "tlaplus_examples_glowingRaccoon/stages_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_glowingRaccoon/stages_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/stages_proof_TypeCorrect/clean.tla",
       "tlaplus_examples_glowingRaccoon/stages_proof_TypeCorrect/stages.tla",
@@ -1408,18 +1640,21 @@
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedNetworkInv.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedNetworkInv/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedNetworkInvDefs.tla"
     ]
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_Safety.tla": {
+    "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_Safety/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_SafetyDefs.tla"
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/LockHS_P_Spec.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/LockHS.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/LockHSModel.tla",
       "tlaplus_examples_locks_auxiliary_vars/LockHS_P_Spec/Lock.tla",
@@ -1429,6 +1664,7 @@
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/LockHS_line31.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/LockHS.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/LockHS_line31/Lock.tla",
       "tlaplus_examples_locks_auxiliary_vars/LockHS_line31/Stuttering.tla",
@@ -1436,18 +1672,21 @@
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/Lock_MutualExclusion.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/LockModel.tla",
       "tlaplus_examples_locks_auxiliary_vars/Lock_MutualExclusionDefs.tla"
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/Peterson_IndInvariant.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/PetersonModel.tla",
       "tlaplus_examples_locks_auxiliary_vars/Peterson_IndInvariantDefs.tla"
     ]
   },
   "tlaplus_examples_locks_auxiliary_vars/Peterson_Refinement.tla": {
+    "spec_id": "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/PetersonModel.tla",
       "tlaplus_examples_locks_auxiliary_vars/Peterson_Refinement/Lock.tla",
@@ -1455,40 +1694,47 @@
     ]
   },
   "tlaplus_examples_spanning/spanning_proof_SntMsgInv.tla": {
+    "spec_id": "tlaplus_examples_spanning/spanning_proof.tla",
     "context": [
       "tlaplus_examples_spanning/spanning_proof_SntMsgInv/spanning.tla",
       "tlaplus_examples_spanning/spanning_proof_SntMsgInvDefs.tla"
     ]
   },
   "tlaplus_examples_sums_even/sums_even_T1.tla": {
+    "spec_id": "tlaplus_examples_sums_even/sums_even.tla",
     "context": [
       "tlaplus_examples_sums_even/sums_even_T1Defs.tla"
     ]
   },
   "tlaplus_examples_sums_even/sums_even_line10.tla": {
+    "spec_id": "tlaplus_examples_sums_even/sums_even.tla",
     "context": [
       "tlaplus_examples_sums_even/sums_even_line10Defs.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_InvInit.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp_proof_InvInit/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_InvInitDefs.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_SpecImpliesInv.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp_proof_SpecImpliesInv/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_SpecImpliesInvDefs.tla"
     ]
   },
   "tlaplus_examples_tcp/tcp_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp_proof_TypeCorrect/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_TypeCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_Init.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_Init/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_Init/TCommit.tla",
@@ -1496,12 +1742,14 @@
     ]
   },
   "tlaplus_examples_transaction_commit/TCommit_proof_TCorrect.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/TCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/TCommit_proof_TCorrect/TCommit.tla",
       "tlaplus_examples_transaction_commit/TCommit_proof_TCorrectDefs.tla"
     ]
   },
   "tlaplus_examples_transaction_commit/TwoPhase_proof_Consistency.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/TwoPhase_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/TwoPhase_proof_Consistency/TCommit.tla",
       "tlaplus_examples_transaction_commit/TwoPhase_proof_Consistency/TwoPhase.tla",
@@ -1509,6 +1757,7 @@
     ]
   },
   "tlaplus_examples_transaction_commit/TwoPhase_proof_TypeCorrect.tla": {
+    "spec_id": "tlaplus_examples_transaction_commit/TwoPhase_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/TwoPhase_proof_TypeCorrect/TCommit.tla",
       "tlaplus_examples_transaction_commit/TwoPhase_proof_TypeCorrect/TwoPhase.tla",
@@ -1516,6 +1765,7 @@
     ]
   },
   "two_thread_mutex/two_thread_mutex_Liveness.tla": {
+    "spec_id": "two_thread_mutex/two_thread_mutex.tla",
     "context": [
       "two_thread_mutex/two_thread_mutexModel.tla",
       "two_thread_mutex/two_thread_mutex_LivenessDefs.tla"

--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -9,6 +9,10 @@ i.e. one coherent protocol or example. A protocol whose proof is split across
 several TLA+ modules stays a single row. The example name links to its upstream
 location.
 
+This presentation grouping is intentionally different from the finer scoring
+identity: scores group tasks by their exact originating source `.tla` module.
+See the [scoring documentation](USAGE.md#tlaps-bench-score).
+
 `–` marks a mode with no task for that example: a source with no human proofs
 yields no proof-completion task, and an example whose only proven theorems are
 *unnamed* (so they cannot be referenced as scaffolding) is likewise

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -179,7 +179,7 @@ Benchmark files live in `benchmark/proof-completion/` and `benchmark/proof-from-
 
 ### Layered-task trust boundary
 
-For layered suites, `benchmark/<mode>/manifest.json` is the authority for task discovery and context. Each entry names one editable target and its complete local TLA+ dependency closure. The runner does not infer dependencies from neighboring filenames, so sibling tasks and unrelated definition modules never enter the workspace, prompt, input artifact, or verifier. An invalid manifest stops the run.
+For layered suites, `benchmark/<mode>/manifest.json` is the authority for task discovery, specification identity, and context. Each entry names the originating source module as `spec_id`, one editable target, and its complete local TLA+ dependency closure. The runner does not infer dependencies from neighboring filenames, so sibling tasks and unrelated definition modules never enter the workspace, prompt, input artifact, or verifier. An invalid manifest stops the run. See [`tlaps-bench score`](#tlaps-bench-score) for the grouping rule.
 
 Proof-completion targets contain one `AGENT PROOF` marker pair. Only its interior may change; imports, the target theorem statement, marker lines, and all surrounding text remain canonical. Module-level declarations are rejected inside the proof region, while proof-local steps such as `DEFINE` and `USE` remain valid. Model and scaffold modules are read-only context; their admitted scaffold lemmas are allowed as givens.
 
@@ -246,14 +246,29 @@ Exit codes: `0` = PASS, `1` = FAIL, `3` = ERROR.
 
 ### `tlaps-bench score`
 
-Compute pass rates from one or more result files.
+Compute scores from one or more result files.
 
 ```bash
 uv run tlaps-bench score results/proof-from-scratch/pi/20260626_220712/results.json
 uv run tlaps-bench score results/proof-completion/*/results.json
 ```
 
-Pass rate = passed tasks / scored tasks. `SKIP`, `INFRA_ERROR`, and `QUOTA_EXHAUSTED` results are excluded from scoring and reported separately; cheating verdicts count as failures.
+Each manifest entry maps its mode-relative task ID to the originating `.tla` path under `source/` (`spec_id`). Tasks from the same source module form one scoring group.
+
+The default primary score gives every represented source specification equal weight while preserving partial credit:
+
+```text
+spec_score = passed selected tasks / applicable selected tasks
+overall_score = mean(spec_score)
+```
+
+Reports show three scores:
+
+- **Specification-macro** (primary): the average above.
+- **Task-micro**: passed applicable tasks divided by all applicable tasks.
+- **All-leaves-complete**: specifications whose selected tasks all passed.
+
+`SKIP`, infrastructure-cut, and removed tasks are excluded and reported separately. Pass `--scoring equal` for the legacy task-micro-primary output.
 
 ### `tlaps-bench validate`
 
@@ -273,7 +288,7 @@ uv run tlaps-bench generate
 uv run tlaps-bench generate --mode proof-from-scratch
 ```
 
-Proof-completion generation emits the layered suite described in [Layered-task trust boundary](#layered-task-trust-boundary): one read-only `<base>Model.tla` per source, one read-only `<task>Scaffold.tla` per target, an editable `<task>.tla` holding the fixed theorem statement and the marked proof region, and a `manifest.json` naming every task's exact context. Use `--legacy` only for the old generators.
+Proof-completion generation emits the layered suite described in [Layered-task trust boundary](#layered-task-trust-boundary): one read-only `<base>Model.tla` per source, one read-only `<task>Scaffold.tla` per target, an editable `<task>.tla` holding the fixed theorem statement and the marked proof region, and a `manifest.json` naming every task's source specification and exact context. Use `--legacy` only for the old generators.
 
 ```bash
 uv run tlaps-bench generate --mode proof-completion
@@ -295,7 +310,7 @@ Each run writes results to a timestamped directory:
 ```
 results/<mode>/<backend>/<timestamp>/
 ├── results.json              # All verdicts, time, equivalent cost, and tokens
-├── summary.md                # Pass rate, total task time, and equivalent cost
+├── summary.md                # Scores, total task time, and equivalent cost
 └── <Module>/<Theorem>/
     ├── result.json           # Per-benchmark verdict and metadata
     ├── input/
@@ -355,7 +370,7 @@ uv run tlaps-bench run --backend codex --model gpt-5.5 --max-continuations 3
 
 Each benchmark still starts with the normal first attempt. If that attempt completes without PASS, the runner starts up to `N` more attempts in the same workspace. Each continuation sees the partial proof from the previous attempt. The chain stops once a continuation passes or the limit is reached.
 
-The first-attempt verdict stays in `check_verdict`. Continuation rounds are saved under `continuations` in `results.json`, and reports show them separately as `Pass rate with continuations (≤N)`.
+The first-attempt verdict stays in `check_verdict`. Continuation rounds are saved under `continuations` in `results.json`, and reports show them separately as `Task-micro pass rate with continuations (≤N)`.
 
 ---
 

--- a/src/common/task_contract.py
+++ b/src/common/task_contract.py
@@ -53,6 +53,7 @@ class TaskBoundary:
     """One editable task and the complete local context assigned to it."""
 
     task_key: str
+    spec_id: str
     task_path: Path
     context_paths: tuple[Path, ...]
 
@@ -187,6 +188,38 @@ def _relative_tla_path(value: str, *, label: str) -> PurePosixPath:
     return path
 
 
+def _manifest_specification_id(task_key: str, entry: Any) -> str:
+    if type(entry) is not dict or set(entry) != {"spec_id", "context"}:
+        raise ManifestError(f"manifest entry {task_key!r} must be an object containing exactly 'spec_id' and 'context'")
+    spec_id = entry["spec_id"]
+    if type(spec_id) is not str:
+        raise ManifestError(f"manifest entry {task_key!r} field 'spec_id' must be a string")
+    _relative_tla_path(spec_id, label=f"manifest entry {task_key!r} field 'spec_id'")
+    return spec_id
+
+
+def load_manifest_specification_ids(suite_root: Path, *, suite_name: str) -> Mapping[str, str]:
+    """Load only the stable task-to-specification identities needed to score.
+
+    This validates the versioned manifest keys and identity fields without
+    parsing every TLA+ file. Full task execution continues to use
+    :func:`load_task_manifest` and its stronger file/content validation.
+    """
+
+    root = _suite_root(Path(suite_root), suite_name=suite_name)
+    raw = _load_manifest_json(_resolve_manifest(root, suite_name=suite_name))
+    if type(raw) is not dict:
+        raise ManifestError(f"{suite_name} manifest root must be a JSON object")
+
+    specification_ids: dict[str, str] = {}
+    for task_key, entry in raw.items():
+        if type(task_key) is not str:
+            raise ManifestError(f"{suite_name} manifest task keys must be strings")
+        _relative_tla_path(task_key, label="manifest task key")
+        specification_ids[task_key] = _manifest_specification_id(task_key, entry)
+    return MappingProxyType(dict(sorted(specification_ids.items())))
+
+
 def _resolve_suite_file(root: Path, relative_path: PurePosixPath, *, label: str) -> Path:
     candidate = root.joinpath(*relative_path.parts)
     try:
@@ -294,7 +327,7 @@ def load_task_manifest(
     if type(raw) is not dict:
         raise ManifestError(f"{suite_name} manifest root must be a JSON object")
 
-    specifications: dict[str, tuple[Path, list[tuple[str, Path]]]] = {}
+    specifications: dict[str, tuple[str, Path, list[tuple[str, Path]]]] = {}
     task_paths: dict[Path, str] = {}
 
     for task_key, entry in raw.items():
@@ -308,8 +341,8 @@ def load_task_manifest(
             raise ManifestError(f"manifest tasks {previous_task!r} and {task_key!r} resolve to the same file")
         task_paths[task_path] = task_key
 
-        if type(entry) is not dict or set(entry) != {"context"}:
-            raise ManifestError(f"manifest entry {task_key!r} must be an object containing only 'context'")
+        spec_id = _manifest_specification_id(task_key, entry)
+
         context = entry["context"]
         if type(context) is not list:
             raise ManifestError(f"manifest entry {task_key!r} field 'context' must be a list")
@@ -340,12 +373,12 @@ def load_task_manifest(
             seen_context_paths.add(context_path)
             resolved_context.append((context_key, context_path))
 
-        specifications[task_key] = (task_path, resolved_context)
+        specifications[task_key] = (spec_id, task_path, resolved_context)
 
     boundaries: dict[str, TaskBoundary] = {}
     task_keys = set(specifications)
     for task_key in sorted(specifications):
-        task_path, context_entries = specifications[task_key]
+        spec_id, task_path, context_entries = specifications[task_key]
         context_paths: list[Path] = []
         for context_key, context_path in context_entries:
             if context_key == task_key or context_path == task_path:
@@ -360,6 +393,7 @@ def load_task_manifest(
         _validate_task_contract(task_key, modules, parse_task_regions=parse_task_regions)
         boundaries[task_key] = TaskBoundary(
             task_key=task_key,
+            spec_id=spec_id,
             task_path=task_path,
             context_paths=resolved_paths,
         )

--- a/src/dataset/proof_completion/generate.py
+++ b/src/dataset/proof_completion/generate.py
@@ -30,11 +30,11 @@ marked proof region is editable:
 
     \\* BEGIN AGENT PROOF / \\* END AGENT PROOF     the proof
 
-A suite-level `manifest.json` maps each task to the exact read-only modules
-assigned to it, so the evaluator never infers context by copying siblings. The
-marker strings and manifest schema come from `src/common/task_contract.py` —
-the same contract the evaluator parses — and every emitted task is re-read
-through it before the manifest is written.
+A suite-level `manifest.json` maps each task to its originating specification
+and the exact read-only modules assigned to it, so the evaluator never infers
+context by copying siblings. The marker strings and manifest schema come from
+`src/common/task_contract.py` — the same contract the evaluator parses — and
+every emitted task is re-read through it before the manifest is written.
 """
 
 import glob
@@ -52,6 +52,7 @@ from common.proof_completion_contract import (
     parse_proof_completion_region,
 )
 from common.task_contract import MANIFEST_FILENAME
+from dataset.specification_identity import source_spec_id
 
 COMMUNITY_MODULES = _tla_modules.COMMUNITY_MODULES
 RESOLVABLE_MODULES = _tla_modules.RESOLVABLE_MODULES
@@ -1490,6 +1491,7 @@ def emit_layered_source(
     manifest,
     audit_state,
     reference_task_keys=None,
+    source_root=None,
 ):
     """Emit the layered split + manifest entries for one source file.
 
@@ -1518,6 +1520,7 @@ def emit_layered_source(
     if not planned:
         return 0
     targets = [target for target, _module, _key in planned]
+    spec_id = source_spec_id(source_path, source_root or SOURCE_ROOT)
 
     os.makedirs(out_dir, exist_ok=True)
     written = audit_state.setdefault("written", {})
@@ -1577,7 +1580,10 @@ def emit_layered_source(
         if model_module:
             context.append(f"{subdir}/{model_module}.tla")
         context += write_task_dependencies(sm, dump, source_path, out_dir, subdir, task_module, audit_writer, written)
-        manifest[task_key] = {"context": sorted(set(context))}
+        manifest[task_key] = {
+            "spec_id": spec_id,
+            "context": sorted(set(context)),
+        }
         audit_state.setdefault("scaffold_owner", {}).setdefault(f"{subdir}/{scaffold_module}.tla", []).append(task_key)
 
         count += 1
@@ -1958,6 +1964,7 @@ def generate_layered(output_root=None, source_dir=None, filter_substring=None, f
                         manifest,
                         audit_state,
                         reference_task_keys,
+                        source_root=SOURCE_ROOT if files else source_dir,
                     )
                 except Exception as e:
                     audit_writer.write(f"[audit] {path}: ERROR {e!r}\n")

--- a/src/dataset/proof_from_scratch/generate.py
+++ b/src/dataset/proof_from_scratch/generate.py
@@ -88,8 +88,9 @@ Only `<task>.tla` is editable, and within it only the two marked regions:
 
 A suite-level `manifest.json` maps each task to the exact read-only modules
 assigned to it, so the evaluator never infers context by copying siblings and
-one task cannot inherit another task's target definitions. The marker strings
-and manifest schema are the contract in src/common/proof_from_scratch_contract.py;
+one task cannot inherit another task's target definitions. Each manifest entry
+also records the originating source specification. The marker strings and
+manifest schema are the contract in src/common/proof_from_scratch_contract.py;
 the two must stay byte-compatible.
 
 Only spec-goal targets extend the shared model; a pure lemma target keeps a
@@ -119,6 +120,7 @@ from dataset.proof_completion.generate import (  # noqa: E402
 )
 from dataset.sany_audit import gate as sany_gate  # noqa: E402
 from dataset.sany_audit import is_task_file  # noqa: E402
+from dataset.specification_identity import source_spec_id  # noqa: E402
 from dataset.triviality_audit import gate as triviality_gate  # noqa: E402
 
 KEYWORD_PATTERN = re.compile(r"^\s*(THEOREM|LEMMA|AXIOM|COROLLARY|PROPOSITION)\b")
@@ -1214,6 +1216,7 @@ def _emit_layered(
     manifest,
     audit_state,
     reference_task_keys,
+    source_root,
 ):
     """Emit the three-layer split + manifest entries for one source file.
 
@@ -1234,6 +1237,7 @@ def _emit_layered(
         return 0
 
     targets = [target for target, _module, _key in planned]
+    spec_id = source_spec_id(source_path, source_root)
     model_set, main_specs = compute_model_set(dump, targets)
 
     model_module = None
@@ -1307,7 +1311,10 @@ def _emit_layered(
                 )
 
         if manifest is not None:
-            manifest[task_key] = {"context": context}
+            manifest[task_key] = {
+                "spec_id": spec_id,
+                "context": context,
+            }
         if audit_state is not None:
             audit_state.setdefault("defs_owner", {}).setdefault(f"{subdir}/{defs_module}.tla", []).append(task_key)
 
@@ -1332,6 +1339,7 @@ def process_file(
     manifest=None,
     audit_state=None,
     reference_task_keys=None,
+    source_root=None,
 ):
     """Generate proof-from-scratch benchmarks for one source .tla file. Returns count emitted.
 
@@ -1486,6 +1494,7 @@ def process_file(
             manifest,
             audit_state,
             reference_task_keys,
+            source_root or SOURCE_ROOT,
         )
 
     # Shared-model mode: emit one proof-free `<module>.tla` model and have
@@ -1599,7 +1608,7 @@ def main():
         action="store_true",
         help="Split each task into <base>Model.tla + <task>Defs.tla + "
         "<task>.tla (editable, with helper/proof markers) and write "
-        "manifest.json mapping each task to its exact read-only context "
+        "manifest.json mapping each task to its source specification and exact read-only context "
         "(Issue #64 / PR #71 contract). For the repository source tree, "
         "the existing dataset/manifest supplies the vetted target selection. "
         "Implies the shared-model split.",
@@ -1620,6 +1629,7 @@ def main():
 
     # Scan unfiltered, then select: a filtered run needs every possible source to
     # tell a regenerated task's source from one it skipped.
+    source_root = SOURCE_ROOT
     if args.files:
         all_targets, repository_sources = positional_targets(args.files, SOURCE_ROOT)
         if args.layered and not repository_sources and any(subdir is not None for _, subdir in all_targets):
@@ -1630,6 +1640,7 @@ def main():
         ownership_targets = scan_source_targets(SOURCE_ROOT) if repository_sources else all_targets
     else:
         src_root = os.path.abspath(args.source_dir)
+        source_root = src_root
         repository_sources = os.path.realpath(src_root) == os.path.realpath(SOURCE_ROOT)
         all_targets = scan_source_targets(src_root)
         ownership_targets = all_targets
@@ -1673,6 +1684,7 @@ def main():
                     manifest=manifest,
                     audit_state=audit_state,
                     reference_task_keys=reference_task_keys,
+                    source_root=source_root,
                 )
             except Exception as e:
                 audit_writer.write(f"[audit] {path}: ERROR {e!r}\n")

--- a/src/dataset/specification_identity.py
+++ b/src/dataset/specification_identity.py
@@ -1,0 +1,21 @@
+"""Stable specification identities for generated benchmark tasks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def source_spec_id(source_path: str, source_root: str) -> str:
+    """Identify a specification by its source-root-relative TLA+ path.
+
+    Repository datasets use paths relative to ``source/``. A generator invoked
+    on an external file falls back to its basename because it has no stable
+    repository-relative path.
+    """
+
+    source = Path(source_path).resolve()
+    try:
+        relative = source.relative_to(Path(source_root).resolve())
+    except ValueError:
+        relative = Path(source.name)
+    return relative.as_posix()

--- a/src/evaluator/modes/base.py
+++ b/src/evaluator/modes/base.py
@@ -88,6 +88,15 @@ class Mode(ABC):  # noqa: B024 - ABC used as a non-instantiable base marker; sub
             files = [f for f in files if any(p in f for p in patterns)]
         return files
 
+    def specification_ids(self) -> dict[str, str] | None:
+        """Return task ID to specification ID mappings for strict suites.
+
+        Legacy proof-completion suites have no versioned manifest, so they keep
+        the historical task-micro score and return ``None``.
+        """
+
+        return None
+
     def get_dependencies(self, benchmark_path: str) -> list[str]:
         """Sibling .tla files the agent's workspace needs alongside the target.
 

--- a/src/evaluator/modes/proof_completion.py
+++ b/src/evaluator/modes/proof_completion.py
@@ -90,6 +90,11 @@ class ProofCompletion(Mode):
             )
         return [str(boundary.task_path) for boundary in boundaries]
 
+    def specification_ids(self) -> dict[str, str] | None:
+        if not self.uses_strict_contract:
+            return None
+        return {boundary.task_key: boundary.spec_id for boundary in self._boundaries or ()}
+
     def get_dependencies(self, benchmark_path: str) -> list[str]:
         if not self.uses_strict_contract:
             return super().get_dependencies(benchmark_path)

--- a/src/evaluator/modes/proof_from_scratch.py
+++ b/src/evaluator/modes/proof_from_scratch.py
@@ -53,6 +53,9 @@ class ProofFromScratch(Mode):
             )
         return [str(boundary.task_path) for boundary in boundaries]
 
+    def specification_ids(self) -> dict[str, str]:
+        return {boundary.task_key: boundary.spec_id for boundary in self._boundaries}
+
     def get_dependencies(self, benchmark_path: str) -> list[str]:
         """Return only the exact context declared for a manifest task."""
 

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -52,6 +52,7 @@ from evaluator.modes import get_mode, list_modes
 from evaluator.modes.base import Mode
 from evaluator.score import (
     SCORERS,
+    applicable_manifest_results,
     continuation_interrupted,
     continuation_rate_line,
     is_non_genuine,
@@ -59,6 +60,8 @@ from evaluator.score import (
     is_skipped,
     n_non_genuine,
     n_skipped,
+    scope_specification_ids,
+    specification_score_lines,
     weighted_score,
 )
 from evaluator.termination import TerminationContext, TerminationReason, classify, startup_error_snippet
@@ -1003,7 +1006,7 @@ def _format_equivalent_cost(value: object) -> str:
     return f"${parsed:.6g}"
 
 
-def update_summary(results, output_dir, total_benchmarks, backend_name, mode_name):
+def update_summary(results, output_dir, total_benchmarks, backend_name, mode_name, specification_ids=None):
     """Incrementally update summary.md + results.json with current results."""
     with _summary_lock:
         supports_cost_time = backend_name in _COST_TIME_BACKENDS
@@ -1024,20 +1027,26 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
         lines = []
         lines.append(f"# {backend_name} on {mode_name}\n")
         lines.append(f"**Date**: {time.strftime('%Y-%m-%d %H:%M:%S')}")
-        # Match `tlaps-bench score`: SKIP and non-genuine infra/quota-cut runs
-        # are excluded from the pass-rate numerator and denominator.
-        pass_pct, n_pass, scored = weighted_score(results, SCORERS["equal"])
-        n_skip = n_skipped(results)
-        non_genuine = n_non_genuine(results)
-        pass_line = f"**Pass rate**: {n_pass}/{scored} ({pass_pct:.1f}%)"
-        if n_skip:
-            pass_line += f" · {n_skip} skipped"
-        if non_genuine:
-            pass_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
         lines.append(f"**Progress**: {total}/{total_benchmarks}")
-        lines.append(pass_line)
+        if specification_ids is None:
+            # Guarded legacy proof-completion suites have no identity manifest.
+            pass_pct, n_pass, scored = weighted_score(results, SCORERS["equal"])
+            n_skip = n_skipped(results)
+            non_genuine = n_non_genuine(results)
+            pass_line = f"**Pass rate**: {n_pass}/{scored} ({pass_pct:.1f}%)"
+            if n_skip:
+                pass_line += f" · {n_skip} skipped"
+            if non_genuine:
+                pass_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
+            lines.append(pass_line)
+            continuation_results = results
+        else:
+            score_lines, specification_score = specification_score_lines(results, specification_ids)
+            lines.extend(score_lines)
+            n_pass = specification_score.tasks_passed
+            continuation_results = applicable_manifest_results(results, specification_ids)
         # Separate, clearly-labeled metric — the pass rate above stays pass@1.
-        cont_line = continuation_rate_line(results, SCORERS["equal"], n_pass)
+        cont_line = continuation_rate_line(continuation_results, SCORERS["equal"], n_pass)
         if cont_line:
             lines.append(cont_line)
         lines.append(
@@ -2250,8 +2259,13 @@ def main():
     mode = get_mode(args.mode, benchmark_root, checker_binary)
     try:
         benchmark_files = mode.get_benchmark_files(args.filter)
+        identity_loader = getattr(mode, "specification_ids", None)
+        task_specification_ids = identity_loader() if identity_loader is not None else None
     except TaskContractError as exc:
         parser.exit(2, f"{parser.prog}: error: {exc}\n")
+    specification_ids = (
+        scope_specification_ids(mode.name, task_specification_ids) if task_specification_ids is not None else None
+    )
     if not benchmark_files:
         if args.filter:
             parser.exit(
@@ -2475,7 +2489,7 @@ def main():
                 f"[{prior_done + i + 1}/{total_benchmarks}] {icon} {r['benchmark']} ({metrics})"
                 + (f" — {cont}" if cont else "")
             )
-            update_summary(results, output_dir, total_benchmarks, backend.name, mode.name)
+            update_summary(results, output_dir, total_benchmarks, backend.name, mode.name, specification_ids)
     else:
         with ProcessPoolExecutor(max_workers=args.jobs) as executor:
             futures = {executor.submit(run_single_benchmark, item): item for item in work_items}
@@ -2495,11 +2509,11 @@ def main():
                     f"[{prior_done + done_count}/{total_benchmarks}] {icon} {r['benchmark']} ({metrics})"
                     + (f" — {cont}" if cont else "")
                 )
-                update_summary(results, output_dir, total_benchmarks, backend.name, mode.name)
+                update_summary(results, output_dir, total_benchmarks, backend.name, mode.name, specification_ids)
 
     total_time = time.monotonic() - start_time
 
-    update_summary(results, output_dir, total_benchmarks, backend.name, mode.name)
+    update_summary(results, output_dir, total_benchmarks, backend.name, mode.name, specification_ids)
     report_path = os.path.join(output_dir, "summary.md")
 
     print(f"\n{'=' * 60}")

--- a/src/evaluator/score.py
+++ b/src/evaluator/score.py
@@ -33,15 +33,20 @@ infra/quota before resolving is interrupted, not failed: like a non-genuine
 first attempt it is excluded from the continuation rate and reported separately
 (see ``continuation_interrupted``).
 
-Pluggable scoring: a scorer assigns a non-negative weight to each task; the
-score of a group of tasks is
+The primary score gives every represented source specification equal weight.
+For each specification, it computes the fraction of applicable selected tasks
+that passed, then averages those fractions. This preserves partial credit while
+preventing specifications with many extracted tasks from dominating the score.
+The historical task-micro pass rate and the fraction of specifications whose
+selected tasks all passed remain visible as secondary diagnostics.
+
+The legacy pluggable task scorer assigns a non-negative weight to each task;
+the score of a group of tasks is
 
     100 * (sum of weights of passed tasks) / (sum of all weights)
 
-The default ``equal`` scorer gives every task weight 1, so the score is simply
-the percentage of tasks passed. To add a scheme (e.g. weight by proof
-obligations), register another weight function in ``SCORERS`` and select it with
-``--scoring``.
+The ``equal`` task scorer gives every task weight 1. It remains available via
+``--scoring equal`` for compatibility and as the task-micro diagnostic.
 """
 
 from __future__ import annotations
@@ -52,7 +57,11 @@ import math
 import os
 import sys
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from common.task_contract import load_manifest_specification_ids
 
 PASS_VERDICT = "PASS"
 SKIP_VERDICT = "SKIP"
@@ -67,6 +76,22 @@ COST_TIME_BACKENDS = {
     "litellm_oneshot",
     "pi",
 }
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPECIFICATION_EQUAL = "specification-equal"
+SpecificationKey = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class SpecificationScore:
+    """Primary and secondary scores over one selected result cohort."""
+
+    specification_macro_pct: float
+    task_micro_pct: float
+    tasks_passed: int
+    applicable_tasks: int
+    complete_specifications: int
+    represented_specifications: int
+    non_applicable_results: int
 
 
 def is_pass(result: dict) -> bool:
@@ -130,7 +155,7 @@ def continuation_rate_line(results: list[dict], weight: Callable[[dict], float],
     budget = continuation_budget(results)
     label = f" (≤{budget})" if budget else ""
     line = (
-        f"**Pass rate with continuations{label}**: {cn_pass}/{cn_total} ({cpct:.1f}%) — "
+        f"**Task-micro pass rate with continuations{label}**: {cn_pass}/{cn_total} ({cpct:.1f}%) — "
         f"{cn_pass - n_pass} recovered by continuation (pass@1 above is first-attempt only)"
     )
     n_cut = sum(1 for r in results if continuation_interrupted(r))
@@ -147,6 +172,140 @@ def n_skipped(results: list[dict]) -> int:
 def n_non_genuine(results: list[dict]) -> int:
     """How many results are excluded as non-genuine (need a re-run)."""
     return sum(1 for r in results if is_non_genuine(r))
+
+
+def scope_specification_ids(mode: str, task_specification_ids: Mapping[str, str]) -> dict[SpecificationKey, str]:
+    """Scope manifest task IDs by mode, since task paths can occur in both suites."""
+
+    return {(mode, task_id): spec_id for task_id, spec_id in task_specification_ids.items()}
+
+
+def _validate_specification_ids(specification_ids: Mapping[SpecificationKey, str]) -> None:
+    for key, spec_id in specification_ids.items():
+        if not isinstance(key, tuple) or len(key) != 2 or not all(isinstance(part, str) and part for part in key):
+            raise ValueError(f"invalid specification mapping key: {key!r}")
+        if not isinstance(spec_id, str) or not spec_id:
+            raise ValueError(f"missing specification identity for {key[0]}/{key[1]}")
+
+
+def _result_specification_key(result: dict) -> SpecificationKey | None:
+    mode = result.get("mode")
+    task_id = result.get("benchmark")
+    if not isinstance(mode, str) or not mode or not isinstance(task_id, str) or not task_id:
+        return None
+    return mode, task_id
+
+
+def specification_equal_score(
+    results: list[dict],
+    specification_ids: Mapping[SpecificationKey, str],
+    passed: Callable[[dict], bool] = is_pass,
+) -> SpecificationScore:
+    """Score selected, applicable tasks with equal total weight per specification.
+
+    A result is applicable when its ``(mode, benchmark)`` identity exists in the
+    active versioned manifest. Results for tasks removed from a later manifest
+    are excluded and counted as non-applicable. Active manifest entries without
+    a specification identity are invalid and fail before any score is returned.
+    SKIP and infra/quota-cut results are excluded by the existing score policy.
+    """
+
+    _validate_specification_ids(specification_ids)
+    by_specification: dict[SpecificationKey, list[dict]] = defaultdict(list)
+    non_applicable = 0
+
+    for result in results:
+        key = _result_specification_key(result)
+        if key is None or key not in specification_ids:
+            non_applicable += 1
+            continue
+        if is_skipped(result) or is_non_genuine(result):
+            continue
+        by_specification[(key[0], specification_ids[key])].append(result)
+
+    applicable = [result for grouped in by_specification.values() for result in grouped]
+    tasks_passed = sum(1 for result in applicable if passed(result))
+    applicable_tasks = len(applicable)
+    task_micro_pct = 100.0 * tasks_passed / applicable_tasks if applicable_tasks else 0.0
+
+    spec_fractions = [
+        sum(1 for result in grouped if passed(result)) / len(grouped) for grouped in by_specification.values()
+    ]
+    represented_specifications = len(spec_fractions)
+    specification_macro_pct = (
+        100.0 * sum(spec_fractions) / represented_specifications if represented_specifications else 0.0
+    )
+    complete_specifications = sum(
+        1 for grouped in by_specification.values() if all(passed(result) for result in grouped)
+    )
+    return SpecificationScore(
+        specification_macro_pct=specification_macro_pct,
+        task_micro_pct=task_micro_pct,
+        tasks_passed=tasks_passed,
+        applicable_tasks=applicable_tasks,
+        complete_specifications=complete_specifications,
+        represented_specifications=represented_specifications,
+        non_applicable_results=non_applicable,
+    )
+
+
+def applicable_manifest_results(
+    results: Iterable[dict], specification_ids: Mapping[SpecificationKey, str]
+) -> list[dict]:
+    """Return results whose task identity is present in the active manifests."""
+
+    return [result for result in results if _result_specification_key(result) in specification_ids]
+
+
+def specification_score_lines(
+    results: list[dict], specification_ids: Mapping[SpecificationKey, str]
+) -> tuple[list[str], SpecificationScore]:
+    """Format the shared primary/secondary score lines for reports."""
+
+    score = specification_equal_score(results, specification_ids)
+    task_line = f"**Task-micro pass rate**: {score.tasks_passed}/{score.applicable_tasks} ({score.task_micro_pct:.1f}%)"
+    mapped_results = applicable_manifest_results(results, specification_ids)
+    skipped = n_skipped(mapped_results)
+    non_genuine = n_non_genuine(mapped_results)
+    if skipped:
+        task_line += f" · {skipped} skipped"
+    if non_genuine:
+        task_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
+
+    specification_word = "specification" if score.represented_specifications == 1 else "specifications"
+    complete_pct = (
+        100.0 * score.complete_specifications / score.represented_specifications
+        if score.represented_specifications
+        else 0.0
+    )
+    lines = [
+        f"**Specification-macro pass rate**: {score.specification_macro_pct:.1f}% "
+        f"across {score.represented_specifications} {specification_word}",
+        task_line,
+        f"**All leaves complete**: {score.complete_specifications}/{score.represented_specifications} "
+        f"{specification_word} ({complete_pct:.1f}%)",
+    ]
+    if score.non_applicable_results:
+        lines.append(
+            f"**Non-applicable results**: {score.non_applicable_results} not present in the active manifest (excluded)"
+        )
+    return lines, score
+
+
+def load_current_specification_ids(
+    modes: Iterable[str], benchmark_root: Path | None = None
+) -> dict[SpecificationKey, str]:
+    """Load stable identities from the current versioned manifests."""
+
+    root = benchmark_root or REPO_ROOT / "benchmark"
+    supported_modes = {"proof-completion", "proof-from-scratch"}
+    specification_ids: dict[SpecificationKey, str] = {}
+    for mode in sorted(set(modes)):
+        if mode not in supported_modes:
+            raise ValueError(f"cannot load specification identities for unknown mode {mode!r}")
+        task_specification_ids = load_manifest_specification_ids(root / mode, suite_name=mode)
+        specification_ids.update(scope_specification_ids(mode, task_specification_ids))
+    return specification_ids
 
 
 # A scorer maps one task result to a non-negative weight; the group score is the
@@ -264,28 +423,40 @@ def _format_cost(cost_usd: float | None) -> str:
     return f"${cost_usd:.6g}"
 
 
-def scorecard_md(run: dict, weight: Callable[[dict], float], scoring_name: str) -> str:
-    """Markdown scorecard for a single run: overall pass rate + per-module table."""
+def scorecard_md(
+    run: dict,
+    weight: Callable[[dict], float],
+    scoring_name: str,
+    specification_ids: Mapping[SpecificationKey, str] | None = None,
+) -> str:
+    """Markdown scorecard for a single run: overall score + per-module table."""
     results = run["results"]
-    pct, n_pass, n_total = weighted_score(results, weight)
-    skipped = n_skipped(results)
-    non_genuine = n_non_genuine(results)
+    scoring_results = results if specification_ids is None else applicable_manifest_results(results, specification_ids)
+    pct, n_pass, n_total = weighted_score(scoring_results, weight)
     in_tok, out_tok, secs, equivalent_cost_usd = _totals(results)
     has_equivalent_cost = _has_equivalent_cost(results)
 
-    pass_line = f"**Pass rate**: {n_pass}/{n_total} ({pct:.1f}%)"
-    if skipped:
-        pass_line += f" · {skipped} skipped"
-    if non_genuine:
-        pass_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
     lines = [
         f"# Scorecard — {run['backend']} / {run['mode']}",
         "",
         f"**Source**: {run['path']}",
-        pass_line,
     ]
+    if specification_ids is None:
+        skipped = n_skipped(results)
+        non_genuine = n_non_genuine(results)
+        pass_line = f"**Pass rate**: {n_pass}/{n_total} ({pct:.1f}%)"
+        if skipped:
+            pass_line += f" · {skipped} skipped"
+        if non_genuine:
+            pass_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
+        lines.append(pass_line)
+    else:
+        score_lines, specification_score = specification_score_lines(results, specification_ids)
+        lines.extend(score_lines)
+        n_pass = specification_score.tasks_passed
+
     # Separate, clearly-labeled metric — the pass rate above stays pass@1.
-    cont_line = continuation_rate_line(results, weight, n_pass)
+    cont_line = continuation_rate_line(scoring_results, weight, n_pass)
     if cont_line:
         lines.append(cont_line)
     if has_equivalent_cost:
@@ -294,20 +465,23 @@ def scorecard_md(run: dict, weight: Callable[[dict], float], scoring_name: str) 
         lines.append(f"**Equivalent cost**: {_format_cost(equivalent_cost_usd)}")
     else:
         lines.append(f"**Cost**: {in_tok:,} in / {out_tok:,} out tokens · {secs:,.0f}s total")
-    if scoring_name != "equal":
+    if scoring_name not in {"equal", SPECIFICATION_EQUAL}:
         lines.append(f"**Scoring**: {scoring_name} (weighted)")
+
+    by_module: dict[str, list[dict]] = defaultdict(list)
+    for r in scoring_results:
+        if is_skipped(r) or is_non_genuine(r):
+            continue  # fully-excluded modules drop out of the table entirely
+        by_module[r.get("module") or "?"].append(r)
+
+    module_heading = "## By module (task micro)" if specification_ids is not None else "## By module"
     lines += [
         "",
-        "## By module",
+        module_heading,
         "",
         "| Module | Passed | Total | Pass % |",
         "|--------|-------:|------:|-------:|",
     ]
-    by_module: dict[str, list[dict]] = defaultdict(list)
-    for r in results:
-        if is_skipped(r) or is_non_genuine(r):
-            continue  # fully-excluded modules drop out of the table entirely
-        by_module[r.get("module") or "?"].append(r)
     for module in sorted(by_module):
         mpct, mp, mt = weighted_score(by_module[module], weight)
         lines.append(f"| {module} | {mp} | {mt} | {mpct:.1f}% |")
@@ -321,52 +495,82 @@ def scorecard_md(run: dict, weight: Callable[[dict], float], scoring_name: str) 
     return "\n".join(lines)
 
 
-def comparison_md(runs: list[dict], weight: Callable[[dict], float], scoring_name: str) -> str:
+def comparison_md(
+    runs: list[dict],
+    weight: Callable[[dict], float],
+    scoring_name: str,
+    specification_ids: Mapping[SpecificationKey, str] | None = None,
+) -> str:
     """Markdown comparison table across several runs (one row per run)."""
     lines = [f"# Comparison — {len(runs)} runs", ""]
-    if scoring_name != "equal":
+    if scoring_name not in {"equal", SPECIFICATION_EQUAL}:
         lines += [f"**Scoring**: {scoring_name} (weighted)", ""]
     show_equivalent_cost = any(_has_equivalent_cost(run["results"]) for run in runs)
+    score_columns = (
+        "Specification macro | Task micro | All leaves complete"
+        if specification_ids is not None
+        else "Pass % | Passed/Total"
+    )
+    score_alignment = (
+        "--------------------:|-----------:|--------------------:"
+        if specification_ids is not None
+        else "-------:|-------------:"
+    )
     if show_equivalent_cost:
         lines += [
-            "| Run | Backend | Mode | Pass % | Passed/Total | Tokens (in/out) | Time | Equivalent cost |",
-            "|-----|---------|------|-------:|-------------:|-----------------|-----:|----------------:|",
+            f"| Run | Backend | Mode | {score_columns} | Tokens (in/out) | Time | Equivalent cost |",
+            f"|-----|---------|------|{score_alignment}|-----------------|-----:|----------------:|",
         ]
     else:
         lines += [
-            "| Run | Backend | Mode | Pass % | Passed/Total | Tokens (in/out) | Time |",
-            "|-----|---------|------|-------:|-------------:|-----------------|-----:|",
+            f"| Run | Backend | Mode | {score_columns} | Tokens (in/out) | Time |",
+            f"|-----|---------|------|{score_alignment}|-----------------|-----:|",
         ]
     for run in runs:
-        pct, n_pass, n_total = weighted_score(run["results"], weight)
+        results = run["results"]
+        scoring_results = (
+            results if specification_ids is None else applicable_manifest_results(results, specification_ids)
+        )
+        pct, n_pass, n_total = weighted_score(scoring_results, weight)
+        if specification_ids is not None:
+            specification_score = specification_equal_score(results, specification_ids)
         in_tok, out_tok, secs, equivalent_cost_usd = _totals(run["results"])
         run_has_equivalent_cost = _has_equivalent_cost(run["results"])
         if show_equivalent_cost and not run_has_equivalent_cost and run["backend"] in COST_TIME_BACKENDS:
             formal = [result for result in run["results"] if not is_skipped(result) and not is_non_genuine(result)]
             secs = _sum_metric(formal, "time_secs")
-        passed_total = f"{n_pass}/{n_total}"
-        skipped = n_skipped(run["results"])
+        score_notes = ""
+        skipped = n_skipped(scoring_results)
         if skipped:
-            passed_total += f" (+{skipped} skipped)"
-        non_genuine = n_non_genuine(run["results"])
+            score_notes += f" (+{skipped} skipped)"
+        non_genuine = n_non_genuine(scoring_results)
         if non_genuine:
-            passed_total += f" (+{non_genuine} infra-cut)"
-        if any(r.get("continuations") for r in run["results"]):
-            _, cn_pass, _ = weighted_score(run["results"], weight, passed=is_pass_with_continuations)
+            score_notes += f" (+{non_genuine} infra-cut)"
+        if any(r.get("continuations") for r in scoring_results):
+            _, cn_pass, _ = weighted_score(scoring_results, weight, passed=is_pass_with_continuations)
             # Name the budget: +1 recovery out of ≤1 round and out of ≤10 are
             # different results, and rows in this table exist to be compared.
-            budget = continuation_budget(run["results"])
+            budget = continuation_budget(scoring_results)
             if budget:
-                passed_total += f" (+{cn_pass - n_pass} via ≤{budget} continuations)"
+                score_notes += f" (+{cn_pass - n_pass} via ≤{budget} continuations)"
             else:
-                passed_total += f" (+{cn_pass - n_pass} via continuation)"
-            n_cut = sum(1 for r in run["results"] if continuation_interrupted(r))
+                score_notes += f" (+{cn_pass - n_pass} via continuation)"
+            n_cut = sum(1 for r in scoring_results if continuation_interrupted(r))
             if n_cut:
-                passed_total += f" (+{n_cut} chain(s) cut)"
-        row = (
-            f"| {run['id']} | {run['backend']} | {run['mode']} | {pct:.1f}% | "
-            f"{passed_total} | {in_tok:,}/{out_tok:,} | "
-        )
+                score_notes += f" (+{n_cut} chain(s) cut)"
+        passed_total = f"{n_pass}/{n_total}{score_notes}"
+        if specification_ids is None:
+            score_cells = f"{pct:.1f}% | {passed_total}"
+        else:
+            if specification_score.non_applicable_results:
+                score_notes += f" (+{specification_score.non_applicable_results} non-applicable)"
+            score_cells = (
+                f"{specification_score.specification_macro_pct:.1f}% | "
+                f"{n_pass}/{n_total} ({specification_score.task_micro_pct:.1f}%){score_notes} | "
+                f"{specification_score.complete_specifications}/"
+                f"{specification_score.represented_specifications}"
+            )
+        row = f"| {run['id']} | {run['backend']} | {run['mode']} | {score_cells} | {in_tok:,}/{out_tok:,} | "
         if show_equivalent_cost:
             time_text = (
                 _format_time(secs)
@@ -391,18 +595,18 @@ def comparison_md(runs: list[dict], weight: Callable[[dict], float], scoring_nam
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="tlaps-bench score",
-        description="Score benchmark results (pass rate, per-module breakdown) from results.json.",
+        description="Score benchmark results (specification macro plus diagnostics) from results.json.",
     )
     parser.add_argument("paths", nargs="+", help="One or more results.json files or run directories")
     parser.add_argument(
         "--scoring",
-        default="equal",
-        choices=sorted(SCORERS),
-        help="Scoring scheme (default: equal — every task weight 1, score = %% passed)",
+        default=SPECIFICATION_EQUAL,
+        choices=[SPECIFICATION_EQUAL, *sorted(SCORERS)],
+        help="Scoring scheme (default: specification-equal; 'equal' retains legacy task-micro scoring)",
     )
     args = parser.parse_args()
 
-    weight = SCORERS[args.scoring]
+    weight = SCORERS["equal"] if args.scoring == SPECIFICATION_EQUAL else SCORERS[args.scoring]
     runs = []
     for p in args.paths:
         try:
@@ -411,10 +615,19 @@ def main() -> int:
             sys.stderr.write(f"tlaps-bench score: {e}\n")
             return 1
 
+    specification_ids = None
+    if args.scoring == SPECIFICATION_EQUAL:
+        modes = {result.get("mode") for run in runs for result in run["results"]}
+        try:
+            specification_ids = load_current_specification_ids(mode for mode in modes if isinstance(mode, str))
+        except (ValueError, OSError) as e:
+            sys.stderr.write(f"tlaps-bench score: {e}\n")
+            return 1
+
     if len(runs) == 1:
-        print(scorecard_md(runs[0], weight, args.scoring))
+        print(scorecard_md(runs[0], weight, args.scoring, specification_ids))
     else:
-        print(comparison_md(runs, weight, args.scoring))
+        print(comparison_md(runs, weight, args.scoring, specification_ids))
     return 0
 
 

--- a/tests/common/test_proof_completion_contract.py
+++ b/tests/common/test_proof_completion_contract.py
@@ -61,8 +61,9 @@ def test_loads_sorted_tasks_and_preserves_exact_context_order(tmp_path):
     _write_manifest(
         suite,
         {
-            "Zed/Zed_Target.tla": {"context": []},
+            "Zed/Zed_Target.tla": {"spec_id": "Fixture.tla", "context": []},
             "Alpha/Alpha_Target.tla": {
+                "spec_id": "Fixture.tla",
                 "context": ["Context/Scaffold.tla", "Context/Model.tla"],
             },
         },
@@ -72,14 +73,24 @@ def test_loads_sorted_tasks_and_preserves_exact_context_order(tmp_path):
 
     assert list(boundaries) == ["Alpha/Alpha_Target.tla", "Zed/Zed_Target.tla"]
     assert boundaries["Alpha/Alpha_Target.tla"].task_path == task_a
+    assert boundaries["Alpha/Alpha_Target.tla"].spec_id == "Fixture.tla"
     assert boundaries["Alpha/Alpha_Target.tla"].context_paths == (scaffold, model)
     assert boundaries["Zed/Zed_Target.tla"].task_path == task_z
+
+
+def test_manifest_requires_a_specification_identity(tmp_path):
+    suite = tmp_path / "proof-completion"
+    _write_task(suite, "Task.tla")
+    _write_manifest(suite, {"Task.tla": {"context": []}})
+
+    with pytest.raises(ManifestError, match="exactly 'spec_id' and 'context'"):
+        load_proof_completion_manifest(suite)
 
 
 def test_task_requires_exact_proof_markers(tmp_path):
     suite = tmp_path / "proof-completion"
     _write_module(suite, "Task.tla", body="THEOREM Target == TRUE\nPROOF OBVIOUS\n")
-    _write_manifest(suite, {"Task.tla": {"context": []}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": []}})
 
     with pytest.raises(ManifestError, match="Task.tla.*invalid editable regions"):
         load_proof_completion_manifest(suite)
@@ -92,7 +103,7 @@ def test_task_cannot_expose_a_helper_region(tmp_path):
         "Task.tla",
         body=f"{BEGIN_AGENT_HELPERS}\nHelper == TRUE\n{END_AGENT_HELPERS}\n",
     )
-    _write_manifest(suite, {"Task.tla": {"context": []}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": []}})
 
     with pytest.raises(ManifestError, match="must not contain an AGENT HELPERS region"):
         load_proof_completion_manifest(suite)
@@ -103,7 +114,7 @@ def test_manifest_context_must_cover_transitive_references(tmp_path):
     _write_task(suite, "Task.tla", body="EXTENDS Model\n")
     _write_module(suite, "Model.tla", body="EXTENDS Missing\n")
     _write_module(suite, "Missing.tla")
-    _write_manifest(suite, {"Task.tla": {"context": ["Model.tla"]}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": ["Model.tla"]}})
 
     with pytest.raises(ManifestError, match="incomplete context.*Missing"):
         load_proof_completion_manifest(suite)

--- a/tests/common/test_proof_from_scratch_contract.py
+++ b/tests/common/test_proof_from_scratch_contract.py
@@ -74,8 +74,9 @@ def test_loads_sorted_immutable_boundaries_and_preserves_context_order(tmp_path)
     _write_manifest(
         suite,
         {
-            "Zed/Zed_Target.tla": {"context": []},
+            "Zed/Zed_Target.tla": {"spec_id": "Fixture.tla", "context": []},
             "Alpha/Alpha_Target.tla": {
+                "spec_id": "Fixture.tla",
                 "context": ["Shared/ZContext.tla", "Shared/AContext.tla"],
             },
         },
@@ -85,6 +86,7 @@ def test_loads_sorted_immutable_boundaries_and_preserves_context_order(tmp_path)
 
     assert list(boundaries) == ["Alpha/Alpha_Target.tla", "Zed/Zed_Target.tla"]
     assert boundaries["Alpha/Alpha_Target.tla"].task_path == target_a
+    assert boundaries["Alpha/Alpha_Target.tla"].spec_id == "Fixture.tla"
     assert boundaries["Alpha/Alpha_Target.tla"].context_paths == (context_z, context_a)
     assert boundaries["Zed/Zed_Target.tla"].task_path == target_z
     with pytest.raises(TypeError):
@@ -114,11 +116,14 @@ def test_malformed_json_is_rejected(tmp_path):
     ("manifest", "message"),
     [
         ([], "root must be a JSON object"),
-        ({"Task.tla": []}, "object containing only 'context'"),
-        ({"Task.tla": {}}, "object containing only 'context'"),
-        ({"Task.tla": {"context": [], "extra": True}}, "object containing only 'context'"),
-        ({"Task.tla": {"context": {}}}, "field 'context' must be a list"),
-        ({"Task.tla": {"context": [7]}}, "context item 0 must be a string"),
+        ({"Task.tla": []}, "exactly 'spec_id' and 'context'"),
+        ({"Task.tla": {}}, "exactly 'spec_id' and 'context'"),
+        ({"Task.tla": {"spec_id": "Fixture.tla", "context": [], "extra": True}}, "exactly 'spec_id' and 'context'"),
+        ({"Task.tla": {"context": []}}, "exactly 'spec_id' and 'context'"),
+        ({"Task.tla": {"spec_id": 7, "context": []}}, "field 'spec_id' must be a string"),
+        ({"Task.tla": {"spec_id": "../Fixture.tla", "context": []}}, "field 'spec_id'.*canonical"),
+        ({"Task.tla": {"spec_id": "Fixture.tla", "context": {}}}, "field 'context' must be a list"),
+        ({"Task.tla": {"spec_id": "Fixture.tla", "context": [7]}}, "context item 0 must be a string"),
     ],
 )
 def test_invalid_manifest_schema_is_rejected(tmp_path, manifest, message):
@@ -134,7 +139,7 @@ def test_duplicate_json_keys_are_rejected(tmp_path):
     suite = tmp_path / "proof-from-scratch"
     suite.mkdir()
     (suite / "manifest.json").write_text(
-        '{"Task.tla":{"context":[]},"Task.tla":{"context":[]}}',
+        '{"Task.tla":{"spec_id": "Fixture.tla", "context":[]},"Task.tla":{"spec_id": "Fixture.tla", "context":[]}}',
         encoding="utf-8",
     )
 
@@ -157,7 +162,7 @@ def test_duplicate_json_keys_are_rejected(tmp_path):
 )
 def test_noncanonical_or_unsafe_paths_are_rejected(tmp_path, task_key):
     suite = tmp_path / "proof-from-scratch"
-    _write_manifest(suite, {task_key: {"context": []}})
+    _write_manifest(suite, {task_key: {"spec_id": "Fixture.tla", "context": []}})
 
     with pytest.raises(ManifestError):
         load_proof_from_scratch_manifest(suite)
@@ -165,7 +170,7 @@ def test_noncanonical_or_unsafe_paths_are_rejected(tmp_path, task_key):
 
 def test_missing_manifest_file_entry_is_rejected(tmp_path):
     suite = tmp_path / "proof-from-scratch"
-    _write_manifest(suite, {"Missing.tla": {"context": []}})
+    _write_manifest(suite, {"Missing.tla": {"spec_id": "Fixture.tla", "context": []}})
 
     with pytest.raises(ManifestError, match="does not exist"):
         load_proof_from_scratch_manifest(suite)
@@ -176,7 +181,7 @@ def test_task_symlink_cannot_escape_suite_root(tmp_path):
     suite.mkdir()
     outside = _write_module(tmp_path, "Escape.tla")
     (suite / "Escape.tla").symlink_to(outside)
-    _write_manifest(suite, {"Escape.tla": {"context": []}})
+    _write_manifest(suite, {"Escape.tla": {"spec_id": "Fixture.tla", "context": []}})
 
     with pytest.raises(ManifestError, match="escapes the suite root through a symlink"):
         load_proof_from_scratch_manifest(suite)
@@ -197,7 +202,7 @@ def test_duplicate_context_path_is_rejected(tmp_path):
     suite = tmp_path / "proof-from-scratch"
     _write_module(suite, "Task.tla")
     _write_module(suite, "Model.tla")
-    _write_manifest(suite, {"Task.tla": {"context": ["Model.tla", "Model.tla"]}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": ["Model.tla", "Model.tla"]}})
 
     with pytest.raises(ManifestError, match="repeats context path 'Model.tla'"):
         load_proof_from_scratch_manifest(suite)
@@ -210,7 +215,7 @@ def test_context_aliases_to_same_file_are_rejected(tmp_path):
     alias = suite / "two/Model.tla"
     alias.parent.mkdir()
     alias.symlink_to(original)
-    _write_manifest(suite, {"Task.tla": {"context": ["one/Model.tla", "two/Model.tla"]}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": ["one/Model.tla", "two/Model.tla"]}})
 
     with pytest.raises(ManifestError, match="multiple context paths resolving"):
         load_proof_from_scratch_manifest(suite)
@@ -219,7 +224,7 @@ def test_context_aliases_to_same_file_are_rejected(tmp_path):
 def test_target_cannot_appear_in_its_own_context(tmp_path):
     suite = tmp_path / "proof-from-scratch"
     _write_module(suite, "Task.tla")
-    _write_manifest(suite, {"Task.tla": {"context": ["Task.tla"]}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": ["Task.tla"]}})
 
     with pytest.raises(ManifestError, match="includes itself in its context"):
         load_proof_from_scratch_manifest(suite)
@@ -232,8 +237,8 @@ def test_context_cannot_include_another_manifest_task(tmp_path):
     _write_manifest(
         suite,
         {
-            "First.tla": {"context": ["Second.tla"]},
-            "Second.tla": {"context": []},
+            "First.tla": {"spec_id": "Fixture.tla", "context": ["Second.tla"]},
+            "Second.tla": {"spec_id": "Fixture.tla", "context": []},
         },
     )
 
@@ -246,7 +251,7 @@ def test_duplicate_module_basenames_are_rejected_per_task(tmp_path):
     _write_module(suite, "Task.tla")
     _write_module(suite, "one/Model.tla")
     _write_module(suite, "two/Model.tla")
-    _write_manifest(suite, {"Task.tla": {"context": ["one/Model.tla", "two/Model.tla"]}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": ["one/Model.tla", "two/Model.tla"]}})
 
     with pytest.raises(ManifestError, match="duplicate module basename 'Model.tla'"):
         load_proof_from_scratch_manifest(suite)
@@ -255,7 +260,7 @@ def test_duplicate_module_basenames_are_rejected_per_task(tmp_path):
 def test_filename_must_match_declared_module_name(tmp_path):
     suite = tmp_path / "proof-from-scratch"
     _write_module(suite, "Task.tla", declared_name="Different")
-    _write_manifest(suite, {"Task.tla": {"context": []}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": []}})
 
     with pytest.raises(ManifestError, match="filename/module mismatch"):
         load_proof_from_scratch_manifest(suite)
@@ -268,7 +273,7 @@ def test_in_suite_symlink_cannot_hide_filename_module_mismatch(tmp_path):
     alias = suite / "alias/Alias.tla"
     alias.parent.mkdir()
     alias.symlink_to(real_module)
-    _write_manifest(suite, {"Task.tla": {"context": ["alias/Alias.tla"]}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": ["alias/Alias.tla"]}})
 
     with pytest.raises(ManifestError, match="filename/module mismatch.*Alias"):
         load_proof_from_scratch_manifest(suite)
@@ -278,7 +283,7 @@ def test_every_file_must_have_a_module_header(tmp_path):
     suite = tmp_path / "proof-from-scratch"
     suite.mkdir()
     (suite / "Task.tla").write_text("THEOREM Target == TRUE\n", encoding="utf-8")
-    _write_manifest(suite, {"Task.tla": {"context": []}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": []}})
 
     with pytest.raises(ManifestError, match="has no module header"):
         load_proof_from_scratch_manifest(suite)
@@ -287,7 +292,7 @@ def test_every_file_must_have_a_module_header(tmp_path):
 def test_task_must_have_valid_editable_regions(tmp_path):
     suite = tmp_path / "proof-from-scratch"
     _write_module(suite, "Task.tla", body="THEOREM Target == TRUE\nPROOF OBVIOUS\n")
-    _write_manifest(suite, {"Task.tla": {"context": []}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": []}})
 
     with pytest.raises(ManifestError, match="Task.tla.*invalid editable regions"):
         load_proof_from_scratch_manifest(suite)
@@ -305,7 +310,7 @@ def test_manifest_context_must_cover_transitive_module_references(tmp_path, refe
     _write_task(suite, "Task.tla", body="EXTENDS Model\n")
     _write_module(suite, "Model.tla", body=reference)
     _write_module(suite, "Missing.tla")
-    _write_manifest(suite, {"Task.tla": {"context": ["Model.tla"]}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": ["Model.tla"]}})
 
     with pytest.raises(ManifestError, match="incomplete context.*Missing"):
         load_proof_from_scratch_manifest(suite)
@@ -319,7 +324,7 @@ def test_manifest_closure_allows_trusted_libraries_and_ignores_non_code_referenc
         "Model.tla",
         body=('Description == "INSTANCE StringOnly"\n\\* EXTENDS LineCommentOnly\n(* INSTANCE BlockCommentOnly *)\n'),
     )
-    _write_manifest(suite, {"Task.tla": {"context": ["Model.tla"]}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": ["Model.tla"]}})
 
     boundaries = load_proof_from_scratch_manifest(suite)
 

--- a/tests/dataset/test_layered_generator.py
+++ b/tests/dataset/test_layered_generator.py
@@ -113,7 +113,7 @@ def _write_task(root, subdir, name, body="THEOREM TRUE", defs_body="Inv == TRUE"
     d.mkdir(parents=True, exist_ok=True)
     (d / f"{name}.tla").write_text(build_task_module(name, f"{name}Defs", body))
     (d / f"{name}Defs.tla").write_text(f"---- MODULE {name}Defs ----\n{defs_body}\n====\n")
-    return f"{subdir}/{name}.tla", {"context": [f"{subdir}/{name}Defs.tla"]}
+    return f"{subdir}/{name}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{name}Defs.tla"]}
 
 
 def test_dataset_selection_bootstraps_from_flat_task_tree(tmp_path):
@@ -128,7 +128,7 @@ def test_dataset_selection_bootstraps_from_flat_task_tree(tmp_path):
 def test_layered_manifest_becomes_the_dataset_selection(tmp_path):
     _write_task(tmp_path, "Legacy", "Legacy_Thm")
     manifest_key = "Current/Current_Thm.tla"
-    (tmp_path / "manifest.json").write_text(json.dumps({manifest_key: {"context": []}}))
+    (tmp_path / "manifest.json").write_text(json.dumps({manifest_key: {"spec_id": "Fixture.tla", "context": []}}))
 
     assert load_dataset_task_keys(str(tmp_path)) == {manifest_key}
 
@@ -235,6 +235,39 @@ def test_positional_repository_run_keeps_overlapping_sibling_source_task(tmp_pat
     generate.main()
 
     assert set(json.loads((output / "manifest.json").read_text())) == set(existing)
+
+
+def test_custom_source_dir_is_used_for_specification_identity(tmp_path, monkeypatch):
+    source_root = tmp_path / "custom-source"
+    source = source_root / "Group" / "Spec.tla"
+    source.parent.mkdir(parents=True)
+    source.write_text("---- MODULE Spec ----\n====\n")
+    output = tmp_path / "benchmark"
+    observed_roots = []
+
+    def fake_process_file(_path, _audit_writer, _output_root, **kwargs):
+        observed_roots.append(kwargs["source_root"])
+        return 0
+
+    monkeypatch.setattr(generate, "process_file", fake_process_file)
+    monkeypatch.setattr(generate, "_finalize_layered", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate.py",
+            "--layered",
+            "--skip-gates",
+            "--source-dir",
+            str(source_root),
+            "--output-dir",
+            str(output),
+        ],
+    )
+
+    generate.main()
+
+    assert observed_roots == [str(source_root)]
 
 
 def test_unnamed_target_preserves_an_existing_line_based_key():
@@ -682,7 +715,7 @@ def _triviality_env(tmp_path, monkeypatch, verdicts):
         return verdicts[len(calls) - 1]
 
     monkeypatch.setattr(triviality_audit, "check_task", fake_check_task)
-    return {"Group/Group_Thm.tla": {"context": []}}, calls
+    return {"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": []}}, calls
 
 
 def test_a_timed_out_task_is_rechecked_alone_on_the_graders_budget(tmp_path, monkeypatch):

--- a/tests/dataset/test_proof_completion_layered.py
+++ b/tests/dataset/test_proof_completion_layered.py
@@ -98,6 +98,31 @@ def _target():
     return _dump()["theorems"][1]
 
 
+def test_custom_source_dir_is_used_for_specification_identity(tmp_path, monkeypatch):
+    import dataset.proof_completion.generate as generate
+
+    source_root = tmp_path / "custom-source"
+    source = source_root / "Group" / "Spec.tla"
+    source.parent.mkdir(parents=True)
+    source.write_text("---- MODULE Spec ----\n====\n")
+    observed_roots = []
+
+    def fake_emit(_sm, _path, _subdir, _out_dir, _audit, _manifest, _state, _reference, *, source_root):
+        observed_roots.append(source_root)
+        return 0
+
+    monkeypatch.setattr(generate, "emit_layered_source", fake_emit)
+    monkeypatch.setattr(generate, "_finalize_layered", lambda *_args, **_kwargs: 0)
+
+    generate.generate_layered(
+        output_root=str(tmp_path / "benchmark"),
+        source_dir=str(source_root),
+        run_gates=False,
+    )
+
+    assert observed_roots == [str(source_root)]
+
+
 # --- the editable task file ------------------------------------------------
 
 
@@ -466,7 +491,9 @@ def test_dataset_selection_bootstraps_from_the_flat_task_tree(tmp_path):
 
 
 def test_dataset_selection_prefers_an_existing_manifest(tmp_path):
-    (tmp_path / "manifest.json").write_text(json.dumps({"Group/Group_Thm.tla": {"context": []}}))
+    (tmp_path / "manifest.json").write_text(
+        json.dumps({"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": []}})
+    )
     (tmp_path / "Stray.tla").write_text("---- MODULE Stray ----\nTHEOREM TRUE\n====\n")
     assert load_dataset_task_keys(str(tmp_path)) == {"Group/Group_Thm.tla"}
 
@@ -474,7 +501,7 @@ def test_dataset_selection_prefers_an_existing_manifest(tmp_path):
 def test_dataset_selection_uses_complete_manifest_without_scanning_extra_flat_tasks(tmp_path):
     """Once migration is complete, the manifest is the whole dataset index."""
     (tmp_path / "manifest.json").write_text(
-        json.dumps({"Group/Group_Thm.tla": {"context": ["Group/Group_ThmScaffold.tla"]}})
+        json.dumps({"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": ["Group/Group_ThmScaffold.tla"]}})
     )
     benor = tmp_path / "BenOr"
     benor.mkdir()
@@ -487,7 +514,7 @@ def test_dataset_selection_does_not_recount_manifest_context_layers(tmp_path):
     task-file rule — but the manifest already names it as context, so it must not
     be mistaken for an un-migrated task."""
     (tmp_path / "manifest.json").write_text(
-        json.dumps({"Group/Group_Thm.tla": {"context": ["Group/Group_ThmScaffold.tla"]}})
+        json.dumps({"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": ["Group/Group_ThmScaffold.tla"]}})
     )
     group = tmp_path / "Group"
     group.mkdir()
@@ -503,7 +530,7 @@ def _emit_task(root, subdir, module, statement="THEOREM Thm == TRUE"):
     scaffold = f"{module}Scaffold"
     (directory / f"{scaffold}.tla").write_text(f"---- MODULE {scaffold} ----\nGiven == TRUE\n====\n")
     (directory / f"{module}.tla").write_text(build_task_module(module, scaffold, statement))
-    return f"{subdir}/{module}.tla", {"context": [f"{subdir}/{scaffold}.tla"]}
+    return f"{subdir}/{module}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{scaffold}.tla"]}
 
 
 def _finalize(root, manifest, audit_state=None, **kwargs):
@@ -643,14 +670,16 @@ def test_seed_staging_copies_the_current_dataset_verbatim(tmp_path):
     source = tmp_path / "dataset"
     (source / "Group").mkdir(parents=True)
     (source / "Group" / "Group_Thm.tla").write_text("theorem body")
-    (source / "manifest.json").write_text('{"Group/Group_Thm.tla": {"context": []}}')
+    (source / "manifest.json").write_text('{"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": []}}')
     staging = tmp_path / "staging"
     staging.mkdir()
 
     _seed_staging(str(source), str(staging))
 
     assert (staging / "Group" / "Group_Thm.tla").read_text() == "theorem body"
-    assert (staging / "manifest.json").read_text() == '{"Group/Group_Thm.tla": {"context": []}}'
+    assert (
+        staging / "manifest.json"
+    ).read_text() == '{"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": []}}'
 
 
 def test_filtered_finalization_keeps_tasks_outside_the_filter(tmp_path):
@@ -731,7 +760,7 @@ def test_finalize_flags_a_scaffold_two_tasks_share(tmp_path):
     (tmp_path / "Group" / "Group_Two.tla").write_text(
         build_task_module("Group_Two", "Group_OneScaffold", "THEOREM Other == TRUE")
     )
-    manifest = {first: entry, second: {"context": entry["context"]}}
+    manifest = {first: entry, second: {"spec_id": "Fixture.tla", "context": entry["context"]}}
     audit_state = {"scaffold_owner": {entry["context"][0]: [first, second]}}
     _finalize(tmp_path, manifest, audit_state)
 
@@ -795,7 +824,7 @@ def test_finalize_keeps_context_a_failing_run_would_have_swept(tmp_path):
 
 def test_finalize_refuses_a_manifest_the_evaluator_would_reject(tmp_path):
     key, entry = _emit_task(tmp_path, "Group", "Group_Thm")
-    entry = {"context": [*entry["context"], "Group/Missing.tla"]}
+    entry = {"spec_id": "Fixture.tla", "context": [*entry["context"], "Group/Missing.tla"]}
     with pytest.raises(ManifestError):
         _finalize(tmp_path, {key: entry})
 
@@ -809,7 +838,7 @@ def _dup_task(root, subdir, module, scaffold_body="Given == TRUE"):
     scaffold = f"{module}Scaffold"
     (directory / f"{scaffold}.tla").write_text(f"---- MODULE {scaffold} ----\n{scaffold_body}\n====\n")
     (directory / f"{module}.tla").write_text(build_task_module(module, scaffold, "THEOREM Thm == TRUE"))
-    return f"{subdir}/{module}.tla", {"context": [f"{subdir}/{scaffold}.tla"]}
+    return f"{subdir}/{module}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{scaffold}.tla"]}
 
 
 def test_an_approved_duplicate_keeps_only_the_canonical_copy(tmp_path):

--- a/tests/dataset/test_specification_identity.py
+++ b/tests/dataset/test_specification_identity.py
@@ -1,0 +1,46 @@
+"""Stable source-specification identities in generated manifests."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from common.task_contract import ManifestError, load_manifest_specification_ids
+from dataset.specification_identity import source_spec_id
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_ROOT = REPO_ROOT / "source"
+
+
+def test_source_spec_id_preserves_the_source_relative_path(tmp_path):
+    source_root = tmp_path / "source"
+    nested = source_root / "Example" / "variant" / "Spec.tla"
+
+    assert source_spec_id(str(nested), str(source_root)) == "Example/variant/Spec.tla"
+    assert source_spec_id(str(tmp_path / "external" / "Spec.tla"), str(source_root)) == "Spec.tla"
+
+
+def test_identity_loader_rejects_a_manifest_entry_without_a_mapping(tmp_path):
+    suite = tmp_path / "proof-completion"
+    suite.mkdir()
+    (suite / "manifest.json").write_text(json.dumps({"Task.tla": {"context": []}}), encoding="utf-8")
+
+    with pytest.raises(ManifestError, match="exactly 'spec_id' and 'context'"):
+        load_manifest_specification_ids(suite, suite_name="proof-completion")
+
+
+def test_current_manifests_map_every_task_to_an_existing_source_specification():
+    manifests = {}
+    for mode in ("proof-completion", "proof-from-scratch"):
+        path = REPO_ROOT / "benchmark" / mode / "manifest.json"
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        manifests[mode] = manifest
+        assert manifest
+        for task_id, entry in manifest.items():
+            assert set(entry) == {"spec_id", "context"}, task_id
+            assert (SOURCE_ROOT / entry["spec_id"]).is_file(), task_id
+
+    shared_tasks = set(manifests["proof-completion"]) & set(manifests["proof-from-scratch"])
+    assert shared_tasks
+    for task_id in shared_tasks:
+        assert manifests["proof-completion"][task_id]["spec_id"] == manifests["proof-from-scratch"][task_id]["spec_id"]

--- a/tests/evaluator/test_continuation.py
+++ b/tests/evaluator/test_continuation.py
@@ -614,7 +614,7 @@ def test_summary_reports_continuation_metric_separately(tmp_path):
     )
     summary = (tmp_path / "summary.md").read_text()
     assert "**Pass rate**: 0/2 (0.0%)" in summary  # pass@1 stays first-attempt only
-    assert "**Pass rate with continuations (≤3)**: 1/2 (50.0%) — 1 recovered by continuation" in summary
+    assert "**Task-micro pass rate with continuations (≤3)**: 1/2 (50.0%) — 1 recovered by continuation" in summary
     assert "PASS on continuation 1" in summary
 
 
@@ -637,7 +637,7 @@ def test_summary_excludes_interrupted_chains_from_continuation_rate(tmp_path):
     summary = (tmp_path / "summary.md").read_text()
     assert "**Pass rate**: 0/3 (0.0%)" in summary  # cut-chain's genuine first FAIL stays scored
     assert (
-        "**Pass rate with continuations (≤3)**: 1/2 (50.0%) — 1 recovered by continuation "
+        "**Task-micro pass rate with continuations (≤3)**: 1/2 (50.0%) — 1 recovered by continuation "
         "(pass@1 above is first-attempt only) · 1 chain(s) infra/quota-cut (excluded — re-run)"
     ) in summary
     assert "continuation chain cut at round 1 (excluded — re-run)" in summary  # per-row note discloses too

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -211,6 +211,35 @@ def test_summary_excludes_non_genuine_results_from_pass_rate(tmp_path):
     assert "INFRA_ERROR (excluded — re-run)" in summary
 
 
+def test_summary_uses_specification_macro_as_primary_for_manifest_suites(tmp_path):
+    results = [
+        _result("A/One.tla", "PASS", mode="proof-completion"),
+        _result("A/Two.tla", "FAIL", mode="proof-completion"),
+        _result("B/Only.tla", "PASS", mode="proof-completion"),
+        _result("Removed/Old.tla", "PASS", mode="proof-completion"),
+    ]
+    specification_ids = {
+        ("proof-completion", "A/One.tla"): "A/A.tla",
+        ("proof-completion", "A/Two.tla"): "A/A.tla",
+        ("proof-completion", "B/Only.tla"): "B/B.tla",
+    }
+
+    runner.update_summary(
+        results,
+        str(tmp_path),
+        total_benchmarks=4,
+        backend_name="copilot",
+        mode_name="proof-completion",
+        specification_ids=specification_ids,
+    )
+
+    summary = (tmp_path / "summary.md").read_text()
+    assert "**Specification-macro pass rate**: 75.0% across 2 specifications" in summary
+    assert "**Task-micro pass rate**: 2/3 (66.7%)" in summary
+    assert "**All leaves complete**: 1/2 specifications (50.0%)" in summary
+    assert "**Non-applicable results**: 1 not present in the active manifest (excluded)" in summary
+
+
 def test_summary_reports_time_and_equivalent_cost_without_zero_filling(tmp_path):
     results = [
         _result("priced.tla", "PASS", time_secs=1.25, equivalent_cost_usd=0.125),

--- a/tests/evaluator/test_proof_completion_mode.py
+++ b/tests/evaluator/test_proof_completion_mode.py
@@ -62,8 +62,9 @@ def test_strict_mode_discovers_only_manifest_tasks_and_exact_context(tmp_path):
     _write_manifest(
         suite,
         {
-            "Zed/Zed_Target.tla": {"context": []},
+            "Zed/Zed_Target.tla": {"spec_id": "Fixture.tla", "context": []},
             "Alpha/Alpha_Target.tla": {
+                "spec_id": "Fixture.tla",
                 "context": ["Context/ModelB.tla", "Context/ModelA.tla"],
             },
         },
@@ -76,6 +77,10 @@ def test_strict_mode_discovers_only_manifest_tasks_and_exact_context(tmp_path):
     assert mode.canonical_replay_required
     assert mode.get_benchmark_files() == [str(task_a), str(task_z)]
     assert mode.get_dependencies(str(task_a)) == [str(context_b), str(context_a)]
+    assert mode.specification_ids() == {
+        "Alpha/Alpha_Target.tla": "Fixture.tla",
+        "Zed/Zed_Target.tla": "Fixture.tla",
+    }
     assert not mode.is_benchmark_file(str(undeclared))
     assert mode.get_benchmark_files("Alpha_Target, Zed/") == [str(task_a), str(task_z)]
 
@@ -83,7 +88,7 @@ def test_strict_mode_discovers_only_manifest_tasks_and_exact_context(tmp_path):
 def test_strict_mode_is_pickleable_after_discovery(tmp_path):
     suite = tmp_path / "proof-completion"
     task = _write_task(suite, "Example/Example_Target.tla")
-    _write_manifest(suite, {"Example/Example_Target.tla": {"context": []}})
+    _write_manifest(suite, {"Example/Example_Target.tla": {"spec_id": "Fixture.tla", "context": []}})
     mode = _mode(tmp_path)
     mode.get_benchmark_files()
 
@@ -103,6 +108,7 @@ def test_absent_manifest_uses_legacy_layout_with_one_warning(tmp_path, capsys):
     assert mode.get_dependencies(str(task)) == [str(dependency)]
     assert not mode.read_only_dependencies
     assert not mode.canonical_replay_required
+    assert mode.specification_ids() is None
 
     warning = capsys.readouterr().err
     assert warning.count("using legacy unmarked proof-completion") == 1
@@ -148,7 +154,7 @@ def test_marker_in_symlinked_directory_cannot_downgrade_to_legacy(tmp_path):
 def test_strict_and_legacy_modes_select_matching_prompts(tmp_path):
     strict_suite = tmp_path / "strict" / "proof-completion"
     _write_task(strict_suite, "Task.tla")
-    _write_manifest(strict_suite, {"Task.tla": {"context": []}})
+    _write_manifest(strict_suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": []}})
     legacy_suite = tmp_path / "legacy" / "proof-completion"
     legacy_suite.mkdir(parents=True)
 
@@ -166,7 +172,7 @@ def test_strict_cli_captures_all_inputs_before_backend_setup(tmp_path, monkeypat
     suite = benchmark_root / "proof-completion"
     task = _write_task(suite, "Suite/Task.tla", "EXTENDS Model\n")
     model = _write_module(suite, "Context/Model.tla", "Value == TRUE\n")
-    _write_manifest(suite, {"Suite/Task.tla": {"context": ["Context/Model.tla"]}})
+    _write_manifest(suite, {"Suite/Task.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"]}})
     task_source = task.read_bytes()
     model_source = model.read_bytes()
     mode = ProofCompletion(str(benchmark_root), "/checker")

--- a/tests/evaluator/test_proof_from_scratch_mode.py
+++ b/tests/evaluator/test_proof_from_scratch_mode.py
@@ -62,8 +62,8 @@ def test_discovers_only_sorted_manifest_tasks(tmp_path):
     _write_manifest(
         suite,
         {
-            "Zed/Zed_Target.tla": {"context": []},
-            "Alpha/Alpha_Target.tla": {"context": []},
+            "Zed/Zed_Target.tla": {"spec_id": "Fixture.tla", "context": []},
+            "Alpha/Alpha_Target.tla": {"spec_id": "Fixture.tla", "context": []},
         },
     )
 
@@ -82,9 +82,9 @@ def test_filters_manifest_tasks_with_existing_comma_separated_substrings(tmp_pat
     _write_manifest(
         suite,
         {
-            "Alpha/Alpha_Target.tla": {"context": []},
-            "Beta/Beta_Target.tla": {"context": []},
-            "Gamma/Gamma_Target.tla": {"context": []},
+            "Alpha/Alpha_Target.tla": {"spec_id": "Fixture.tla", "context": []},
+            "Beta/Beta_Target.tla": {"spec_id": "Fixture.tla", "context": []},
+            "Gamma/Gamma_Target.tla": {"spec_id": "Fixture.tla", "context": []},
         },
     )
 
@@ -105,19 +105,21 @@ def test_returns_only_manifest_context_in_declared_order(tmp_path):
         suite,
         {
             "Example/Example_Target.tla": {
+                "spec_id": "Fixture.tla",
                 "context": ["Context/ModelB.tla", "Context/ModelA.tla"],
             }
         },
     )
 
     assert _mode(tmp_path).get_dependencies(str(target)) == [str(context_b), str(context_a)]
+    assert _mode(tmp_path).specification_ids() == {"Example/Example_Target.tla": "Fixture.tla"}
 
 
 def test_rejects_dependency_lookup_for_undeclared_file(tmp_path):
     suite = tmp_path / "proof-from-scratch"
     _write_task(suite, "Example/Example_Target.tla")
     undeclared = _write_module(suite, "Example/Other_Target.tla")
-    _write_manifest(suite, {"Example/Example_Target.tla": {"context": []}})
+    _write_manifest(suite, {"Example/Example_Target.tla": {"spec_id": "Fixture.tla", "context": []}})
 
     with pytest.raises(ValueError, match="is not declared"):
         _mode(tmp_path).get_dependencies(str(undeclared))
@@ -136,7 +138,7 @@ def test_mode_remains_pickleable_after_manifest_discovery(tmp_path):
     context = _write_module(suite, "Context/Model.tla")
     _write_manifest(
         suite,
-        {"Example/Example_Target.tla": {"context": ["Context/Model.tla"]}},
+        {"Example/Example_Target.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"]}},
     )
     mode = _mode(tmp_path)
     mode.get_benchmark_files()

--- a/tests/evaluator/test_proof_from_scratch_runner.py
+++ b/tests/evaluator/test_proof_from_scratch_runner.py
@@ -67,7 +67,9 @@ def test_runner_grades_from_pre_agent_canonical_bytes(tmp_path, monkeypatch):
     model.write_text(model_source)
     sibling.write_text(_module("Sibling_Task", "THEOREM Leak == TRUE\nPROOF OBVIOUS\n"))
     unrelated.write_text(_module("UnrelatedDefs", "Leak == TRUE\n"))
-    (suite / "manifest.json").write_text(json.dumps({"Suite/Task.tla": {"context": ["Context/Model.tla"]}}))
+    (suite / "manifest.json").write_text(
+        json.dumps({"Suite/Task.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"]}})
+    )
 
     mode = ProofFromScratch(str(tmp_path / "benchmark"), "/checker")
     backend = _Backend()
@@ -153,7 +155,9 @@ def test_cli_captures_all_replay_inputs_before_backend_setup(tmp_path, monkeypat
     model_source = _module("Model", "Value == TRUE\n")
     task.write_text(task_source)
     model.write_text(model_source)
-    (suite / "manifest.json").write_text(json.dumps({"Suite/Task.tla": {"context": ["Context/Model.tla"]}}))
+    (suite / "manifest.json").write_text(
+        json.dumps({"Suite/Task.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"]}})
+    )
 
     mode = ProofFromScratch(str(benchmark_root), "/checker")
     backend = _Backend()

--- a/tests/evaluator/test_score.py
+++ b/tests/evaluator/test_score.py
@@ -1,10 +1,10 @@
 """Scoring from results.json.
 
 A task passes iff check_verdict == "PASS"; CHEATING/FAIL/TIMEOUT/ERROR all count
-as not passed, and CHEATING is never shown as its own category. The default
-"equal" scorer makes the score the plain percentage of tasks passed. SKIP is the
-one exception: it is dropped from scoring entirely (neither passed nor failed)
-and only reported as a side count.
+as not passed, and CHEATING is never shown as its own category. Specification
+macro is primary; the legacy equal-task scorer remains a diagnostic and CLI
+option. SKIP is dropped from scoring entirely (neither passed nor failed) and
+only reported as a side count.
 
 Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_score.py
 """
@@ -12,8 +12,11 @@ Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_score.py
 import json
 import sys
 
+import pytest
+
 from evaluator.score import (
     SCORERS,
+    SPECIFICATION_EQUAL,
     comparison_md,
     continuation_budget,
     continuation_interrupted,
@@ -25,7 +28,9 @@ from evaluator.score import (
     main,
     n_non_genuine,
     n_skipped,
+    scope_specification_ids,
     scorecard_md,
+    specification_equal_score,
     weighted_score,
 )
 
@@ -59,6 +64,110 @@ def test_equal_weight_is_percent_passed():
 
 def test_empty_is_zero_not_crash():
     assert weighted_score([], EQUAL) == (0.0, 0, 0)
+
+
+def test_specification_equal_preserves_partial_credit_without_task_count_bias():
+    specification_ids = scope_specification_ids(
+        "proof-completion",
+        {
+            "A/One.tla": "A/A.tla",
+            "A/Two.tla": "A/A.tla",
+            "B/Only.tla": "B/B.tla",
+        },
+    )
+    results = [
+        _r("PASS", mode="proof-completion", benchmark="A/One.tla"),
+        _r("FAIL", mode="proof-completion", benchmark="A/Two.tla"),
+        _r("PASS", mode="proof-completion", benchmark="B/Only.tla"),
+    ]
+
+    score = specification_equal_score(results, specification_ids)
+
+    assert score.specification_macro_pct == 75.0  # mean(1/2, 1/1)
+    assert score.task_micro_pct == pytest.approx(66.6667)
+    assert (score.tasks_passed, score.applicable_tasks) == (2, 3)
+    assert (score.complete_specifications, score.represented_specifications) == (1, 2)
+
+
+def test_specification_equal_rejects_an_active_task_without_a_spec_id():
+    results = [_r("PASS", mode="proof-completion", benchmark="A/One.tla")]
+
+    with pytest.raises(ValueError, match="missing specification identity"):
+        specification_equal_score(results, {("proof-completion", "A/One.tla"): ""})
+
+
+def test_specification_equal_excludes_non_applicable_and_unscored_results():
+    specification_ids = scope_specification_ids(
+        "proof-completion",
+        {
+            "A/Pass.tla": "A/A.tla",
+            "A/Skipped.tla": "A/A.tla",
+            "B/Infra.tla": "B/B.tla",
+        },
+    )
+    results = [
+        _r("PASS", mode="proof-completion", benchmark="A/Pass.tla"),
+        _r("SKIP", mode="proof-completion", benchmark="A/Skipped.tla"),
+        _r("ERROR", mode="proof-completion", benchmark="B/Infra.tla", termination_reason="INFRA_ERROR"),
+        _r("PASS", mode="proof-completion", benchmark="Removed/Old.tla"),
+    ]
+
+    score = specification_equal_score(results, specification_ids)
+
+    assert score.specification_macro_pct == 100.0
+    assert (score.tasks_passed, score.applicable_tasks) == (1, 1)
+    assert (score.complete_specifications, score.represented_specifications) == (1, 1)
+    assert score.non_applicable_results == 1
+
+
+def test_specification_scorecard_keeps_both_secondary_diagnostics():
+    specification_ids = scope_specification_ids(
+        "proof-completion",
+        {
+            "A/One.tla": "A/A.tla",
+            "A/Two.tla": "A/A.tla",
+            "B/Only.tla": "B/B.tla",
+        },
+    )
+    results = [
+        _r("PASS", module="A", mode="proof-completion", benchmark="A/One.tla"),
+        _r("FAIL", module="A", mode="proof-completion", benchmark="A/Two.tla"),
+        _r("PASS", module="B", mode="proof-completion", benchmark="B/Only.tla"),
+    ]
+    run = {"path": "x", "id": "x", "backend": "codex", "mode": "proof-completion", "results": results}
+
+    md = scorecard_md(run, EQUAL, SPECIFICATION_EQUAL, specification_ids)
+
+    assert "**Specification-macro pass rate**: 75.0% across 2 specifications" in md
+    assert "**Task-micro pass rate**: 2/3 (66.7%)" in md
+    assert "**All leaves complete**: 1/2 specifications (50.0%)" in md
+    assert "## By module (task micro)" in md
+    assert "| **Total** | **2** | **3** | **66.7%** |" in md
+
+
+def test_specification_comparison_shows_primary_and_secondary_scores():
+    specification_ids = scope_specification_ids(
+        "proof-completion",
+        {"A/One.tla": "A/A.tla", "A/Two.tla": "A/A.tla", "B/Only.tla": "B/B.tla"},
+    )
+    runs = [
+        {
+            "path": "one",
+            "id": "one",
+            "backend": "codex",
+            "mode": "proof-completion",
+            "results": [
+                _r("PASS", mode="proof-completion", benchmark="A/One.tla"),
+                _r("FAIL", mode="proof-completion", benchmark="A/Two.tla"),
+                _r("PASS", mode="proof-completion", benchmark="B/Only.tla"),
+            ],
+        }
+    ]
+
+    md = comparison_md(runs, EQUAL, SPECIFICATION_EQUAL, specification_ids)
+
+    assert "| Run | Backend | Mode | Specification macro | Task micro | All leaves complete |" in md
+    assert "| one | codex | proof-completion | 75.0% | 2/3 (66.7%) | 1/2 |" in md
 
 
 def test_scorecard_module_breakdown_and_no_cheating_row():
@@ -411,7 +520,7 @@ def test_scorecard_reports_continuation_rate_separately():
     run = {"path": "x", "id": "r", "backend": "copilot", "mode": "proof-completion", "results": results}
     md = scorecard_md(run, EQUAL, "equal")
     assert "**Pass rate**: 0/2 (0.0%)" in md  # pass@1 stays first-attempt only
-    assert "**Pass rate with continuations**: 1/2 (50.0%) — 1 recovered by continuation" in md
+    assert "**Task-micro pass rate with continuations**: 1/2 (50.0%) — 1 recovered by continuation" in md
 
 
 def test_scorecard_labels_continuation_budget_and_excludes_cut_chains():
@@ -426,7 +535,7 @@ def test_scorecard_labels_continuation_budget_and_excludes_cut_chains():
     md = scorecard_md(run, EQUAL, "equal")
     assert "**Pass rate**: 0/3 (0.0%)" in md  # the cut chain's genuine first FAIL stays scored
     assert (
-        "**Pass rate with continuations (≤3)**: 1/2 (50.0%) — 1 recovered by continuation "
+        "**Task-micro pass rate with continuations (≤3)**: 1/2 (50.0%) — 1 recovered by continuation "
         "(pass@1 above is first-attempt only) · 1 chain(s) infra/quota-cut (excluded — re-run)"
     ) in md
 
@@ -497,17 +606,43 @@ def _write_run(tmp_path, name, results):
 
 
 def test_main_single_prints_scorecard(tmp_path, monkeypatch, capsys):
-    d = _write_run(tmp_path, "run1", [_r("PASS", backend="codex", mode="proof-completion"), _r("FAIL")])
+    results = [
+        _r("PASS", backend="codex", mode="proof-completion", benchmark="A/One.tla"),
+        _r("FAIL", backend="codex", mode="proof-completion", benchmark="A/Two.tla"),
+    ]
+    d = _write_run(tmp_path, "run1", results)
+    specification_ids = scope_specification_ids("proof-completion", {"A/One.tla": "A/A.tla", "A/Two.tla": "A/A.tla"})
+    monkeypatch.setattr("evaluator.score.load_current_specification_ids", lambda _modes: specification_ids)
     monkeypatch.setattr(sys, "argv", ["tlaps-bench score", d])
     assert main() == 0
     out = capsys.readouterr().out
     assert "# Scorecard" in out
-    assert "**Pass rate**: 1/2 (50.0%)" in out
+    assert "**Specification-macro pass rate**: 50.0% across 1 specification" in out
+    assert "**Task-micro pass rate**: 1/2 (50.0%)" in out
+
+
+def test_main_equal_retains_legacy_task_micro_score(tmp_path, monkeypatch, capsys):
+    d = _write_run(tmp_path, "run1", [_r("PASS"), _r("FAIL")])
+    monkeypatch.setattr(sys, "argv", ["tlaps-bench score", "--scoring", "equal", d])
+
+    assert main() == 0
+
+    assert "**Pass rate**: 1/2 (50.0%)" in capsys.readouterr().out
 
 
 def test_main_multiple_prints_comparison(tmp_path, monkeypatch, capsys):
-    d1 = _write_run(tmp_path, "run1", [_r("PASS", backend="codex", mode="proof-completion")])
-    d2 = _write_run(tmp_path, "run2", [_r("FAIL", backend="codex", mode="proof-completion")])
+    d1 = _write_run(
+        tmp_path,
+        "run1",
+        [_r("PASS", backend="codex", mode="proof-completion", benchmark="A/One.tla")],
+    )
+    d2 = _write_run(
+        tmp_path,
+        "run2",
+        [_r("FAIL", backend="codex", mode="proof-completion", benchmark="A/One.tla")],
+    )
+    specification_ids = scope_specification_ids("proof-completion", {"A/One.tla": "A/A.tla"})
+    monkeypatch.setattr("evaluator.score.load_current_specification_ids", lambda _modes: specification_ids)
     monkeypatch.setattr(sys, "argv", ["tlaps-bench score", d1, d2])
     assert main() == 0
     assert "# Comparison — 2 runs" in capsys.readouterr().out


### PR DESCRIPTION
## What changed

- Add a stable `spec_id` to every task in the versioned manifests: 706 proof-completion tasks and 250 proof-from-scratch tasks.
- Group tasks by the exact source-relative `.tla` path. This keeps files with the same basename separate and treats different source modules in the same example as different specifications.
- Do not count `SKIP`, infrastructure failures, or tasks removed from the current manifest. Report each separately instead.
- Keep the old task-micro score as the primary score when `--scoring equal` is used.

## Scores

- **Specification-macro (primary):** Calculate the pass rate within each specification, then average those rates so every specification has equal weight.
- **Task-micro:** Divide the number of passed tasks by the number of applicable tasks, so every task has equal weight.
- **All-leaves-complete:** Count specifications where every applicable selected task passed.

## Existing result check

I ran the new scorer on the existing Codex GPT-5.5 proof-completion results:

- **Specification-macro:** 95.1% across 95 specifications.
- **Task-micro:** 407/445 tasks passed (91.5%).
- **All-leaves-complete:** 85/95 specifications passed every selected task (89.5%).
- 38 old results were not present in the current manifest, so they were reported as non-applicable and excluded.

## Testing

- Added tests for partial credit, missing mappings, non-applicable results, `SKIP`, and infrastructure failures.
- Regenerated both benchmark suites and verified that all 706 proof-completion tasks and all 250 proof-from-scratch tasks match the versioned outputs.
- Ran Codex GPT-5.5 on `GCD_GCD1` and `GCD_GCD3`. Both passed. Because both tasks come from the same specification, the scores were 100% specification-macro, 2/2 task-micro, and 1/1 all-leaves-complete.

Closes #101.
