### PR TITLE
Add Codex single-turn benchmark backend

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -38,11 +38,12 @@ uv run tlaps-bench run --backend codex --model gpt-5.5 --mode proof-from-scratch
 
 ## Backends
 
-A backend is the model integration that attempts the proof. Eight are included:
+A backend is the model integration that attempts the proof. Nine are included:
 
 | Backend | CLI Name | Default Model |
 |---------|----------|---------------|
 | OpenAI Codex | `codex` | `gpt-5.5` |
+| OpenAI Codex (single-turn approximation) | `codex_single_turn` | `gpt-5.5` |
 | Claude Code | `claude_code` | `claude-opus-4-8` |
 | Cursor | `cursor` | `sonnet-4.5` |
 | GitHub Copilot | `copilot` | `claude-opus-4.8` |
@@ -58,6 +59,7 @@ uv run tlaps-bench run --backend claude_code --model claude-opus-4-8
 uv run tlaps-bench run --backend pi --model anthropic/claude-sonnet-4-6
 uv run tlaps-bench run --backend litellm --model claude-sonnet-4-6
 uv run tlaps-bench run --backend litellm_oneshot --model claude-sonnet-4-6
+uv run tlaps-bench run --backend codex_single_turn --model gpt-5.6-sol
 ```
 
 ### Agent skills
@@ -73,7 +75,7 @@ The benchmark automatically makes the portable skills under `skills/` available 
 | `litellm` | `.agents/skills` |
 | `pi` | `.agents/skills` |
 
-One-shot backends do not receive skills.
+Strict one-shot backends and `codex_single_turn` do not receive skills.
 
 ### OpenAI-compatible endpoints
 
@@ -126,6 +128,7 @@ If you are already logged in to an agent on your host machine (e.g. `codex login
 | Backend | Environment Variable | Host Credentials (auto-mounted) |
 |---------|---------------------|----------------------------------|
 | `codex` | `OPENAI_API_KEY` or `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_HOST` | `~/.codex/` (logged-in session) |
+| `codex_single_turn` | Same as `codex` | `~/.codex/` (logged-in session, including ChatGPT subscription auth) |
 | `claude_code` | `ANTHROPIC_API_KEY` | `~/.claude/` |
 | `copilot` | `COPILOT_GITHUB_TOKEN` or `GH_TOKEN`. BYOK: `COPILOT_PROVIDER_BASE_URL` + `COPILOT_PROVIDER_API_KEY` + `COPILOT_PROVIDER_TYPE` | |
 | `copilot_oneshot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` | |
@@ -156,6 +159,49 @@ Both backends default to three outer infrastructure retries, but only for explic
 Copilot uses the benchmark deadline for startup and inference, records `TIMEOUT` before bounded teardown, and blocks late requests. It accepts `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`; stored CLI sessions and agentic BYOK settings are not used.
 
 With `--no-container`, the runner uses its source-tree path instead of `/opt`. LiteLLM is already a project dependency; native Copilot runs additionally require `github-copilot-sdk` and its runtime (`python3 -m copilot download-runtime`) in the active environment.
