### PR TITLE
Make specification pass rate primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ uv run tlaps-bench run --jobs 10 --timeout 7200
 uv run tlaps-bench run --mode proof-from-scratch --jobs 10
 ```
 
-Each run writes `results.json` and `summary.md` (with specification-macro as the
-primary score and task-micro as a diagnostic); `uv run tlaps-bench score`
-(re)computes and compares scores. See the [scoring documentation](docs/USAGE.md#tlaps-bench-score)
+Each run writes `results.json` and `summary.md` (with specification pass rate as
+the primary score and task-level pass rate as a secondary metric); `uv run
+tlaps-bench score` (re)computes and compares scores. See the [scoring documentation](docs/USAGE.md#tlaps-bench-score)
 for the grouping rule and formulas. Use `--resume` with a fixed `--output-dir` to
 skip tasks already recorded as PASS, and `--force-build` to rebuild the image
 after changing source.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -264,6 +264,8 @@ uv run tlaps-bench score results/proof-from-scratch/pi/20260626_220712/results.j
 uv run tlaps-bench score results/proof-completion/*/results.json
 ```
 
+Strict comparisons require every run to contain the same applicable task IDs.
+
 Each manifest entry maps its mode-relative task ID to the originating `.tla` path under `source/` (`spec_id`). Tasks from the same source module form one scoring group.
 
 The default primary score is the specification pass rate: a represented specification passes only when all of its selected tasks pass.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -266,20 +266,20 @@ uv run tlaps-bench score results/proof-completion/*/results.json
 
 Each manifest entry maps its mode-relative task ID to the originating `.tla` path under `source/` (`spec_id`). Tasks from the same source module form one scoring group.
 
-The default primary score gives every represented source specification equal weight while preserving partial credit:
+The default primary score is the specification pass rate: a represented specification passes only when all of its selected tasks pass.
 
 ```text
-spec_score = passed selected tasks / applicable selected tasks
-overall_score = mean(spec_score)
+spec_pass = 1 if all applicable selected tasks pass, otherwise 0
+overall_score = completed specifications / represented specifications
 ```
 
 Reports show three scores:
 
-- **Specification-macro** (primary): the average above.
-- **Task-micro**: passed applicable tasks divided by all applicable tasks.
-- **All-leaves-complete**: specifications whose selected tasks all passed.
+- **Specification pass rate** (primary, all leaves complete): specifications whose selected tasks all passed.
+- **Task-level pass rate** (secondary): passed applicable tasks divided by all applicable tasks.
+- **Specification-macro** (secondary): the average per-specification task pass rate, preserving partial credit.
 
-`SKIP`, infrastructure-cut, and removed tasks are excluded and reported separately. Pass `--scoring equal` for the legacy task-micro-primary output.
+`SKIP`, infrastructure-cut, and removed tasks are excluded and reported separately. Pass `--scoring equal` for the legacy task-level-only output.
 
 ### `tlaps-bench validate`
 

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -1140,6 +1140,11 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
             continuation_results = results
         else:
             score_lines, specification_score = specification_score_lines(results, specification_ids)
+            if total < total_benchmarks:
+                score_lines[0] = (
+                    "**Specification pass rate**: pending until the run completes "
+                    f"({total}/{total_benchmarks} tasks finished)"
+                )
             lines.extend(score_lines)
             n_pass = specification_score.tasks_passed
             continuation_results = applicable_manifest_results(results, specification_ids)

--- a/src/evaluator/score.py
+++ b/src/evaluator/score.py
@@ -33,12 +33,10 @@ infra/quota before resolving is interrupted, not failed: like a non-genuine
 first attempt it is excluded from the continuation rate and reported separately
 (see ``continuation_interrupted``).
 
-The primary score gives every represented source specification equal weight.
-For each specification, it computes the fraction of applicable selected tasks
-that passed, then averages those fractions. This preserves partial credit while
-preventing specifications with many extracted tasks from dominating the score.
-The historical task-micro pass rate and the fraction of specifications whose
-selected tasks all passed remain visible as secondary diagnostics.
+The primary score is the strict specification pass rate. A represented source
+specification passes only when all of its applicable selected tasks pass. The
+task-level pass rate and specification-macro partial-credit average remain
+visible as secondary diagnostics.
 
 The legacy pluggable task scorer assigns a non-negative weight to each task;
 the score of a group of tasks is
@@ -83,8 +81,9 @@ SpecificationKey = tuple[str, str]
 
 @dataclass(frozen=True)
 class SpecificationScore:
-    """Primary and secondary scores over one selected result cohort."""
+    """Specification pass rate and secondary diagnostics for one cohort."""
 
+    specification_pass_pct: float
     specification_macro_pct: float
     task_micro_pct: float
     tasks_passed: int
@@ -201,7 +200,7 @@ def specification_equal_score(
     specification_ids: Mapping[SpecificationKey, str],
     passed: Callable[[dict], bool] = is_pass,
 ) -> SpecificationScore:
-    """Score selected, applicable tasks with equal total weight per specification.
+    """Score selected, applicable tasks at specification and task levels.
 
     A result is applicable when its ``(mode, benchmark)`` identity exists in the
     active versioned manifest. Results for tasks removed from a later manifest
@@ -238,7 +237,11 @@ def specification_equal_score(
     complete_specifications = sum(
         1 for grouped in by_specification.values() if all(passed(result) for result in grouped)
     )
+    specification_pass_pct = (
+        100.0 * complete_specifications / represented_specifications if represented_specifications else 0.0
+    )
     return SpecificationScore(
+        specification_pass_pct=specification_pass_pct,
         specification_macro_pct=specification_macro_pct,
         task_micro_pct=task_micro_pct,
         tasks_passed=tasks_passed,
@@ -273,17 +276,13 @@ def specification_score_lines(
         task_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
 
     specification_word = "specification" if score.represented_specifications == 1 else "specifications"
-    complete_pct = (
-        100.0 * score.complete_specifications / score.represented_specifications
-        if score.represented_specifications
-        else 0.0
-    )
     lines = [
+        f"**Specification pass rate (all leaves complete)**: "
+        f"{score.complete_specifications}/{score.represented_specifications} "
+        f"{specification_word} ({score.specification_pass_pct:.1f}%)",
+        task_line,
         f"**Specification-macro pass rate**: {score.specification_macro_pct:.1f}% "
         f"across {score.represented_specifications} {specification_word}",
-        task_line,
-        f"**All leaves complete**: {score.complete_specifications}/{score.represented_specifications} "
-        f"{specification_word} ({complete_pct:.1f}%)",
     ]
     if score.non_applicable_results:
         lines.append(
@@ -507,7 +506,7 @@ def comparison_md(
         lines += [f"**Scoring**: {scoring_name} (weighted)", ""]
     show_equivalent_cost = any(_has_equivalent_cost(run["results"]) for run in runs)
     score_columns = (
-        "Specification macro | Task micro | All leaves complete"
+        "Specification pass rate | Task pass rate | Specification macro"
         if specification_ids is not None
         else "Pass % | Passed/Total"
     )
@@ -565,10 +564,11 @@ def comparison_md(
             if specification_score.non_applicable_results:
                 score_notes += f" (+{specification_score.non_applicable_results} non-applicable)"
             score_cells = (
-                f"{specification_score.specification_macro_pct:.1f}% | "
-                f"{n_pass}/{n_total} ({specification_score.task_micro_pct:.1f}%){score_notes} | "
                 f"{specification_score.complete_specifications}/"
-                f"{specification_score.represented_specifications}"
+                f"{specification_score.represented_specifications} "
+                f"({specification_score.specification_pass_pct:.1f}%) | "
+                f"{n_pass}/{n_total} ({specification_score.task_micro_pct:.1f}%){score_notes} | "
+                f"{specification_score.specification_macro_pct:.1f}%"
             )
         row = f"| {run['id']} | {run['backend']} | {run['mode']} | {score_cells} | {in_tok:,}/{out_tok:,} | "
         if show_equivalent_cost:
@@ -595,14 +595,17 @@ def comparison_md(
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="tlaps-bench score",
-        description="Score benchmark results (specification macro plus diagnostics) from results.json.",
+        description="Score benchmark results (strict specification pass rate plus diagnostics) from results.json.",
     )
     parser.add_argument("paths", nargs="+", help="One or more results.json files or run directories")
     parser.add_argument(
         "--scoring",
         default=SPECIFICATION_EQUAL,
         choices=[SPECIFICATION_EQUAL, *sorted(SCORERS)],
-        help="Scoring scheme (default: specification-equal; 'equal' retains legacy task-micro scoring)",
+        help=(
+            "Scoring scheme (default: specification-equal with strict specification pass rate primary; "
+            "'equal' retains legacy task-level scoring)"
+        ),
     )
     args = parser.parse_args()
 

--- a/src/evaluator/score.py
+++ b/src/evaluator/score.py
@@ -501,6 +501,20 @@ def comparison_md(
     specification_ids: Mapping[SpecificationKey, str] | None = None,
 ) -> str:
     """Markdown comparison table across several runs (one row per run)."""
+    if specification_ids is not None and runs:
+        reference = {
+            key for result in runs[0]["results"] if (key := _result_specification_key(result)) in specification_ids
+        }
+        for run in runs[1:]:
+            cohort = {
+                key for result in run["results"] if (key := _result_specification_key(result)) in specification_ids
+            }
+            if cohort != reference:
+                raise ValueError(
+                    "cannot compare runs with different applicable task cohorts: "
+                    f"{runs[0]['id']} has {len(reference)} task IDs, {run['id']} has {len(cohort)}"
+                )
+
     lines = [f"# Comparison — {len(runs)} runs", ""]
     if scoring_name not in {"equal", SPECIFICATION_EQUAL}:
         lines += [f"**Scoring**: {scoring_name} (weighted)", ""]
@@ -627,10 +641,16 @@ def main() -> int:
             sys.stderr.write(f"tlaps-bench score: {e}\n")
             return 1
 
-    if len(runs) == 1:
-        print(scorecard_md(runs[0], weight, args.scoring, specification_ids))
-    else:
-        print(comparison_md(runs, weight, args.scoring, specification_ids))
+    try:
+        rendered = (
+            scorecard_md(runs[0], weight, args.scoring, specification_ids)
+            if len(runs) == 1
+            else comparison_md(runs, weight, args.scoring, specification_ids)
+        )
+    except ValueError as e:
+        sys.stderr.write(f"tlaps-bench score: {e}\n")
+        return 1
+    print(rendered)
     return 0
 
 

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -211,7 +211,7 @@ def test_summary_excludes_non_genuine_results_from_pass_rate(tmp_path):
     assert "INFRA_ERROR (excluded — re-run)" in summary
 
 
-def test_summary_uses_specification_macro_as_primary_for_manifest_suites(tmp_path):
+def test_summary_uses_strict_specification_pass_rate_as_primary_for_manifest_suites(tmp_path):
     results = [
         _result("A/One.tla", "PASS", mode="proof-completion"),
         _result("A/Two.tla", "FAIL", mode="proof-completion"),
@@ -234,9 +234,13 @@ def test_summary_uses_specification_macro_as_primary_for_manifest_suites(tmp_pat
     )
 
     summary = (tmp_path / "summary.md").read_text()
-    assert "**Specification-macro pass rate**: 75.0% across 2 specifications" in summary
-    assert "**Task-micro pass rate**: 2/3 (66.7%)" in summary
-    assert "**All leaves complete**: 1/2 specifications (50.0%)" in summary
+    primary = "**Specification pass rate (all leaves complete)**: 1/2 specifications (50.0%)"
+    task_level = "**Task-micro pass rate**: 2/3 (66.7%)"
+    specification_macro = "**Specification-macro pass rate**: 75.0% across 2 specifications"
+    assert primary in summary
+    assert task_level in summary
+    assert specification_macro in summary
+    assert summary.index(primary) < summary.index(task_level) < summary.index(specification_macro)
     assert "**Non-applicable results**: 1 not present in the active manifest (excluded)" in summary
 
 

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -244,6 +244,28 @@ def test_summary_uses_strict_specification_pass_rate_as_primary_for_manifest_sui
     assert "**Non-applicable results**: 1 not present in the active manifest (excluded)" in summary
 
 
+def test_incomplete_summary_defers_strict_specification_pass_rate(tmp_path):
+    results = [_result("A/One.tla", "PASS", mode="proof-completion")]
+    specification_ids = {
+        ("proof-completion", "A/One.tla"): "A/A.tla",
+        ("proof-completion", "A/Two.tla"): "A/A.tla",
+    }
+
+    runner.update_summary(
+        results,
+        str(tmp_path),
+        total_benchmarks=2,
+        backend_name="copilot",
+        mode_name="proof-completion",
+        specification_ids=specification_ids,
+    )
+
+    summary = (tmp_path / "summary.md").read_text()
+    assert "**Specification pass rate**: pending until the run completes (1/2 tasks finished)" in summary
+    assert "**Specification pass rate (all leaves complete)**" not in summary
+    assert "**Task-micro pass rate**: 1/1 (100.0%)" in summary
+
+
 def test_summary_reports_time_and_equivalent_cost_without_zero_filling(tmp_path):
     results = [
         _result("priced.tla", "PASS", time_secs=1.25, equivalent_cost_usd=0.125),

--- a/tests/evaluator/test_score.py
+++ b/tests/evaluator/test_score.py
@@ -175,6 +175,30 @@ def test_specification_comparison_shows_primary_and_secondary_scores():
     assert "| one | codex | proof-completion | 1/2 (50.0%) | 2/3 (66.7%) | 75.0% |" in md
 
 
+def test_specification_comparison_rejects_different_task_cohorts():
+    specification_ids = scope_specification_ids("proof-completion", {"A/One.tla": "A/A.tla", "A/Two.tla": "A/A.tla"})
+    runs = [
+        {
+            "id": "one",
+            "backend": "codex",
+            "mode": "proof-completion",
+            "results": [_r("PASS", mode="proof-completion", benchmark="A/One.tla")],
+        },
+        {
+            "id": "two",
+            "backend": "codex",
+            "mode": "proof-completion",
+            "results": [
+                _r("PASS", mode="proof-completion", benchmark="A/One.tla"),
+                _r("PASS", mode="proof-completion", benchmark="A/Two.tla"),
+            ],
+        },
+    ]
+
+    with pytest.raises(ValueError, match="different applicable task cohorts"):
+        comparison_md(runs, EQUAL, SPECIFICATION_EQUAL, specification_ids)
+
+
 def test_scorecard_module_breakdown_and_no_cheating_row():
     results = [_r("PASS", module="A"), _r("CHEATING", module="A"), _r("PASS", module="B")]
     run = {"path": "x/results.json", "id": "x", "backend": "codex", "mode": "proof-completion", "results": results}
@@ -652,6 +676,28 @@ def test_main_multiple_prints_comparison(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["tlaps-bench score", d1, d2])
     assert main() == 0
     assert "# Comparison — 2 runs" in capsys.readouterr().out
+
+
+def test_main_reports_mismatched_comparison_cohorts(tmp_path, monkeypatch, capsys):
+    d1 = _write_run(
+        tmp_path,
+        "run1",
+        [_r("PASS", backend="codex", mode="proof-completion", benchmark="A/One.tla")],
+    )
+    d2 = _write_run(
+        tmp_path,
+        "run2",
+        [
+            _r("PASS", backend="codex", mode="proof-completion", benchmark="A/One.tla"),
+            _r("PASS", backend="codex", mode="proof-completion", benchmark="A/Two.tla"),
+        ],
+    )
+    specification_ids = scope_specification_ids("proof-completion", {"A/One.tla": "A/A.tla", "A/Two.tla": "A/A.tla"})
+    monkeypatch.setattr("evaluator.score.load_current_specification_ids", lambda _modes: specification_ids)
+    monkeypatch.setattr(sys, "argv", ["tlaps-bench score", d1, d2])
+
+    assert main() == 1
+    assert "different applicable task cohorts" in capsys.readouterr().err
 
 
 def test_main_missing_path_exits_1(tmp_path, monkeypatch, capsys):

--- a/tests/evaluator/test_score.py
+++ b/tests/evaluator/test_score.py
@@ -1,10 +1,10 @@
 """Scoring from results.json.
 
 A task passes iff check_verdict == "PASS"; CHEATING/FAIL/TIMEOUT/ERROR all count
-as not passed, and CHEATING is never shown as its own category. Specification
-macro is primary; the legacy equal-task scorer remains a diagnostic and CLI
-option. SKIP is dropped from scoring entirely (neither passed nor failed) and
-only reported as a side count.
+as not passed, and CHEATING is never shown as its own category. Strict
+specification pass rate is primary; task-level and specification-macro scores
+remain diagnostics. SKIP is dropped from scoring entirely (neither passed nor
+failed) and only reported as a side count.
 
 Run: PYTHONPATH=src python3 -m pytest tests/evaluator/test_score.py
 """
@@ -83,6 +83,7 @@ def test_specification_equal_preserves_partial_credit_without_task_count_bias():
 
     score = specification_equal_score(results, specification_ids)
 
+    assert score.specification_pass_pct == 50.0
     assert score.specification_macro_pct == 75.0  # mean(1/2, 1/1)
     assert score.task_micro_pct == pytest.approx(66.6667)
     assert (score.tasks_passed, score.applicable_tasks) == (2, 3)
@@ -120,7 +121,7 @@ def test_specification_equal_excludes_non_applicable_and_unscored_results():
     assert score.non_applicable_results == 1
 
 
-def test_specification_scorecard_keeps_both_secondary_diagnostics():
+def test_specification_scorecard_shows_strict_primary_before_secondary_diagnostics():
     specification_ids = scope_specification_ids(
         "proof-completion",
         {
@@ -138,9 +139,13 @@ def test_specification_scorecard_keeps_both_secondary_diagnostics():
 
     md = scorecard_md(run, EQUAL, SPECIFICATION_EQUAL, specification_ids)
 
-    assert "**Specification-macro pass rate**: 75.0% across 2 specifications" in md
-    assert "**Task-micro pass rate**: 2/3 (66.7%)" in md
-    assert "**All leaves complete**: 1/2 specifications (50.0%)" in md
+    primary = "**Specification pass rate (all leaves complete)**: 1/2 specifications (50.0%)"
+    task_level = "**Task-micro pass rate**: 2/3 (66.7%)"
+    specification_macro = "**Specification-macro pass rate**: 75.0% across 2 specifications"
+    assert primary in md
+    assert task_level in md
+    assert specification_macro in md
+    assert md.index(primary) < md.index(task_level) < md.index(specification_macro)
     assert "## By module (task micro)" in md
     assert "| **Total** | **2** | **3** | **66.7%** |" in md
 
@@ -166,8 +171,8 @@ def test_specification_comparison_shows_primary_and_secondary_scores():
 
     md = comparison_md(runs, EQUAL, SPECIFICATION_EQUAL, specification_ids)
 
-    assert "| Run | Backend | Mode | Specification macro | Task micro | All leaves complete |" in md
-    assert "| one | codex | proof-completion | 75.0% | 2/3 (66.7%) | 1/2 |" in md
+    assert "| Run | Backend | Mode | Specification pass rate | Task pass rate | Specification macro |" in md
+    assert "| one | codex | proof-completion | 1/2 (50.0%) | 2/3 (66.7%) | 75.0% |" in md
 
 
 def test_scorecard_module_breakdown_and_no_cheating_row():
@@ -617,6 +622,7 @@ def test_main_single_prints_scorecard(tmp_path, monkeypatch, capsys):
     assert main() == 0
     out = capsys.readouterr().out
     assert "# Scorecard" in out
+    assert "**Specification pass rate (all leaves complete)**: 0/1 specification (0.0%)" in out
     assert "**Specification-macro pass rate**: 50.0% across 1 specification" in out
     assert "**Task-micro pass rate**: 1/2 (50.0%)" in out
 


### PR DESCRIPTION
Based on a recent Slack conversation and the resulting decision, benchmark scoring now uses the strict specification pass rate as the primary score.