+
+### Codex subscription single-turn approximation
+
+`codex_single_turn` provides a subscription-compatible approximation when a
+strict provider API one-shot is unavailable. It uses the official
+[`codex exec`](https://learn.chatgpt.com/docs/non-interactive-mode) interface and
+reuses the same [`codex login`](https://learn.chatgpt.com/docs/auth) credentials
+as the agentic `codex` backend, including ChatGPT subscription authentication:
+
+```bash
+codex login
+uv run tlaps-bench run --backend codex_single_turn --model gpt-5.6-sol --reasoning-effort medium --task-list core
+```
+
+OpenAI, ChatGPT, and Azure Codex authentication are supported. Amazon Bedrock
+models are rejected because their user-level provider configuration is
+intentionally ignored by this isolated mode.
+
+Each benchmark starts one non-interactive Codex process, supplies the strict
+one-shot prompt plus an explicit no-tools instruction on stdin, permits one
+logical turn, disables project skills and Codex shell, code-mode, multi-agent,
+app, browser, computer, image, and goal tool features, and uses a read-only
+sandbox. The final message is materialized as the complete TLA+ module and
+passed to the normal grader. User configuration and repository rules are
+ignored so they cannot silently add tools, instructions, or a different
+service tier. Continuations are disabled.
+
+This backend is not labeled strict one-shot. The public Codex JSONL stream does
+not expose the wire request or prove removal of Codex's built-in internal
+instructions. The evaluator therefore records `one_shot: false`. It keeps the
+Codex session long enough for the rollout wrapper to audit native token-count
+deltas: a valid result records `model_request_count_visible: true`,
+`model_request_count_source: codex_rollout_token_count`, and
+`model_requests: 1`. It also records whether exactly one thread and turn
+completed, whether a complete zero-tool session-tree audit was observed, event
+counts, and the final message's presence. Multiple progress/final
+`agent_message` events inside the same turn do not make it a multi-turn run.
+
+An incomplete rollout audit, more than one model request, any child agent or
+tool call, or a damaged turn is an infrastructure/contract failure and is
+excluded from capability scoring. This keeps a normal SANY or TLAPS rejection
+as a genuine model FAIL without treating a broken approximation as model
+behavior.
 
 ---
 
@@ -346,7 +392,7 @@ With `--max-continuations`, each continuation round also writes a `continuations
 
 ### Usage and cost telemetry
 
-For `codex`, `claude_code`, `copilot`, `copilot_oneshot`, `cursor`, `litellm`, `litellm_oneshot`, and `pi`, each formal benchmark result records:
+For `codex`, `codex_single_turn`, `claude_code`, `copilot`, `copilot_oneshot`, `cursor`, `litellm`, `litellm_oneshot`, and `pi`, each formal benchmark result records:
 
 - `time_secs`: agent wall time, excluding the checker
 - `equivalent_cost_usd`: the same usage valued at public API prices, not the actual subscription spend
@@ -439,7 +485,7 @@ docker ps -a --filter name=tlaps-bench- --format '{{.Names}}' | xargs -r docker 
 
 ### Persisting session state to the host (`--session-dir`)
 
-Session state lives inside the container, and for backends that authenticate from a mounted credential file (`codex` / `claude_code` / `pi`) it is written into a `/tmp` tempdir — so a reboot (e.g. after an OOM) clears it even if the container is kept. To avoid that, the agent's session state is bind-mounted straight to a **persistent host directory**.
+Session state lives inside the container, and for backends that authenticate from a mounted credential file (`codex` / `codex_single_turn` / `claude_code` / `pi`) it is written into a `/tmp` tempdir — so a reboot (e.g. after an OOM) clears it even if the container is kept. To avoid that, the agent's session state is bind-mounted straight to a **persistent host directory**.
 
 With `--keep-container` this happens automatically under `~/.tlaps-bench/sessions/`. Pass `--session-dir` to choose the location explicitly (and to persist without keeping the container):
 
@@ -447,7 +493,7 @@ With `--keep-container` this happens automatically under `~/.tlaps-bench/session
 uv run tlaps-bench run --backend copilot --session-dir ./sessions --filter my_benchmark
 ```
 
-Each run writes its state to `<session-dir>/<backend>/<benchmark>/` (or `<...>/<container-name>/` under `--keep-container`, one dir per retained container). For `codex`/`claude_code`/`pi` the credential files are stored there too, so a single mount holds both auth and session. Because it is a real host path — not `/tmp` and not tied to the container's lifetime — the state survives container removal *and* reboot, and can be moved to another machine. A `.gitignore` (`*`) is written at the session root so this credential-bearing data can't be accidentally committed. `--session-dir` is ignored with `--no-container`.
+Each run writes its state to `<session-dir>/<backend>/<benchmark>/` (or `<...>/<container-name>/` under `--keep-container`, one dir per retained container). For `codex`/`codex_single_turn`/`claude_code`/`pi` the credential files are stored there too, so a single mount holds both auth and session. Because it is a real host path — not `/tmp` and not tied to the container's lifetime — the state survives container removal *and* reboot, and can be moved to another machine. A `.gitignore` (`*`) is written at the session root so this credential-bearing data can't be accidentally committed. `--session-dir` is ignored with `--no-container`.
 
 ### Restoring a session into a container
 
@@ -477,7 +523,7 @@ This installs the Python environment, downloads tlapm 1.6, compiles the checker 
 
 ## Backend Architecture
 
-All entries in the backend registry share the neutral `Backend` lifecycle. Tool-using workspace editors inherit `AgenticBackend`; strict single-response implementations inherit the sibling `OneShotBackend`. Prompt construction, command/deadline propagation, option validation, result metadata, request-audit validation, and submission preparation are polymorphic backend hooks, so the common runner and termination classifier do not special-case one-shot names or provider names. Runtime one-shot providers implement the `OneShotProvider` protocol and are selected through a registry; each one-shot backend cross-checks the common request contract against its provider's raw audit evidence. A provider may report one `usage_details` entry per model request; each entry must explicitly include both `input_tokens` and `output_tokens` to be complete. Providers without per-request details can return exact aggregate token counts instead. Unavailable counts must be `None`, which becomes `null` and makes the record a lower bound; explicit zeroes remain exact zeroes.
+All entries in the backend registry share the neutral `Backend` lifecycle. Tool-using workspace editors inherit `AgenticBackend`; strict single-response implementations inherit the sibling `OneShotBackend`. `codex_single_turn` instead reuses Codex CLI execution and telemetry while overriding its prompt, sandbox, materialization, and continuation capabilities. Prompt construction, command/deadline propagation, option validation, result metadata, request-audit validation, and submission preparation are polymorphic backend hooks, so the common runner and termination classifier do not special-case strict one-shot names or provider names. Runtime one-shot providers implement the `OneShotProvider` protocol and are selected through a registry; each strict one-shot backend cross-checks the common request contract against its provider's raw audit evidence. A provider may report one `usage_details` entry per model request; each entry must explicitly include both `input_tokens` and `output_tokens` to be complete. Providers without per-request details can return exact aggregate token counts instead. Unavailable counts must be `None`, which becomes `null` and makes the record a lower bound; explicit zeroes remain exact zeroes.
 
 ## Adding a New Agentic Backend
 

--- a/src/evaluator/backends/__init__.py
+++ b/src/evaluator/backends/__init__.py
@@ -5,6 +5,7 @@ from .base import AgentBackend as AgentBackend
 from .base import Backend
 from .claude_code import ClaudeCodeBackend
 from .codex import CodexBackend
+from .codex_single_turn import CodexSingleTurnBackend
 from .copilot import CopilotBackend
 from .copilot_oneshot import CopilotOneShotBackend
 from .cursor import CursorBackend
@@ -15,6 +16,7 @@ from .pi import PiBackend
 
 _REGISTRY = {
     CodexBackend.name: CodexBackend,
+    CodexSingleTurnBackend.name: CodexSingleTurnBackend,
     ClaudeCodeBackend.name: ClaudeCodeBackend,
     CursorBackend.name: CursorBackend,
     CopilotBackend.name: CopilotBackend,

--- a/src/evaluator/backends/codex_single_turn.py
+++ b/src/evaluator/backends/codex_single_turn.py
@@ -1,0 +1,341 @@
+"""Tool-free, single-turn Codex CLI approximation of a one-shot request."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from evaluator.termination import TerminationReason
+
+from .base import BackendCapabilities, SubmissionDisposition, SubmissionPlan
+from .codex import CodexBackend
+from .oneshot import _reconstruct_marked_solution, _unwrap_tla_fence
+
+
+class CodexSingleTurnBackend(CodexBackend):
+    """Run one tool-free Codex turn and grade its final message as a module.
+
+    This is deliberately not the strict ``OneShotBackend`` contract.  Codex
+    exposes one logical turn and aggregate token usage, but not the number of
+    underlying model requests used to produce that turn.
+    """
+
+    name = "codex_single_turn"
+    approach = "single_turn_tool_free"
+    project_skills_dir = None
+    capabilities = BackendCapabilities(
+        model_preflight=True,
+        default_infra_retries=3,
+        max_infra_retries=None,
+        max_continuations=0,
+    )
+
+    def _uses_bedrock(self) -> bool:
+        # User config is intentionally ignored for protocol isolation. Bedrock
+        # needs provider configuration from that file, so this backend supports
+        # only Codex's OpenAI/ChatGPT/Azure authentication paths.
+        return False
+
+    def check_auth(self) -> str | None:
+        if self.model.startswith("openai."):
+            return "codex_single_turn: Amazon Bedrock models are unsupported; use an OpenAI Codex model"
+        return super().check_auth()
+
+    def build_command(self, workspace: str, result_dir: str) -> list[str]:
+        last_message = os.path.join(result_dir, "codex_last_message.txt")
+        wrapper = (
+            ["python3", "/opt/codex_usage_wrapper.py"]
+            if workspace == "/workspace"
+            else [sys.executable, os.path.join(os.path.dirname(__file__), "codex_usage_wrapper.py")]
+        )
+        command = [
+            *wrapper,
+            "--",
+            "codex",
+            "exec",
+            "--ignore-user-config",
+            "--ignore-rules",
+            "--sandbox",
+            "read-only",
+            "-C",
+            workspace,
+            "-m",
+            self.model,
+            "-c",
+            'approval_policy="never"',
+            "-c",
+            'web_search="disabled"',
+            "-c",
+            "agents.enabled=false",
+            "-c",
+            "apps._default.enabled=false",
+            "--disable",
+            "shell_tool",
+            "--disable",
+            "unified_exec",
+            "--disable",
+            "code_mode",
+            "--disable",
+            "code_mode_host",
+            "--disable",
+            "code_mode_only",
+            "--disable",
+            "code_mode_buffered_exec",
+            "--disable",
+            "multi_agent",
+            "--disable",
+            "multi_agent_v2",
+            "--disable",
+            "apps",
+            "--disable",
+            "browser_use",
+            "--disable",
+            "computer_use",
+            "--disable",
+            "image_generation",
+            "--disable",
+            "view_image",
+            "--disable",
+            "goals",
+            "--disable",
+            "tool_suggest",
+            "--json",
+            "-o",
+            last_message,
+            "-",
+        ]
+        if self.reasoning_effort is not None:
+            command[-1:-1] = ["-c", f"model_reasoning_effort={self.reasoning_effort}"]
+        return command
+
+    def build_prompt(
+        self,
+        mode: Any,
+        benchmark_path: str,
+        dependencies: list[str],
+        benchmark_basename: str,
+        tlapm_path: str,
+        tlapm_lib: str,
+    ) -> str:
+        del benchmark_basename, tlapm_path, tlapm_lib
+        prompt = mode.build_one_shot_prompt(benchmark_path, dependencies)
+        return (
+            "Do not call or suggest any tools. Use only the target and context embedded below, "
+            "and return the requested module directly.\n\n"
+            f"{prompt}"
+        )
+
+    @staticmethod
+    def public_pricing_configuration_error() -> str | None:
+        # ``--ignore-user-config`` prevents a host service_tier from changing
+        # this execution, so it must not block public-price accounting.
+        return None
+
+    def initial_result_metadata(self) -> dict[str, object]:
+        return {
+            **super().initial_result_metadata(),
+            "one_shot": False,
+            "single_turn": True,
+            "tool_free_requested": True,
+            "model_request_count_visible": False,
+            "model_requests": None,
+        }
+
+    def prepare_submission(
+        self,
+        jsonl_path: str,
+        destination: str,
+        termination_reason: str,
+        error: str,
+        *,
+        allow_materialization: bool,
+    ) -> SubmissionPlan:
+        if not allow_materialization:
+            return SubmissionPlan(copy_solution=False)
+        if termination_reason == TerminationReason.INFRA_ERROR:
+            return SubmissionPlan(
+                disposition=SubmissionDisposition.ERROR,
+                copy_solution=False,
+                error=error or "Codex single-turn execution failed",
+            )
+        if termination_reason == TerminationReason.TIMEOUT:
+            return SubmissionPlan(
+                disposition=SubmissionDisposition.TIMEOUT,
+                copy_solution=False,
+                error=error or None,
+            )
+        if termination_reason != TerminationReason.OK:
+            return SubmissionPlan(
+                disposition=SubmissionDisposition.ERROR,
+                copy_solution=False,
+                error=error or f"Codex single-turn run ended with {termination_reason}",
+            )
+
+        materialized = self.materialize_solution(jsonl_path, destination)
+        metadata: dict[str, object] = {"materialized": materialized}
+        if not materialized:
+            message = "Codex final message could not be materialized"
+            metadata["materialization_error"] = message
+            return SubmissionPlan(
+                disposition=SubmissionDisposition.FAIL,
+                copy_solution=False,
+                error=message,
+                metadata=metadata,
+            )
+        return SubmissionPlan(copy_solution=True, metadata=metadata)
+
+    def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
+        metadata = super().parse_run_metadata(jsonl_path)
+        counts = {
+            "thread_started": 0,
+            "turn_started": 0,
+            "turn_completed": 0,
+            "turn_failed": 0,
+            "agent_messages": 0,
+            "reasoning_items": 0,
+            "tool_items": 0,
+            "non_tool_items": 0,
+        }
+        thread_ids: set[str] = set()
+        tool_item_types: set[str] = set()
+        request_audits: list[tuple[bool, int]] = []
+        final_message = Path(jsonl_path).with_name("codex_last_message.txt")
+        final_message_present = False
+        with suppress(OSError, UnicodeError):
+            final_message_present = bool(final_message.read_text(encoding="utf-8").strip())
+
+        try:
+            with open(jsonl_path, encoding="utf-8", errors="replace") as stream:
+                for raw in stream:
+                    try:
+                        event = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(event, dict):
+                        continue
+                    event_type = event.get("type")
+                    if event_type == "thread.started":
+                        counts["thread_started"] += 1
+                        thread_id = event.get("thread_id")
+                        if isinstance(thread_id, str) and thread_id:
+                            thread_ids.add(thread_id)
+                    elif event_type == "turn.started":
+                        counts["turn_started"] += 1
+                    elif event_type == "turn.completed":
+                        counts["turn_completed"] += 1
+                    elif event_type == "turn.failed":
+                        counts["turn_failed"] += 1
+                    elif event_type == "tlaps.codex_child_usage":
+                        requests = event.get("requests")
+                        warning_codes = event.get("warning_codes")
+                        request_audits.append(
+                            (
+                                event.get("complete") is True and isinstance(requests, list) and warning_codes == [],
+                                len(requests) if isinstance(requests, list) else 0,
+                            )
+                        )
+                    if event_type != "item.completed":
+                        continue
+                    item = event.get("item")
+                    if not isinstance(item, dict):
+                        continue
+                    item_type = item.get("type")
+                    if item_type == "agent_message":
+                        counts["agent_messages"] += 1
+                    elif item_type == "reasoning":
+                        counts["reasoning_items"] += 1
+                    elif item_type in {
+                        "command_execution",
+                        "file_change",
+                        "mcp_tool_call",
+                        "collab_tool_call",
+                        "todo_list",
+                        "web_search",
+                    }:
+                        counts["tool_items"] += 1
+                        tool_item_types.add(item_type)
+                    elif isinstance(item_type, str):
+                        counts["non_tool_items"] += 1
+        except OSError:
+            pass
+
+        tool_calls = metadata.get("tool_calls")
+        complete_zero_tool_audit = (
+            isinstance(tool_calls, dict)
+            and tool_calls.get("available") is True
+            and tool_calls.get("complete") is True
+            and tool_calls.get("total") == 0
+        )
+        single_turn_observed = (
+            counts["thread_started"] == 1
+            and len(thread_ids) == 1
+            and counts["turn_started"] == 1
+            and counts["turn_completed"] == 1
+            and counts["turn_failed"] == 0
+            and final_message_present
+        )
+        tool_free_observed = counts["tool_items"] == 0 and complete_zero_tool_audit
+        model_request_count_visible = len(request_audits) == 1 and request_audits[0][0]
+        model_requests = request_audits[0][1] if model_request_count_visible else None
+        metadata.update(
+            {
+                "one_shot": False,
+                "single_turn": True,
+                "tool_free_requested": True,
+                "model_request_count_visible": model_request_count_visible,
+                "model_request_count_source": "codex_rollout_token_count" if model_request_count_visible else None,
+                "model_requests": model_requests,
+                "protocol_counts": counts,
+                "observed_thread_ids": sorted(thread_ids),
+                "observed_tool_item_types": sorted(tool_item_types),
+                "final_message_present": final_message_present,
+                "single_turn_observed": single_turn_observed,
+                "tool_free_observed": tool_free_observed,
+                "single_turn_tool_free_observed": single_turn_observed and tool_free_observed,
+                "one_model_request_observed": model_requests == 1,
+                "one_shot_approximation_observed": (
+                    single_turn_observed and tool_free_observed and model_requests == 1
+                ),
+            }
+        )
+        return metadata
+
+    def materialize_solution(self, jsonl_path: str, destination: str) -> bool:
+        last_message = Path(jsonl_path).with_name("codex_last_message.txt")
+        try:
+            response = last_message.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            return False
+        if not response.strip():
+            return False
+
+        solution = _unwrap_tla_fence(response)
+        target = Path(destination)
+        solution = _reconstruct_marked_solution(target, solution)
+        if solution is None:
+            return False
+
+        temporary: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=target.parent,
+                prefix=f".{target.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as stream:
+                temporary = stream.name
+                stream.write(solution)
+            os.replace(temporary, target)
+        except OSError:
+            if temporary is not None:
+                with suppress(OSError):
+                    os.unlink(temporary)
+            return False
+        return True

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -92,7 +92,17 @@ _USAGE_TOKEN_FIELDS = (
     "reasoning_output_tokens",
 )
 _COST_TIME_BACKENDS = frozenset(
-    {"codex", "claude_code", "copilot", "copilot_oneshot", "cursor", "litellm", "litellm_oneshot", "pi"}
+    {
+        "codex",
+        "codex_single_turn",
+        "claude_code",
+        "copilot",
+        "copilot_oneshot",
+        "cursor",
+        "litellm",
+        "litellm_oneshot",
+        "pi",
+    }
 )
 _RUNNER_OWNED_ACCOUNTING_KEYS = frozenset(
     {"usage", "input_tokens", "output_tokens", "time_secs", "equivalent_cost_usd"}
@@ -110,7 +120,7 @@ def _pricing_provider(backend: Backend) -> str | None:
         return None
     if backend.name.startswith("litellm"):
         return "litellm"
-    if backend.name == "codex":
+    if backend.name.startswith("codex"):
         uses_bedrock = getattr(backend, "_uses_bedrock", None)
         if callable(uses_bedrock) and uses_bedrock():
             return "amazon-bedrock"

--- a/src/evaluator/termination.py
+++ b/src/evaluator/termination.py
@@ -14,7 +14,7 @@ LIMIT — the model was working, it just ran out of time — reported as TIMEOUT
 never INFRA_ERROR), then runs a registry of INFRA RULES (criteria). Each rule
 inspects a ``TerminationContext`` and returns a reason if it fires, else
 ``None``; the first that fires wins. There is one rule per backend
-(:func:`codex_turn_failed`, :func:`claude_code_result_error`,
+(:func:`codex_turn_failed`, :func:`codex_single_turn_contract_error`, :func:`claude_code_result_error`,
 :func:`copilot_session_error`, :func:`cursor_result_error`,
 :func:`litellm_completion_error`, :func:`pi_run_failed`), each branching on
 ``ctx.backend`` to read its own event vocabulary, plus one backend-independent
@@ -161,7 +161,7 @@ def codex_turn_failed(ctx: TerminationContext) -> str | None:
     A run that hit a transient error mid-way but recovered and completed a turn
     is NOT flagged.
     """
-    if ctx.backend != "codex":
+    if ctx.backend not in {"codex", "codex_single_turn"}:
         return None
     events = ctx.events()
     if not events:
@@ -177,6 +177,59 @@ def codex_turn_failed(ctx: TerminationContext) -> str | None:
         return TerminationReason.INFRA_ERROR
     if last_terminal is None:
         return TerminationReason.INFRA_ERROR
+    return None
+
+
+def codex_single_turn_contract_error(ctx: TerminationContext) -> str | None:
+    """Require one rollout-audited, tool-free request in one Codex turn."""
+
+    if ctx.backend != "codex_single_turn":
+        return None
+    events = ctx.events()
+    if not ctx.event_stream_valid() or not events:
+        return TerminationReason.INFRA_ERROR
+
+    starts = [event for event in events if event.get("type") == "tlaps.codex_child_usage.started"]
+    audits = [event for event in events if event.get("type") == "tlaps.codex_child_usage"]
+    threads = [event.get("thread_id") for event in events if event.get("type") == "thread.started"]
+    if len(starts) != 1 or len(audits) != 1 or len(threads) != 1:
+        return TerminationReason.INFRA_ERROR
+    if events[0] is not starts[0] or events[-1] is not audits[0]:
+        return TerminationReason.INFRA_ERROR
+
+    version = starts[0].get("version")
+    audit = audits[0]
+    if not isinstance(version, int) or isinstance(version, bool) or version <= 0 or audit.get("version") != version:
+        return TerminationReason.INFRA_ERROR
+    thread_id = threads[0]
+    if not isinstance(thread_id, str) or not thread_id or audit.get("root_thread_id") != thread_id:
+        return TerminationReason.INFRA_ERROR
+    if audit.get("complete") is not True or audit.get("warning_codes") != [] or audit.get("child_count") != 0:
+        return TerminationReason.INFRA_ERROR
+    requests = audit.get("requests")
+    if not isinstance(requests, list) or len(requests) != 1 or not isinstance(requests[0], dict):
+        return TerminationReason.INFRA_ERROR
+
+    tool_calls = audit.get("tool_calls")
+    if not isinstance(tool_calls, dict):
+        return TerminationReason.INFRA_ERROR
+    if (
+        tool_calls.get("available") is not True
+        or tool_calls.get("complete") is not True
+        or tool_calls.get("is_lower_bound") is not False
+        or tool_calls.get("warnings") != []
+        or any(tool_calls.get(field) != 0 for field in ("total", "tlaps", "tlc", "apalache", "other"))
+    ):
+        return TerminationReason.INFRA_ERROR
+
+    allowed_items = {"agent_message", "reasoning", "error"}
+    for event in events:
+        event_type = event.get("type")
+        if not isinstance(event_type, str) or not event_type.startswith("item."):
+            continue
+        item = event.get("item")
+        if not isinstance(item, dict) or item.get("type") not in allowed_items:
+            return TerminationReason.INFRA_ERROR
     return None
 
 
@@ -457,6 +510,7 @@ def startup_error_snippet(ctx: TerminationContext) -> str:
 # fires. This list IS the extension point.
 INFRA_RULES: list[Rule] = [
     codex_turn_failed,
+    codex_single_turn_contract_error,
     claude_code_result_error,
     copilot_session_error,
     cursor_result_error,

--- a/tests/evaluator/test_agent_skills.py
+++ b/tests/evaluator/test_agent_skills.py
@@ -26,7 +26,7 @@ SUPPORTED_BACKENDS = [
     ("litellm", ".agents/skills"),
     ("pi", ".agents/skills"),
 ]
-UNSUPPORTED_BACKENDS = ["copilot_oneshot", "litellm_oneshot"]
+UNSUPPORTED_BACKENDS = ["codex_single_turn", "copilot_oneshot", "litellm_oneshot"]
 BENCHMARK = "---- MODULE Task ----\nTHEOREM Goal == TRUE\nPROOF OBVIOUS\n====\n"
 
 

--- a/tests/evaluator/test_codex_single_turn.py
+++ b/tests/evaluator/test_codex_single_turn.py
@@ -1,0 +1,238 @@
+"""Codex CLI single-turn backend contract."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from evaluator.backends import get_backend, list_backends
+from evaluator.backends.codex_single_turn import CodexSingleTurnBackend
+from evaluator.backends.codex_usage_wrapper import CODEX_CHILD_USAGE_VERSION
+
+MODULE = "---- MODULE Example ----\nTHEOREM Target == TRUE\nPROOF OBVIOUS\n====\n"
+
+
+class _Mode:
+    def build_one_shot_prompt(self, benchmark_path, dependencies):
+        return f"one shot: {benchmark_path}; dependencies={dependencies}"
+
+
+def _write_events(path: Path, *events: dict[str, object]) -> None:
+    path.write_text("".join(json.dumps(event) + "\n" for event in events))
+
+
+def _zero_tool_audit(thread_id: str = "root") -> dict[str, object]:
+    return {
+        "type": "tlaps.codex_child_usage",
+        "version": CODEX_CHILD_USAGE_VERSION,
+        "tool_calls_scope": "session_tree",
+        "root_thread_id": thread_id,
+        "child_count": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "cache_write_input_tokens": 0,
+        "output_tokens": 0,
+        "reasoning_output_tokens": 0,
+        "requests": [
+            {
+                "input_tokens": 10,
+                "cached_input_tokens": 0,
+                "cache_write_input_tokens": 0,
+                "output_tokens": 5,
+                "reasoning_output_tokens": 0,
+                "model": "gpt-5.5",
+                "provider": "openai",
+            }
+        ],
+        "complete": True,
+        "warning_codes": [],
+        "tool_calls": {
+            "total": 0,
+            "tlaps": 0,
+            "tlc": 0,
+            "apalache": 0,
+            "other": 0,
+            "available": True,
+            "complete": True,
+            "is_lower_bound": False,
+            "warnings": [],
+        },
+    }
+
+
+def _completed_stream(path: Path, *items: dict[str, object]) -> None:
+    _write_events(
+        path,
+        {"type": "tlaps.codex_child_usage.started", "version": CODEX_CHILD_USAGE_VERSION},
+        {"type": "thread.started", "thread_id": "root"},
+        {"type": "turn.started"},
+        *items,
+        {"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 5}},
+        _zero_tool_audit(),
+    )
+
+
+def test_registry_exposes_codex_single_turn_backend():
+    assert "codex_single_turn" in list_backends()
+    assert isinstance(get_backend("codex_single_turn", model="gpt-5.6-sol"), CodexSingleTurnBackend)
+
+
+def test_command_is_read_only_tool_free_single_codex_turn(tmp_path):
+    backend = CodexSingleTurnBackend(model="gpt-5.6-sol")
+    backend.set_reasoning_effort("medium")
+
+    command = backend.build_command("/workspace", "/results")
+
+    assert command[:5] == ["python3", "/opt/codex_usage_wrapper.py", "--", "codex", "exec"]
+    assert command[-1] == "-"
+    assert command.count("exec") == 1
+    assert command[command.index("--sandbox") + 1] == "read-only"
+    assert "--ignore-user-config" in command
+    assert "--ignore-rules" in command
+    assert "--dangerously-bypass-approvals-and-sandbox" not in command
+    assert "--ephemeral" not in command
+    assert 'approval_policy="never"' in command
+    assert 'web_search="disabled"' in command
+    assert "agents.enabled=false" in command
+    assert "apps._default.enabled=false" in command
+    assert "model_reasoning_effort=medium" in command
+    disabled = {command[index + 1] for index, value in enumerate(command[:-1]) if value == "--disable"}
+    assert {
+        "shell_tool",
+        "unified_exec",
+        "code_mode",
+        "code_mode_host",
+        "code_mode_only",
+        "code_mode_buffered_exec",
+        "multi_agent",
+        "multi_agent_v2",
+        "apps",
+        "browser_use",
+        "computer_use",
+        "image_generation",
+        "view_image",
+        "goals",
+        "tool_suggest",
+    } <= disabled
+
+    native = backend.build_command(str(tmp_path), str(tmp_path / "results"))
+    assert native[0] == sys.executable
+    assert Path(native[1]).name == "codex_usage_wrapper.py"
+
+
+def test_backend_uses_one_shot_prompt_and_disables_continuations():
+    backend = CodexSingleTurnBackend()
+
+    prompt = backend.build_prompt(_Mode(), "/tmp/Task.tla", ["/tmp/Model.tla"], "Task.tla", "tlapm", "lib")
+    metadata = backend.initial_result_metadata()
+
+    assert prompt == (
+        "Do not call or suggest any tools. Use only the target and context embedded below, "
+        "and return the requested module directly.\n\n"
+        "one shot: /tmp/Task.tla; dependencies=['/tmp/Model.tla']"
+    )
+    assert backend.approach == "single_turn_tool_free"
+    assert backend.project_skills_dir is None
+    assert backend.capabilities.model_preflight is True
+    assert backend.capabilities.max_continuations == 0
+    assert metadata["one_shot"] is False
+    assert metadata["single_turn"] is True
+    assert metadata["model_request_count_visible"] is False
+    assert metadata["model_requests"] is None
+
+
+def test_backend_rejects_bedrock_because_user_provider_config_is_ignored():
+    backend = CodexSingleTurnBackend(model="openai.gpt-5.5")
+
+    assert backend.check_auth() == (
+        "codex_single_turn: Amazon Bedrock models are unsupported; use an OpenAI Codex model"
+    )
+
+
+def test_protocol_audit_accepts_multiple_messages_with_one_tool_free_turn(tmp_path):
+    output = tmp_path / "output.jsonl"
+    _completed_stream(
+        output,
+        {"type": "item.completed", "item": {"id": "progress", "type": "agent_message", "text": "Working"}},
+        {"type": "item.completed", "item": {"id": "final", "type": "agent_message", "text": MODULE}},
+    )
+    (tmp_path / "codex_last_message.txt").write_text(MODULE)
+
+    metadata = CodexSingleTurnBackend().parse_run_metadata(str(output))
+
+    assert metadata["protocol_counts"] == {
+        "thread_started": 1,
+        "turn_started": 1,
+        "turn_completed": 1,
+        "turn_failed": 0,
+        "agent_messages": 2,
+        "reasoning_items": 0,
+        "tool_items": 0,
+        "non_tool_items": 0,
+    }
+    assert metadata["tool_calls"]["total"] == 0
+    assert metadata["tool_calls"]["complete"] is True
+    assert metadata["single_turn_observed"] is True
+    assert metadata["tool_free_observed"] is True
+    assert metadata["single_turn_tool_free_observed"] is True
+    assert metadata["model_request_count_visible"] is True
+    assert metadata["model_request_count_source"] == "codex_rollout_token_count"
+    assert metadata["model_requests"] == 1
+    assert metadata["one_model_request_observed"] is True
+    assert metadata["one_shot_approximation_observed"] is True
+
+
+def test_protocol_audit_rejects_observed_tool_item(tmp_path):
+    output = tmp_path / "output.jsonl"
+    _completed_stream(
+        output,
+        {
+            "type": "item.completed",
+            "item": {"id": "command", "type": "command_execution", "command": "pwd"},
+        },
+        {"type": "item.completed", "item": {"id": "final", "type": "agent_message", "text": MODULE}},
+    )
+    (tmp_path / "codex_last_message.txt").write_text(MODULE)
+
+    metadata = CodexSingleTurnBackend().parse_run_metadata(str(output))
+
+    assert metadata["protocol_counts"]["tool_items"] == 1
+    assert metadata["observed_tool_item_types"] == ["command_execution"]
+    assert metadata["tool_free_observed"] is False
+    assert metadata["single_turn_tool_free_observed"] is False
+
+
+def test_code_mode_disabled_notice_is_not_a_tool_dispatch(tmp_path):
+    output = tmp_path / "output.jsonl"
+    _completed_stream(
+        output,
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "notice",
+                "type": "error",
+                "message": "Code Mode is unavailable because code-mode host is disabled.",
+            },
+        },
+        {"type": "item.completed", "item": {"id": "final", "type": "agent_message", "text": MODULE}},
+    )
+    (tmp_path / "codex_last_message.txt").write_text(MODULE)
+
+    metadata = CodexSingleTurnBackend().parse_run_metadata(str(output))
+
+    assert metadata["protocol_counts"]["non_tool_items"] == 1
+    assert metadata["protocol_counts"]["tool_items"] == 0
+    assert metadata["tool_free_observed"] is True
+    assert metadata["one_shot_approximation_observed"] is True
+
+
+def test_materialize_solution_uses_only_codex_final_message(tmp_path):
+    output = tmp_path / "output.jsonl"
+    output.write_text('{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}\n')
+    (tmp_path / "codex_last_message.txt").write_text(f"```tla\n{MODULE}```\n")
+    destination = tmp_path / "Example.tla"
+    destination.write_text("unchanged")
+
+    assert CodexSingleTurnBackend().materialize_solution(str(output), str(destination)) is True
+    assert destination.read_text() == MODULE

--- a/tests/evaluator/test_cost.py
+++ b/tests/evaluator/test_cost.py
@@ -614,7 +614,17 @@ def test_public_price_preflight_normalizes_cursor_default_model():
 
 @pytest.mark.parametrize(
     "backend_name",
-    ["codex", "claude_code", "copilot", "copilot_oneshot", "cursor", "litellm", "litellm_oneshot", "pi"],
+    [
+        "codex",
+        "codex_single_turn",
+        "claude_code",
+        "copilot",
+        "copilot_oneshot",
+        "cursor",
+        "litellm",
+        "litellm_oneshot",
+        "pi",
+    ],
 )
 def test_supported_backends_require_public_price_preflight(backend_name):
     assert get_backend(backend_name).requires_public_pricing

--- a/tests/evaluator/test_reasoning_effort.py
+++ b/tests/evaluator/test_reasoning_effort.py
@@ -13,6 +13,7 @@ from evaluator.backends import get_backend, litellm_agent
 
 EXPECTED_EFFORT_VALUES = {
     "codex": ("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"),
+    "codex_single_turn": ("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"),
     "claude_code": ("low", "medium", "high", "xhigh", "max"),
     "copilot": ("none", "minimal", "low", "medium", "high", "xhigh", "max"),
     "copilot_oneshot": ("low", "medium", "high", "xhigh"),
@@ -37,6 +38,7 @@ def _has_option(command: list[str], option: str, value: str) -> bool:
     ("backend_name", "option", "value"),
     [
         ("codex", "-c", "model_reasoning_effort=low"),
+        ("codex_single_turn", "-c", "model_reasoning_effort=low"),
         ("claude_code", "--effort", "low"),
         ("copilot", "--effort", "low"),
         ("litellm", "--reasoning-effort", "low"),

--- a/tests/evaluator/test_termination.py
+++ b/tests/evaluator/test_termination.py
@@ -24,6 +24,7 @@ from evaluator.termination import (
     agent_startup_failure,
     classify,
     claude_code_result_error,
+    codex_single_turn_contract_error,
     codex_turn_failed,
     copilot_session_error,
     cursor_result_error,
@@ -170,6 +171,71 @@ def test_turn_failed_is_infra(tmp_path):
 def test_turn_completed_is_ok(tmp_path):
     p = _write_jsonl(tmp_path / "genuine.jsonl", GENUINE_STREAM)
     assert classify(_ctx(p)) == TerminationReason.OK
+
+
+def test_codex_single_turn_uses_codex_terminal_contract(tmp_path):
+    audit_start = {"type": "tlaps.codex_child_usage.started", "version": 5}
+    audit = {
+        "type": "tlaps.codex_child_usage",
+        "version": 5,
+        "root_thread_id": "t2",
+        "child_count": 0,
+        "complete": True,
+        "warning_codes": [],
+        "requests": [{"input_tokens": 100, "output_tokens": 10}],
+        "tool_calls": {
+            "total": 0,
+            "tlaps": 0,
+            "tlc": 0,
+            "apalache": 0,
+            "other": 0,
+            "available": True,
+            "complete": True,
+            "is_lower_bound": False,
+            "warnings": [],
+        },
+    }
+    failed = _write_jsonl(tmp_path / "single-turn-infra.jsonl", [audit_start, *INFRA_STREAM, audit])
+    completed = _write_jsonl(tmp_path / "single-turn-genuine.jsonl", [audit_start, *GENUINE_STREAM, audit])
+
+    assert classify(_ctx(failed, backend="codex_single_turn", approach="single_turn_tool_free")) == (
+        TerminationReason.INFRA_ERROR
+    )
+    assert classify(_ctx(completed, backend="codex_single_turn", approach="single_turn_tool_free")) == (
+        TerminationReason.OK
+    )
+
+
+def test_codex_single_turn_contract_excludes_multiple_model_requests(tmp_path):
+    events = [
+        {"type": "tlaps.codex_child_usage.started", "version": 5},
+        *GENUINE_STREAM,
+        {
+            "type": "tlaps.codex_child_usage",
+            "version": 5,
+            "root_thread_id": "t2",
+            "child_count": 0,
+            "complete": True,
+            "warning_codes": [],
+            "requests": [{"input_tokens": 50}, {"input_tokens": 50}],
+            "tool_calls": {
+                "total": 0,
+                "tlaps": 0,
+                "tlc": 0,
+                "apalache": 0,
+                "other": 0,
+                "available": True,
+                "complete": True,
+                "is_lower_bound": False,
+                "warnings": [],
+            },
+        },
+    ]
+    path = _write_jsonl(tmp_path / "single-turn-retried-request.jsonl", events)
+    ctx = _ctx(path, backend="codex_single_turn", approach="single_turn_tool_free")
+
+    assert codex_single_turn_contract_error(ctx) == TerminationReason.INFRA_ERROR
+    assert classify(ctx) == TerminationReason.INFRA_ERROR
 
 
 def test_recovered_midrun_error_is_ok(tmp_path):
@@ -424,6 +490,7 @@ def test_same_truncation_without_timeout_is_still_infra(tmp_path):
 def test_registry_is_the_extension_point():
     # The interface contract: classify() runs INFRA_RULES in order.
     assert codex_turn_failed in INFRA_RULES
+    assert codex_single_turn_contract_error in INFRA_RULES
     assert claude_code_result_error in INFRA_RULES
     assert copilot_session_error in INFRA_RULES
     assert cursor_result_error in INFRA_RULES


### PR DESCRIPTION
## Summary

- add a subscription-compatible `codex_single_turn` backend using official `codex exec`
- reuse the one-shot prompt and final-module materialization while disabling skills, continuations, and Codex tool surfaces
- require one rollout-audited model request, one completed turn, no child agents, and zero tool calls for capability scoring
- record protocol, usage, cost, and approximation metadata and document ChatGPT subscription usage