### PR TITLE
Add reference_proof_steps to Proof Completion manifest

### DIFF
--- a/benchmark/proof-completion/manifest.json
+++ b/benchmark/proof-completion/manifest.json
@@ -3,231 +3,268 @@
     "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_AllocateMutexScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 25
   },
   "Allocator/Allocator_AllocateTypeInvariant.tla": {
     "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_AllocateTypeInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Allocator/Allocator_InitMutex.tla": {
     "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_InitMutexScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Allocator/Allocator_InitTypeInvariant.tla": {
     "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_InitTypeInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Allocator/Allocator_NextMutex.tla": {
     "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_NextMutexScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Allocator/Allocator_NextTypeInvariant.tla": {
     "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_NextTypeInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "Allocator/Allocator_RequestMutexBis.tla": {
     "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_RequestMutexBisScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Allocator/Allocator_RequestTypeInvariant.tla": {
     "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_RequestTypeInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Allocator/Allocator_ReturnMutex.tla": {
     "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_ReturnMutexScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "Allocator/Allocator_ReturnTypeInvariant.tla": {
     "spec_id": "Allocator/Allocator.tla",
     "context": [
       "Allocator/Allocator_ReturnTypeInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_AfterPrime.tla": {
     "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_AfterPrimeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_GGIrreflexive.tla": {
     "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_GGIrreflexiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_InductiveInvariant.tla": {
     "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_InductiveInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 137
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_InitImpliesTypeOK.tla": {
     "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_InitImpliesTypeOKScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_InitInv.tla": {
     "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_InitInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_InvExclusion.tla": {
     "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_InvExclusionScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_Safety.tla": {
     "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_SafetyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "AtomicBakery/AtomicBakeryWithoutSMT_TypeOKInvariant.tla": {
     "spec_id": "AtomicBakery/AtomicBakeryWithoutSMT.tla",
     "context": [
       "AtomicBakery/AtomicBakeryWithoutSMTModel.tla",
       "AtomicBakery/AtomicBakeryWithoutSMT_TypeOKInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 21
   },
   "BubbleSort/BubbleSort_CompositionAssociative.tla": {
     "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_CompositionAssociativeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "BubbleSort/BubbleSort_CompositionOfPerms.tla": {
     "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_CompositionOfPermsScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "BubbleSort/BubbleSort_ExchangeAPerm.tla": {
     "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_ExchangeAPermScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "BubbleSort/BubbleSort_IdAPerm.tla": {
     "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IdAPermScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "BubbleSort/BubbleSort_IdIdentity.tla": {
     "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IdIdentityScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "BubbleSort/BubbleSort_IsPermOfExchange.tla": {
     "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IsPermOfExchangeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "BubbleSort/BubbleSort_IsPermOfReflexive.tla": {
     "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IsPermOfReflexiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "BubbleSort/BubbleSort_IsPermOfTransitive.tla": {
     "spec_id": "BubbleSort/BubbleSort.tla",
     "context": [
       "BubbleSort/BubbleSort_IsPermOfTransitiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "Cantor/Cantor10_Cantor.tla": {
     "spec_id": "Cantor/Cantor10.tla",
     "context": [
       "Cantor/Cantor10_CantorScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "Cantor/Cantor10_NoSetContainsAllValues.tla": {
     "spec_id": "Cantor/Cantor10.tla",
     "context": [
       "Cantor/Cantor10_NoSetContainsAllValuesScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "Cantor/Cantor1_cantor.tla": {
     "spec_id": "Cantor/Cantor1.tla",
     "context": [
       "Cantor/Cantor1_cantorScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "Cantor/Cantor2_cantor.tla": {
     "spec_id": "Cantor/Cantor2.tla",
     "context": [
       "Cantor/Cantor2_cantorScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "Cantor/Cantor3_cantor.tla": {
     "spec_id": "Cantor/Cantor3.tla",
     "context": [
       "Cantor/Cantor3_cantorScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 16
   },
   "Cantor/Cantor4_cantor.tla": {
     "spec_id": "Cantor/Cantor4.tla",
     "context": [
       "Cantor/Cantor4_cantorScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 14
   },
   "Cantor/Cantor5_cantor.tla": {
     "spec_id": "Cantor/Cantor5.tla",
     "context": [
       "Cantor/Cantor5_cantorScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "Cantor/Cantor6_cantor.tla": {
     "spec_id": "Cantor/Cantor6.tla",
     "context": [
       "Cantor/Cantor6_cantorScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "Cantor/Cantor7_cantor.tla": {
     "spec_id": "Cantor/Cantor7.tla",
     "context": [
       "Cantor/Cantor7_cantorScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "Cantor/Cantor8_Cantor.tla": {
     "spec_id": "Cantor/Cantor8.tla",
     "context": [
       "Cantor/Cantor8_CantorScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "Cantor/Cantor9_Cantor.tla": {
     "spec_id": "Cantor/Cantor9.tla",
     "context": [
       "Cantor/Cantor9_CantorScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "Consensus/Consensus_Invariance.tla": {
     "spec_id": "Consensus/Consensus.tla",
@@ -235,7 +272,8 @@
       "Consensus/ConsensusModel.tla",
       "Consensus/Consensus_InvarianceScaffold.tla",
       "Consensus/Sets.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "Consensus/PaxosProof_WFmsgs.tla": {
     "spec_id": "Consensus/PaxosProof.tla",
@@ -245,7 +283,8 @@
       "Consensus/PaxosTuple.tla",
       "Consensus/Sets.tla",
       "Consensus/Voting.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Consensus/PaxosProof_struct_lemma.tla": {
     "spec_id": "Consensus/PaxosProof.tla",
@@ -255,7 +294,8 @@
       "Consensus/PaxosTuple.tla",
       "Consensus/Sets.tla",
       "Consensus/Voting.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "Consensus/PaxosProof_typing.tla": {
     "spec_id": "Consensus/PaxosProof.tla",
@@ -265,7 +305,8 @@
       "Consensus/PaxosTuple.tla",
       "Consensus/Sets.tla",
       "Consensus/Voting.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "Consensus/Voting_AllSafeAtZero.tla": {
     "spec_id": "Consensus/Voting.tla",
@@ -274,7 +315,8 @@
       "Consensus/Sets.tla",
       "Consensus/VotingModel_2.tla",
       "Consensus/Voting_AllSafeAtZeroScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Consensus/Voting_ChoosableThm.tla": {
     "spec_id": "Consensus/Voting.tla",
@@ -283,7 +325,8 @@
       "Consensus/Sets.tla",
       "Consensus/VotingModel_2.tla",
       "Consensus/Voting_ChoosableThmScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Consensus/Voting_Consistent.tla": {
     "spec_id": "Consensus/Voting.tla",
@@ -292,7 +335,8 @@
       "Consensus/Sets.tla",
       "Consensus/VotingModel_2.tla",
       "Consensus/Voting_ConsistentScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "Consensus/Voting_Invariant.tla": {
     "spec_id": "Consensus/Voting.tla",
@@ -301,7 +345,8 @@
       "Consensus/Sets.tla",
       "Consensus/VotingModel_2.tla",
       "Consensus/Voting_InvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 36
   },
   "Consensus/Voting_OneVoteThm.tla": {
     "spec_id": "Consensus/Voting.tla",
@@ -310,7 +355,8 @@
       "Consensus/Sets.tla",
       "Consensus/VotingModel_2.tla",
       "Consensus/Voting_OneVoteThmScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Consensus/Voting_QuorumNonEmpty.tla": {
     "spec_id": "Consensus/Voting.tla",
@@ -319,7 +365,8 @@
       "Consensus/Sets.tla",
       "Consensus/VotingModel.tla",
       "Consensus/Voting_QuorumNonEmptyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Consensus/Voting_Refinement.tla": {
     "spec_id": "Consensus/Voting.tla",
@@ -328,7 +375,8 @@
       "Consensus/Sets.tla",
       "Consensus/VotingModel_2.tla",
       "Consensus/Voting_RefinementScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "Consensus/Voting_ShowsSafety.tla": {
     "spec_id": "Consensus/Voting.tla",
@@ -337,7 +385,8 @@
       "Consensus/Sets.tla",
       "Consensus/VotingModel_2.tla",
       "Consensus/Voting_ShowsSafetyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Consensus/Voting_VotesSafeImpliesConsistency.tla": {
     "spec_id": "Consensus/Voting.tla",
@@ -346,194 +395,224 @@
       "Consensus/Sets.tla",
       "Consensus/VotingModel_2.tla",
       "Consensus/Voting_VotesSafeImpliesConsistencyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "Data/GraphTheorem_AtLeastTwo.tla": {
     "spec_id": "Data/GraphTheorem.tla",
     "context": [
       "Data/GraphTheorem_AtLeastTwoScaffold.tla",
       "Data/Sets.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Data/GraphTheorem_EdgesAxiom.tla": {
     "spec_id": "Data/GraphTheorem.tla",
     "context": [
       "Data/GraphTheorem_EdgesAxiomScaffold.tla",
       "Data/Sets.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Data/SequencesTheorems_RemoveSeq.tla": {
     "spec_id": "Data/SequencesTheorems.tla",
     "context": [
       "Data/SequencesTheorems_RemoveSeqScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "Data/Sets_CardinalityInNat.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityInNatScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Data/Sets_CardinalityOne.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityOneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Data/Sets_CardinalityOneConverse.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityOneConverseScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "Data/Sets_CardinalityPlusOne.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityPlusOneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "Data/Sets_CardinalitySetMinus.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalitySetMinusScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 20
   },
   "Data/Sets_CardinalityTwo.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityTwoScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Data/Sets_CardinalityZero.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_CardinalityZeroScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "Data/Sets_FiniteSubset.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_FiniteSubsetScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 22
   },
   "Data/Sets_IntervalCardinality.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_IntervalCardinalityScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "Data/Sets_IsBijectionInverse.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_IsBijectionInverseScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "Data/Sets_IsBijectionTransitive.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_IsBijectionTransitiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "Data/Sets_PigeonHole.tla": {
     "spec_id": "Data/Sets.tla",
     "context": [
       "Data/Sets_PigeonHoleScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 22
   },
   "EWD840/EWD840_Inv_implies_Termination.tla": {
     "spec_id": "EWD840/EWD840.tla",
     "context": [
       "EWD840/EWD840Model.tla",
       "EWD840/EWD840_Inv_implies_TerminationScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "EWD840/EWD840_TypeOK_inv.tla": {
     "spec_id": "EWD840/EWD840.tla",
     "context": [
       "EWD840/EWD840Model.tla",
       "EWD840/EWD840_TypeOK_invScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "Euclid/Euclid_Correctness.tla": {
     "spec_id": "Euclid/Euclid-TLAPS-Example/Euclid.tla",
     "context": [
       "Euclid/EuclidModel_2.tla",
       "Euclid/Euclid_CorrectnessScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "Euclid/Euclid_InitProperty.tla": {
     "spec_id": "Euclid/Euclid-TLAPS-Example/Euclid.tla",
     "context": [
       "Euclid/EuclidModel.tla",
       "Euclid/Euclid_InitPropertyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Euclid/Euclid_NextProperty.tla": {
     "spec_id": "Euclid/Euclid-TLAPS-Example/Euclid.tla",
     "context": [
       "Euclid/EuclidModel_2.tla",
       "Euclid/Euclid_NextPropertyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "Euclid/GCD_GCD1.tla": {
     "spec_id": "Euclid/Euclid-Hyperbook/GCD.tla",
     "context": [
       "Euclid/GCD_GCD1Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "Euclid/GCD_GCD2.tla": {
     "spec_id": "Euclid/Euclid-Hyperbook/GCD.tla",
     "context": [
       "Euclid/GCD_GCD2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Euclid/GCD_GCD3.tla": {
     "spec_id": "Euclid/Euclid-Hyperbook/GCD.tla",
     "context": [
       "Euclid/GCD_GCD3Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "OpenAddressing/OpenAddressing_proof_CompleteSafety.tla": {
     "spec_id": "OpenAddressing/OpenAddressing_proof.tla",
     "context": [
       "OpenAddressing/OpenAddressing.tla",
       "OpenAddressing/OpenAddressing_proof_CompleteSafetyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": null
   },
   "Paxos/PaxosHistVar_Consistent.tla": {
     "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_ConsistentScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "Paxos/PaxosHistVar_Invariant.tla": {
     "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_InvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 57
   },
   "Paxos/PaxosHistVar_SafeAtStable.tla": {
     "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_SafeAtStableScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 17
   },
   "Paxos/PaxosHistVar_VotedInv.tla": {
     "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_VotedInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Paxos/PaxosHistVar_VotedOnce.tla": {
     "spec_id": "Paxos/PaxosHistVar.tla",
     "context": [
       "Paxos/PaxosHistVarModel.tla",
       "Paxos/PaxosHistVar_VotedOnceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Paxos/Paxos_Consistent.tla": {
     "spec_id": "Paxos/Paxos.tla",
@@ -541,7 +620,8 @@
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
       "Paxos/Paxos_ConsistentScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "Paxos/Paxos_Invariant.tla": {
     "spec_id": "Paxos/Paxos.tla",
@@ -549,7 +629,8 @@
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
       "Paxos/Paxos_InvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 73
   },
   "Paxos/Paxos_NoneNotAValue.tla": {
     "spec_id": "Paxos/Paxos.tla",
@@ -557,7 +638,8 @@
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_2.tla",
       "Paxos/Paxos_NoneNotAValueScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Paxos/Paxos_QuorumNonEmpty.tla": {
     "spec_id": "Paxos/Paxos.tla",
@@ -565,7 +647,8 @@
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel.tla",
       "Paxos/Paxos_QuorumNonEmptyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Paxos/Paxos_Refinement.tla": {
     "spec_id": "Paxos/Paxos.tla",
@@ -573,7 +656,8 @@
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
       "Paxos/Paxos_RefinementScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "Paxos/Paxos_SafeAtStable.tla": {
     "spec_id": "Paxos/Paxos.tla",
@@ -581,7 +665,8 @@
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
       "Paxos/Paxos_SafeAtStableScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 21
   },
   "Paxos/Paxos_VotedInv.tla": {
     "spec_id": "Paxos/Paxos.tla",
@@ -589,7 +674,8 @@
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
       "Paxos/Paxos_VotedInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "Paxos/Paxos_VotedOnce.tla": {
     "spec_id": "Paxos/Paxos.tla",
@@ -597,42 +683,48 @@
       "Paxos/Consensus.tla",
       "Paxos/PaxosModel_3.tla",
       "Paxos/Paxos_VotedOnceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "SimpleMutex/SimpleMutex_Initialization.tla": {
     "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutexModel.tla",
       "SimpleMutex/SimpleMutex_InitializationScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "SimpleMutex/SimpleMutex_Invariance.tla": {
     "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutexModel.tla",
       "SimpleMutex/SimpleMutex_InvarianceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 13
   },
   "SimpleMutex/SimpleMutex_Mutex.tla": {
     "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutexModel.tla",
       "SimpleMutex/SimpleMutex_MutexScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "SimpleMutex/SimpleMutex_Safety.tla": {
     "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutexModel.tla",
       "SimpleMutex/SimpleMutex_SafetyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "SimpleMutex/SimpleMutex_TLAInvariance.tla": {
     "spec_id": "SimpleMutex/SimpleMutex.tla",
     "context": [
       "SimpleMutex/SimpleMutexModel.tla",
       "SimpleMutex/SimpleMutex_TLAInvarianceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ALL_Card.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -642,7 +734,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ALL_CardScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Agreement.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -652,7 +745,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_AgreementScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 18
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DiffPos.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -662,7 +756,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DiffPosScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleGtNplusTImplGt3T.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -672,7 +767,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleGtNplusTImplGt3TScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleGtNplusTImplTplusOne.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -682,7 +778,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleGtNplusTImplTplusOneScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleLeFromNotGtMono.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -692,7 +789,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleLeFromNotGtMonoScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleLtTplusOneLeNplusT.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -702,7 +800,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleLtTplusOneLeNplusTScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleNotGtLe.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -712,7 +811,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Arith_DoubleNotGtLeScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_NotAllFaulty.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -722,7 +822,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Arith_NotAllFaultyScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_NotLtTplusOneGe.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -732,7 +833,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Arith_NotLtTplusOneGeScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_OtherLtFromStrictOverlap.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -742,7 +844,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Arith_OtherLtFromStrictOverlapScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_SupportedQuorumGeContrad.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -752,7 +855,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Arith_SupportedQuorumGeContradScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Arith_TplusOneNotFaulty.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -762,7 +866,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Arith_TplusOneNotFaultyScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_CardUnion2LeSum.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -772,7 +877,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_CardUnion2LeSumScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_CardUnion3LeSum.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -782,7 +888,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_CardUnion3LeSumScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_CorrectD2Exists.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -792,7 +899,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_CorrectD2ExistsScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 21
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_CrossRoundStrictQuorum.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -802,7 +910,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_CrossRoundStrictQuorumScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_D2Fixed_CardLeSenders.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -812,7 +921,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_D2Fixed_CardLeSendersScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_D2PSetFinite.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -822,7 +932,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_D2PSetFiniteScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_D2SetFinite.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -832,7 +943,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_D2SetFiniteScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DQuorumDominatesMajorityD.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -842,7 +954,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_DQuorumDominatesMajorityDScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 15
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DQuorumDominatesSupported.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -852,7 +965,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_DQuorumDominatesSupportedScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 16
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvFaultyMono.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -862,7 +976,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_DvFaultyMonoScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvInjective.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -872,7 +987,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_DvInjectiveScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvPInjective.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -882,7 +998,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_DvPInjectiveScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvPSenderWitness.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -892,7 +1009,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_DvPSenderWitnessScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvSenderWitness.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -902,7 +1020,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_DvSenderWitnessScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_DvStep2Mono.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -912,7 +1031,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_DvStep2MonoScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_EarlyMajorityM1HasCorrect.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -922,7 +1042,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_EarlyMajorityM1HasCorrectScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_EarlyTplusOneHasCorrect.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -932,7 +1053,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_EarlyTplusOneHasCorrectScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_FaultyBound.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -942,7 +1064,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_FaultyBoundScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_FaultyD2Bound.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -952,7 +1075,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_FaultyD2BoundScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_FaultyD2Injective.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -962,7 +1086,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_FaultyD2InjectiveScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_FaultyMsgs2AddedFaulty.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -972,7 +1097,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_FaultyMsgs2AddedFaultyScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_FaultyStepProps.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -982,7 +1108,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_FaultyStepPropsScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 17
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_HighWeightReceivedL11Witness.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -992,7 +1119,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_HighWeightReceivedL11WitnessScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 62
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Inductive.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1002,7 +1130,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_InductiveScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_InitInd.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1012,7 +1141,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_InitIndScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 48
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LaterQuorumGivesTotalBefore.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1022,7 +1152,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_LaterQuorumGivesTotalBeforeScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 26
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Lemma3_D2D2SameCorrect.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1032,7 +1163,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Lemma3_D2D2SameCorrectScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Lemma3_Q2D2Faulty.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1042,7 +1174,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Lemma3_Q2D2FaultyScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockLemma.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1052,7 +1185,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_LockLemmaScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 13
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockedFullCorrectType2Strict.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1062,7 +1196,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_LockedFullCorrectType2StrictScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 49
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockedNextCorrectD2Value.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1072,7 +1207,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_LockedNextCorrectD2ValueScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockedNextNoCorrectQ2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1082,7 +1218,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_LockedNextNoCorrectQ2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 37
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockedReceiveCorrectType2Strict.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1092,7 +1229,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_LockedReceiveCorrectType2StrictScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 33
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LockedReceiveStrictD.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1102,7 +1240,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_LockedReceiveStrictDScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LowWeightsReceivedL11Witness.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1112,7 +1251,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_LowWeightsReceivedL11WitnessScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 35
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LowWeightsReceivedL8Witness.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1122,7 +1262,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_LowWeightsReceivedL8WitnessScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 70
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_LowWeightsSupportedEmpty.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1132,7 +1273,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_LowWeightsSupportedEmptyScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_MajCardBound.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1142,7 +1284,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_MajCardBoundScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 15
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_MajorityIntersect.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1152,7 +1295,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_MajorityIntersectScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_MajorityM1HasCorrect.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1162,7 +1306,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_MajorityM1HasCorrectScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs1AddOneRep.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1172,7 +1317,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs1AddOneRepScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs1DomR.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1182,7 +1328,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs1DomRScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs1Shape.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1192,7 +1339,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs1ShapeScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2AddDRep.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1202,7 +1350,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2AddDRepScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2AddQRep.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1212,7 +1361,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2AddQRepScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2Decomp.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1222,7 +1372,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2DecompScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2DomR.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1232,7 +1383,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2DomRScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2FaultyMono.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1242,7 +1394,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2FaultyMonoScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2Finite.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1252,7 +1405,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2FiniteScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeDecomp.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1262,7 +1416,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeDecompScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeFinite.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1272,7 +1427,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeFiniteScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeQSrcInAll.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1282,7 +1438,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeQSrcInAllScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeRShape.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1292,7 +1449,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeRShapeScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeShape.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1302,7 +1460,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeShapeScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeSrcInAll.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1312,7 +1471,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeSrcInAllScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeVInValues.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1322,7 +1482,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2PrimeVInValuesScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2QSrcInAll.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1332,7 +1493,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2QSrcInAllScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2RShape.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1342,7 +1504,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2RShapeScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2SenderPartitionBound.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1352,7 +1515,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2SenderPartitionBoundScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 20
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2Shape.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1362,7 +1526,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2ShapeScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2SrcInAll.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1372,7 +1537,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2SrcInAllScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2Step2Mono.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1382,7 +1548,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2Step2MonoScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2VInValues.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1392,7 +1559,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Msgs2VInValuesScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1402,7 +1570,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1412,7 +1581,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 20
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1422,7 +1592,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 20
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1432,7 +1603,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1442,7 +1614,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L10_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1452,7 +1625,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 39
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1462,7 +1636,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1472,7 +1647,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 47
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1482,7 +1658,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 27
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1492,7 +1669,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L11_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1502,7 +1680,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1512,7 +1691,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1522,7 +1702,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 18
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1532,7 +1713,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 23
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1542,7 +1724,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L12_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1552,7 +1735,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 31
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1562,7 +1746,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1572,7 +1757,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 36
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1582,7 +1768,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 47
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1592,7 +1779,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L13_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1602,7 +1790,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 27
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1612,7 +1801,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1622,7 +1812,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 26
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1632,7 +1823,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 56
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S3_DecidedCarry.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1642,7 +1834,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_S3_DecidedCarryScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 21
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1652,7 +1845,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L1_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1662,7 +1856,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1672,7 +1867,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 29
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1682,7 +1878,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1692,7 +1889,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1702,7 +1900,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L2_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1712,7 +1911,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1722,7 +1922,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1732,7 +1933,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 18
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1742,7 +1944,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1752,7 +1955,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L3_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1762,7 +1966,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1772,7 +1977,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 42
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1782,7 +1988,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 44
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1792,7 +1999,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 36
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1802,7 +2010,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L4_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1812,7 +2021,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1822,7 +2032,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 27
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1832,7 +2043,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 38
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1842,7 +2054,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 35
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1852,7 +2065,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L5_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1862,7 +2076,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1872,7 +2087,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1882,7 +2098,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1892,7 +2109,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 52
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1902,7 +2120,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L6_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1912,7 +2131,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1922,7 +2142,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1932,7 +2153,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 26
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1942,7 +2164,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1952,7 +2175,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L7_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1962,7 +2186,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 22
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1972,7 +2197,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 22
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1982,7 +2208,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 25
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -1992,7 +2219,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2002,7 +2230,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L8_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_F.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2012,7 +2241,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_FScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 39
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_S1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2022,7 +2252,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_S1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 35
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_S2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2032,7 +2263,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_S2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 42
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_S3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2042,7 +2274,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_S3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_ST.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2052,7 +2285,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_L9_STScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2062,7 +2296,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma10.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2072,7 +2307,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma10Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma11.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2082,7 +2318,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma11Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma12.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2092,7 +2329,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma12Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 13
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma13.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2102,7 +2340,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma13Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2112,7 +2351,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 1
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma3.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2122,7 +2362,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma3Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma4.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2132,7 +2373,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma4Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 1
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma5.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2142,7 +2384,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma5Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 1
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma6.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2152,7 +2395,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma6Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma7.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2162,7 +2406,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma7Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma8.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2172,7 +2417,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma8Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma9.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2182,7 +2428,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Pres_Lemma9Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Q2Fixed_CardLeSenders.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2192,7 +2439,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Q2Fixed_CardLeSendersScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Q2SetFinite.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2202,7 +2450,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Q2SetFiniteScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QFaultyMono.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2212,7 +2461,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_QFaultyMonoScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QInjective.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2222,7 +2472,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_QInjectiveScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QPInjective.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2232,7 +2483,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_QPInjectiveScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QPSetFinite.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2242,7 +2494,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_QPSetFiniteScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QStep2Mono.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2252,7 +2505,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_QStep2MonoScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QuorumDominatesSupported.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2262,7 +2516,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_QuorumDominatesSupportedScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 17
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QuorumHasCorrectM1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2272,7 +2527,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_QuorumHasCorrectM1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QuorumHasM1Majority.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2282,7 +2538,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_QuorumHasM1MajorityScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QuorumIntersect.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2292,7 +2549,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_QuorumIntersectScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 13
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_QuorumUnique.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2302,7 +2560,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_QuorumUniqueScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 14
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ReceivedDQuorumDominatesSupported.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2312,7 +2571,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ReceivedDQuorumDominatesSupportedScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ReplicaPredRoundHasTotal.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2322,7 +2582,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ReplicaPredRoundHasTotalScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 18
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_RoundPos.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2332,7 +2593,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_RoundPosScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_RoundPredInRounds.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2342,7 +2604,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_RoundPredInRoundsScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders1_Mono.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2352,7 +2615,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Senders1_MonoScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders1_Sub.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2362,7 +2626,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Senders1_SubScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_CardLeSet.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2372,7 +2637,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_CardLeSetScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_Mono.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2382,7 +2648,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_MonoScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_Sub.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2392,7 +2659,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_SubScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_Witness.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2402,7 +2670,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_Senders2_WitnessScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SetEqHelper.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2412,7 +2681,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SetEqHelperScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeFromExists.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2422,7 +2692,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ShapeFromExistsScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelper.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2432,7 +2703,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperR.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2442,7 +2714,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperRScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperSrc.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2452,7 +2725,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperSrcScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperSrcQ.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2462,7 +2736,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperSrcQScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperV.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2472,7 +2747,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ShapeHelperVScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeRFromExists.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2482,7 +2758,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ShapeRFromExistsScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeSrcFromExists.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2492,7 +2769,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ShapeSrcFromExistsScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeSrcQFromExists.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2502,7 +2780,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ShapeSrcQFromExistsScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_ShapeVFromExists.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2512,7 +2791,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_ShapeVFromExistsScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumCarriesToQuorumRound.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2522,7 +2802,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumCarriesToQuorumRoundScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 47
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumFewOthers.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2532,7 +2813,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumFewOthersScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 46
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumNextCorrectType2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2542,7 +2824,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumNextCorrectType2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumNextReceiveStrictD.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2552,7 +2835,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumNextReceiveStrictDScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumNextStrictQuorum.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2562,7 +2846,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumNextStrictQuorumScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumSenderStrict.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2572,7 +2857,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumSenderStrictScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumSupportedSingleton.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2582,7 +2868,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_StrictQuorumSupportedSingletonScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SubAll_Finite.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2592,7 +2879,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SubAll_FiniteScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedFromTotalAndFewOthers.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2602,7 +2890,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SupportedFromTotalAndFewOthersScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 16
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedInReceivedQuorum.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2612,7 +2901,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SupportedInReceivedQuorumScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 18
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedPHasOldCorrectD2.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2622,7 +2912,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SupportedPHasOldCorrectD2Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedPToOldWhenTotal.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2632,7 +2923,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SupportedPToOldWhenTotalScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedSingletonNextQuorum.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2642,7 +2934,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SupportedSingletonNextQuorumScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedSingletonNextSupported.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2652,7 +2945,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SupportedSingletonNextSupportedScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 23
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedSingletonPinsNextM1.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2662,7 +2956,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SupportedSingletonPinsNextM1Scaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedUnique.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2672,7 +2967,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SupportedUniqueScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 21
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedValuesPFrame.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2682,7 +2978,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SupportedValuesPFrameScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_SupportedValuesPrimeIsP.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2692,7 +2989,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_SupportedValuesPrimeIsPScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_TplusOneHasCorrect.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2702,7 +3000,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_TplusOneHasCorrectScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_TypeOKPrimeIntro.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2712,7 +3011,8 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_TypeOKPrimeIntroScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_ben-or83/Ben_or83_proofs_TypePres.tla": {
     "spec_id": "apalache_examples_ben-or83/Ben_or83_proofs.tla",
@@ -2722,357 +3022,408 @@
       "apalache_examples_ben-or83/Ben_or83_proofs_TypePresScaffold.tla",
       "apalache_examples_ben-or83/Variants.tla",
       "apalache_examples_ben-or83/typedefs.tla"
-    ]
+    ],
+    "reference_proof_steps": 80
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_BoundedMaxExists.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_BoundedMaxExistsScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 24
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Inductive.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_InductiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_MaxReachedProps.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_MaxReachedPropsScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_OnRoundCatchupGivesSender.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_OnRoundCatchupGivesSenderScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 15
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCAllMonotone.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCAllMonotoneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetFlip.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetFlipScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetPFlip.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetPFlipScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetSubset.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PCSetSubsetScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetFlip.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetFlipScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetPFlip.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetPFlipScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetPFlipCard.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetPFlipCardScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetQuorumMonotone.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetQuorumMonotoneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetSubset.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PVSetSubsetScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PastStartRoundOperator.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PastStartRoundOperatorScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PastStartRoundQuorumMonotone.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PastStartRoundQuorumMonotoneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 17
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PostPrecommitByCorrectGivesPostPrevoteQuorum.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PostPrecommitByCorrectGivesPostPrevoteQuorumScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PostPrecommitLocksLaterPrevotesOp.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PostPrecommitLocksLaterPrevotesOpScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitByCorrectGivesPrevoteQuorum.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitByCorrectGivesPrevoteQuorumScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitLockContra.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitLockContraScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitLocksLaterPrevotesOp.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitLocksLaterPrevotesOpScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitRecTyped.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitRecTypedScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitSenderSetCardinalityMonotone.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitSenderSetCardinalityMonotoneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitsLockValueOp.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrecommitsLockValueOpScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 22
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_AllValidAndLockedRoundBounded.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_AllValidAndLockedRoundBoundedScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_Faulty.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_FaultyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_InsertProposal.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_InsertProposalScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_OnQuorumOfNilPrevotes.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_OnQuorumOfNilPrevotesScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_OnTimeoutPropose.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_OnTimeoutProposeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInPrecommitNoDecision.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInPrecommitNoDecisionScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInPrevoteOrCommitAndPrevote.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInPrevoteOrCommitAndPrevoteScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInPropose.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInProposeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInProposeAndPrevote.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponProposalInProposeAndPrevoteScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponQuorumOfPrecommitsAny.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponQuorumOfPrecommitsAnyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponQuorumOfPrevotesAny.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_Bounded_UponQuorumOfPrevotesAnyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_PrecommitLocksLaterPrevotes.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Pres_PrecommitLocksLaterPrevotesScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteAllSenderSetCardinalityMonotone.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteAllSenderSetCardinalityMonotoneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteEvidenceSenderSetCardinalityLeAllSenders.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteEvidenceSenderSetCardinalityLeAllSendersScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteRecTyped.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteRecTypedScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteSenderSetCardinalityMonotone.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteSenderSetCardinalityMonotoneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteValueSenderSetCardinalityLeAllSenders.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_PrevoteValueSenderSetCardinalityLeAllSendersScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_ProposeRecTyped.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_ProposeRecTypedScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_Q3UnionMonotone.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_Q3UnionMonotoneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_QuorumHasCorrect.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_QuorumHasCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_QuorumsIntersectInCorrect.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_QuorumsIntersectInCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 41
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_SmallQuorumHasCorrect.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_SmallQuorumHasCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_StepChangeChar.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_StepChangeCharScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 49
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_SubsetCFFinite.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_SubsetCFFiniteScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "apalache_examples_tendermint/tendermint_single_indinv_proofs_SubsetCardGeq.tla": {
     "spec_id": "apalache_examples_tendermint/tendermint_single_indinv_proofs.tla",
     "context": [
       "apalache_examples_tendermint/tendermint_single_indinv.tla",
       "apalache_examples_tendermint/tendermint_single_indinv_proofs_SubsetCardGeqScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_Bakery-Boulangerie/Bakery_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_Bakery-Boulangerie/Bakery.tla",
     "context": [
       "tlaplus_examples_Bakery-Boulangerie/BakeryModel.tla",
       "tlaplus_examples_Bakery-Boulangerie/Bakery_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 16
   },
   "tlaplus_examples_Bakery-Boulangerie/Boulanger_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_Bakery-Boulangerie/Boulanger.tla",
     "context": [
       "tlaplus_examples_Bakery-Boulangerie/BoulangerModel.tla",
       "tlaplus_examples_Bakery-Boulangerie/Boulanger_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 16
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs_EmptySeqRange.tla": {
     "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs.tla",
@@ -3081,7 +3432,8 @@
       "tlaplus_examples_BlockingQueue/BlockingQueueFair.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs_EmptySeqRangeScaffold.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs_ITypeInv.tla": {
     "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs.tla",
@@ -3090,7 +3442,8 @@
       "tlaplus_examples_BlockingQueue/BlockingQueueFair.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs_ITypeInvScaffold.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit.tla"
-    ]
+    ],
+    "reference_proof_steps": 15
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_DeadlockFreedom.tla": {
     "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs.tla",
@@ -3098,7 +3451,8 @@
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_DeadlockFreedomScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_IInvRefines.tla": {
     "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs.tla",
@@ -3106,7 +3460,8 @@
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_IInvRefinesScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_ITypeInv.tla": {
     "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs.tla",
@@ -3114,7 +3469,8 @@
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_ITypeInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_Implements.tla": {
     "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs.tla",
@@ -3122,98 +3478,112 @@
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_ImplementsScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_BlockingQueue/BlockingQueue_proofs_DeadlockFreedom.tla": {
     "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueue_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueue_proofs_DeadlockFreedomScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_BlockingQueue/BlockingQueue_proofs_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_BlockingQueue/BlockingQueue_proofs.tla",
     "context": [
       "tlaplus_examples_BlockingQueue/BlockingQueue.tla",
       "tlaplus_examples_BlockingQueue/BlockingQueue_proofs_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneCorrect.tla": {
     "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 51
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneViaSmokingSet.tla": {
     "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneViaSmokingSetScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_OffersFact.tla": {
     "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_OffersFactScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_SmokingSetFinite.tla": {
     "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_SmokingSetFiniteScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_StartSmokingSmokingSet.tla": {
     "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_StartSmokingSmokingSetScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_StopSmokingSmokingSet.tla": {
     "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_StopSmokingSmokingSetScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 16
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 20
   },
   "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_UniqueComplement2.tla": {
     "spec_id": "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof.tla",
     "context": [
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers.tla",
       "tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_UniqueComplement2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 42
   },
   "tlaplus_examples_CoffeeCan/CoffeeCan_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_CoffeeCan/CoffeeCan_proof.tla",
     "context": [
       "tlaplus_examples_CoffeeCan/CoffeeCan.tla",
       "tlaplus_examples_CoffeeCan/CoffeeCan_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 51
   },
   "tlaplus_examples_DieHard/DieHard_proof_MinNat.tla": {
     "spec_id": "tlaplus_examples_DieHard/DieHard_proof.tla",
     "context": [
       "tlaplus_examples_DieHard/DieHard.tla",
       "tlaplus_examples_DieHard/DieHard_proof_MinNatScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_DieHard/DieHard_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_DieHard/DieHard_proof.tla",
     "context": [
       "tlaplus_examples_DieHard/DieHard.tla",
       "tlaplus_examples_DieHard/DieHard_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 45
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_EnabledGossip.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3221,7 +3591,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_EnabledGossipScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_GossipDecreasesMeasure.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3229,7 +3600,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_GossipDecreasesMeasureScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_GossipDoesntIncreaseMeasure.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3237,7 +3609,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_GossipDoesntIncreaseMeasureScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_MeasureIsZero.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3245,7 +3618,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_MeasureIsZeroScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_MeasureType.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3253,7 +3627,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_MeasureTypeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_MeasureTypePrime.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3261,7 +3636,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_MeasureTypePrimeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_OGLiveness.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3269,7 +3645,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel_2.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_OGLivenessScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 63
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_Safe.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3277,7 +3654,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_SafeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumIsSumFunction.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3285,7 +3663,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumIsSumFunctionScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumIsZero.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3293,7 +3672,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumIsZeroScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumStronglyMonotonic.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3301,7 +3681,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumStronglyMonotonicScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumType.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3309,7 +3690,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumTypeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumWeaklyMonotonic.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3317,7 +3699,8 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_SumWeaklyMonotonicScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "tlaplus_examples_FiniteMonotonic/CRDT_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_FiniteMonotonic/CRDT_proof.tla",
@@ -3325,208 +3708,240 @@
       "tlaplus_examples_FiniteMonotonic/CRDT.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proofModel.tla",
       "tlaplus_examples_FiniteMonotonic/CRDT_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_KeyValueStore/KeyValueStore_proof_TypeAndLifecycle.tla": {
     "spec_id": "tlaplus_examples_KeyValueStore/KeyValueStore_proof.tla",
     "context": [
       "tlaplus_examples_KeyValueStore/KeyValueStore.tla",
       "tlaplus_examples_KeyValueStore/KeyValueStore_proof_TypeAndLifecycleScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 13
   },
   "tlaplus_examples_LearnProofs/AddTwo_TypeInvariant.tla": {
     "spec_id": "tlaplus_examples_LearnProofs/AddTwo.tla",
     "context": [
       "tlaplus_examples_LearnProofs/AddTwoModel.tla",
       "tlaplus_examples_LearnProofs/AddTwo_TypeInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_LearnProofs/FindHighest_DoneIndexValueThm.tla": {
     "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_DoneIndexValueThmScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "tlaplus_examples_LearnProofs/FindHighest_InductiveInvariantHolds.tla": {
     "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_InductiveInvariantHoldsScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "tlaplus_examples_LearnProofs/FindHighest_IsCorrect.tla": {
     "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_IsCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_LearnProofs/FindHighest_TypeInvariantHolds.tla": {
     "spec_id": "tlaplus_examples_LearnProofs/FindHighest.tla",
     "context": [
       "tlaplus_examples_LearnProofs/FindHighestModel.tla",
       "tlaplus_examples_LearnProofs/FindHighest_TypeInvariantHoldsScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "tlaplus_examples_LoopInvariance/BinarySearch_SortedLess.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/BinarySearch.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/BinarySearch_SortedLessScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_LoopInvariance/Quicksort_AutomorphismsCompose.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_AutomorphismsComposeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_LoopInvariance/Quicksort_IntervalMinMax.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_IntervalMinMaxScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_LoopInvariance/Quicksort_MaxIsMax.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_MaxIsMaxScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_LoopInvariance/Quicksort_MinIsMin.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_MinIsMinScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_LoopInvariance/Quicksort_NonemptyMax.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_NonemptyMaxScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 23
   },
   "tlaplus_examples_LoopInvariance/Quicksort_NonemptyMin.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_NonemptyMinScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 23
   },
   "tlaplus_examples_LoopInvariance/Quicksort_PartitionsLemma.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_PartitionsLemmaScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_LoopInvariance/Quicksort_PermsOfLemma.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_PermsOfLemmaScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_LoopInvariance/Quicksort_PermsOfPermsOf.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/Quicksort.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/Quicksort_PermsOfPermsOfScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_LoopInvariance/SumSequence_FrontDef.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_FrontDefScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_LoopInvariance/SumSequence_Lemma1_Proof.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_Lemma1_ProofScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_LoopInvariance/SumSequence_Lemma2.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_Lemma2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_LoopInvariance/SumSequence_Lemma3.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_Lemma3Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 13
   },
   "tlaplus_examples_LoopInvariance/SumSequence_Lemma4.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_Lemma4Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 16
   },
   "tlaplus_examples_LoopInvariance/SumSequence_Lemma5_Proof.tla": {
     "spec_id": "tlaplus_examples_LoopInvariance/SumSequence.tla",
     "context": [
       "tlaplus_examples_LoopInvariance/SumSequence_Lemma5_ProofScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 51
   },
   "tlaplus_examples_Majority/MajorityProof_Correctness.tla": {
     "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_CorrectnessScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 21
   },
   "tlaplus_examples_Majority/MajorityProof_OccurrencesOne.tla": {
     "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_OccurrencesOneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_Majority/MajorityProof_OccurrencesPlusOne.tla": {
     "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_OccurrencesPlusOneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "tlaplus_examples_Majority/MajorityProof_OccurrencesType.tla": {
     "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_OccurrencesTypeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_Majority/MajorityProof_PositionsFinite.tla": {
     "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_PositionsFiniteScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_Majority/MajorityProof_PositionsOne.tla": {
     "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_PositionsOneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_Majority/MajorityProof_PositionsPlusOne.tla": {
     "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_PositionsPlusOneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_Majority/MajorityProof_PositionsType.tla": {
     "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_PositionsTypeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_Majority/MajorityProof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_Majority/MajorityProof.tla",
     "context": [
       "tlaplus_examples_Majority/Majority.tla",
       "tlaplus_examples_Majority/MajorityProof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_MisraReachability/ParReachProofs_TypeInvariant.tla": {
     "spec_id": "tlaplus_examples_MisraReachability/ParReachProofs.tla",
@@ -3535,35 +3950,40 @@
       "tlaplus_examples_MisraReachability/ParReachProofs_TypeInvariantScaffold.tla",
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/Reachable.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable0.tla": {
     "spec_id": "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable0Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable1.tla": {
     "spec_id": "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable1Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 25
   },
   "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable2.tla": {
     "spec_id": "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 13
   },
   "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable3.tla": {
     "spec_id": "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
     "context": [
       "tlaplus_examples_MisraReachability/Reachability.tla",
       "tlaplus_examples_MisraReachability/ReachabilityProofs_Reachable3Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_MisraReachability/ReachableProofs_Thm1.tla": {
     "spec_id": "tlaplus_examples_MisraReachability/ReachableProofs.tla",
@@ -3572,7 +3992,8 @@
       "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
       "tlaplus_examples_MisraReachability/Reachable.tla",
       "tlaplus_examples_MisraReachability/ReachableProofs_Thm1Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "tlaplus_examples_MisraReachability/ReachableProofs_Thm2.tla": {
     "spec_id": "tlaplus_examples_MisraReachability/ReachableProofs.tla",
@@ -3581,7 +4002,8 @@
       "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
       "tlaplus_examples_MisraReachability/Reachable.tla",
       "tlaplus_examples_MisraReachability/ReachableProofs_Thm2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_MisraReachability/ReachableProofs_Thm3.tla": {
     "spec_id": "tlaplus_examples_MisraReachability/ReachableProofs.tla",
@@ -3590,7 +4012,8 @@
       "tlaplus_examples_MisraReachability/ReachabilityProofs.tla",
       "tlaplus_examples_MisraReachability/Reachable.tla",
       "tlaplus_examples_MisraReachability/ReachableProofs_Thm3Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 20
   },
   "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proof.tla",
@@ -3598,98 +4021,112 @@
       "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals.tla",
       "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proofModel.tla",
       "tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 23
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_DirectionInElevatorDirectionState.tla": {
     "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_DirectionInElevatorDirectionStateScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_ElevatorCallFields.tla": {
     "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_ElevatorCallFieldsScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_GetDirectionType.tla": {
     "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_GetDirectionTypeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_InitImpliesInv1.tla": {
     "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_InitImpliesInv1Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 15
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_InitImpliesInv2.tla": {
     "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_InitImpliesInv2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 25
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_Inv1Next.tla": {
     "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_Inv1NextScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 84
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_SafetyCorrect.tla": {
     "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_SafetyCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_StationaryInElevatorDirectionState.tla": {
     "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_StationaryInElevatorDirectionStateScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_MultiCarElevator/Elevator_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_MultiCarElevator/Elevator_proof.tla",
     "context": [
       "tlaplus_examples_MultiCarElevator/Elevator.tla",
       "tlaplus_examples_MultiCarElevator/Elevator_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_Paxos/Consensus_Invariance.tla": {
     "spec_id": "tlaplus_examples_Paxos/Consensus.tla",
     "context": [
       "tlaplus_examples_Paxos/ConsensusModel.tla",
       "tlaplus_examples_Paxos/Consensus_InvarianceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_Paxos/Consensus_LivenessTheorem.tla": {
     "spec_id": "tlaplus_examples_Paxos/Consensus.tla",
     "context": [
       "tlaplus_examples_Paxos/ConsensusModel_2.tla",
       "tlaplus_examples_Paxos/Consensus_LivenessTheoremScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_Paxos/Voting_QuorumNonEmpty.tla": {
     "spec_id": "tlaplus_examples_Paxos/Voting.tla",
     "context": [
       "tlaplus_examples_Paxos/Consensus.tla",
       "tlaplus_examples_Paxos/Voting_QuorumNonEmptyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Consensus_Invariance.tla": {
     "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
     "context": [
       "tlaplus_examples_PaxosHowToWinATuringAward/ConsensusModel.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus_InvarianceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_Implementation.tla": {
     "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
@@ -3697,7 +4134,8 @@
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/VotingModel.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_ImplementationScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_Invariance.tla": {
     "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
@@ -3705,7 +4143,8 @@
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/VotingModel.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_InvarianceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_AllSafeAtZero_T.tla": {
     "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
@@ -3713,7 +4152,8 @@
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_AllSafeAtZero_TScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ChoosableThm_T.tla": {
     "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
@@ -3721,7 +4161,8 @@
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ChoosableThm_TScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_OneValuePerBallotApply.tla": {
     "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
@@ -3729,7 +4170,8 @@
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_OneValuePerBallotApplyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_QuorumIntersect.tla": {
     "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
@@ -3737,7 +4179,8 @@
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_QuorumIntersectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_QuorumNonEmpty.tla": {
     "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
@@ -3745,7 +4188,8 @@
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_QuorumNonEmptyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ShowsSafety_T.tla": {
     "spec_id": "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof.tla",
@@ -3753,49 +4197,56 @@
       "tlaplus_examples_PaxosHowToWinATuringAward/Consensus.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting.tla",
       "tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ShowsSafety_TScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 38
   },
   "tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyCorrect.tla": {
     "spec_id": "tlaplus_examples_ReadersWriters/ReadersWriters_proof.tla",
     "context": [
       "tlaplus_examples_ReadersWriters/ReadersWriters.tla",
       "tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyStep.tla": {
     "spec_id": "tlaplus_examples_ReadersWriters/ReadersWriters_proof.tla",
     "context": [
       "tlaplus_examples_ReadersWriters/ReadersWriters.tla",
       "tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyStepScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 90
   },
   "tlaplus_examples_ReadersWriters/ReadersWriters_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_ReadersWriters/ReadersWriters_proof.tla",
     "context": [
       "tlaplus_examples_ReadersWriters/ReadersWriters.tla",
       "tlaplus_examples_ReadersWriters/ReadersWriters_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 36
   },
   "tlaplus_examples_SpanningTree/SpanTree_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_SpanningTree/SpanTree_proof.tla",
     "context": [
       "tlaplus_examples_SpanningTree/SpanTree.tla",
       "tlaplus_examples_SpanningTree/SpanTree_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 19
   },
   "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface.tla",
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel.tla",
       "tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_InvInductive.tla": {
     "spec_id": "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof.tla",
@@ -3803,7 +4254,8 @@
       "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory.tla",
       "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_InvInductiveScaffold.tla",
       "tlaplus_examples_SpecifyingSystems_CachingMemory/MemoryInterface.tla"
-    ]
+    ],
+    "reference_proof_steps": 22
   },
   "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof.tla",
@@ -3811,7 +4263,8 @@
       "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory.tla",
       "tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_TypeCorrectScaffold.tla",
       "tlaplus_examples_SpecifyingSystems_CachingMemory/MemoryInterface.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO_proof.tla",
@@ -3819,238 +4272,272 @@
       "tlaplus_examples_SpecifyingSystems_FIFO/Channel.tla",
       "tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO.tla",
       "tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "tlaplus_examples_SpecifyingSystems_HourClock/HourClock_proof_HCini_Invariant.tla": {
     "spec_id": "tlaplus_examples_SpecifyingSystems_HourClock/HourClock_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_HourClock/HourClock.tla",
       "tlaplus_examples_SpecifyingSystems_HourClock/HourClock_proof_HCini_InvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof.tla",
     "context": [
       "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit.tla",
       "tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 14
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness.tla": {
     "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegularModel.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_CorrectnessScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 15
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness2.tla": {
     "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegularModel.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_InvInvariant.tla": {
     "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegular.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_InvInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 14
   },
   "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleRegular.tla",
       "tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 15
   },
   "tlaplus_examples_TeachingConcurrency/Simple_Correctness.tla": {
     "spec_id": "tlaplus_examples_TeachingConcurrency/Simple.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleModel.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_CorrectnessScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "tlaplus_examples_TeachingConcurrency/Simple_Correctness2.tla": {
     "spec_id": "tlaplus_examples_TeachingConcurrency/Simple.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/SimpleModel.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_Correctness2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_TeachingConcurrency/Simple_proof_InvInvariant.tla": {
     "spec_id": "tlaplus_examples_TeachingConcurrency/Simple_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/Simple.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_proof_InvInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_TeachingConcurrency/Simple_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_TeachingConcurrency/Simple_proof.tla",
     "context": [
       "tlaplus_examples_TeachingConcurrency/Simple.tla",
       "tlaplus_examples_TeachingConcurrency/Simple_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_AcceptMsgInv.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_AcceptMsgInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 128
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_Consistent.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_ConsistentScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_Invariant.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_InvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 105
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_MaxBigger.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_MaxBiggerScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_MaxTypeOK.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_MaxTypeOKScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_MsgNotLost.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_MsgNotLostScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_NoneNotAValue.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_NoneNotAValueScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageAccInv.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageAccInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 132
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageBiggerProperty.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageBiggerPropertyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageMsgInv.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_OnMessageMsgInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 53
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_PrepareMsgInv.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_PrepareMsgInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 65
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_SafeAtStable.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_SafeAtStableScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 62
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateBiggerProperty.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateBiggerPropertyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateMsgInv.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateMsgInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 157
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateTypeOKProperty.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateTypeOKPropertyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateValue.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateValueScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 24
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateViewValue.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_UpdateStateViewValueScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 49
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_VotedInv.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_VotedInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_TencentPaxos/TPaxosWithProof_VotedOnce.tla": {
     "spec_id": "tlaplus_examples_TencentPaxos/TPaxosWithProof.tla",
     "context": [
       "tlaplus_examples_TencentPaxos/TPaxosWithProofModel_2.tla",
       "tlaplus_examples_TencentPaxos/TPaxosWithProof_VotedOnceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_Termination/Termination_proof_Invariant1.tla": {
     "spec_id": "tlaplus_examples_Termination/Termination_proof.tla",
     "context": [
       "tlaplus_examples_Termination/Termination.tla",
       "tlaplus_examples_Termination/Termination_proof_Invariant1Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 18
   },
   "tlaplus_examples_Termination/Termination_proof_Invariant2.tla": {
     "spec_id": "tlaplus_examples_Termination/Termination_proof.tla",
     "context": [
       "tlaplus_examples_Termination/Termination.tla",
       "tlaplus_examples_Termination/Termination_proof_Invariant2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 57
   },
   "tlaplus_examples_Termination/Termination_proof_Invariant3.tla": {
     "spec_id": "tlaplus_examples_Termination/Termination_proof.tla",
     "context": [
       "tlaplus_examples_Termination/Termination.tla",
       "tlaplus_examples_Termination/Termination_proof_Invariant3Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_Termination/Termination_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_Termination/Termination_proof.tla",
     "context": [
       "tlaplus_examples_Termination/Termination.tla",
       "tlaplus_examples_Termination/Termination_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 13
   },
   "tlaplus_examples_TwoPhase/TwoPhase_Implementation.tla": {
     "spec_id": "tlaplus_examples_TwoPhase/TwoPhase.tla",
@@ -4058,7 +4545,8 @@
       "tlaplus_examples_TwoPhase/Alternate.tla",
       "tlaplus_examples_TwoPhase/TwoPhaseModel.tla",
       "tlaplus_examples_TwoPhase/TwoPhase_ImplementationScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "tlaplus_examples_allocator/AllocatorImplementation_proof_DropType.tla": {
     "spec_id": "tlaplus_examples_allocator/AllocatorImplementation_proof.tla",
@@ -4066,7 +4554,8 @@
       "tlaplus_examples_allocator/AllocatorImplementation.tla",
       "tlaplus_examples_allocator/AllocatorImplementation_proof_DropTypeScaffold.tla",
       "tlaplus_examples_allocator/SchedulingAllocator.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_allocator/AllocatorImplementation_proof_PermSeqsType.tla": {
     "spec_id": "tlaplus_examples_allocator/AllocatorImplementation_proof.tla",
@@ -4074,7 +4563,8 @@
       "tlaplus_examples_allocator/AllocatorImplementation.tla",
       "tlaplus_examples_allocator/AllocatorImplementation_proof_PermSeqsTypeScaffold.tla",
       "tlaplus_examples_allocator/SchedulingAllocator.tla"
-    ]
+    ],
+    "reference_proof_steps": 24
   },
   "tlaplus_examples_allocator/AllocatorImplementation_proof_PermsFnRec.tla": {
     "spec_id": "tlaplus_examples_allocator/AllocatorImplementation_proof.tla",
@@ -4082,7 +4572,8 @@
       "tlaplus_examples_allocator/AllocatorImplementation.tla",
       "tlaplus_examples_allocator/AllocatorImplementation_proof_PermsFnRecScaffold.tla",
       "tlaplus_examples_allocator/SchedulingAllocator.tla"
-    ]
+    ],
+    "reference_proof_steps": 25
   },
   "tlaplus_examples_allocator/AllocatorImplementation_proof_PermsRecNonempty.tla": {
     "spec_id": "tlaplus_examples_allocator/AllocatorImplementation_proof.tla",
@@ -4090,7 +4581,8 @@
       "tlaplus_examples_allocator/AllocatorImplementation.tla",
       "tlaplus_examples_allocator/AllocatorImplementation_proof_PermsRecNonemptyScaffold.tla",
       "tlaplus_examples_allocator/SchedulingAllocator.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_allocator/AllocatorImplementation_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_allocator/AllocatorImplementation_proof.tla",
@@ -4098,70 +4590,80 @@
       "tlaplus_examples_allocator/AllocatorImplementation.tla",
       "tlaplus_examples_allocator/AllocatorImplementation_proof_TypeCorrectScaffold.tla",
       "tlaplus_examples_allocator/SchedulingAllocator.tla"
-    ]
+    ],
+    "reference_proof_steps": 27
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_DropType.tla": {
     "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_DropTypeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_Mutex.tla": {
     "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_MutexScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 45
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_PermSeqsIsPermsFn.tla": {
     "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_PermSeqsIsPermsFnScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_PermSeqsType.tla": {
     "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_PermSeqsTypeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 24
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_PermsFnRec.tla": {
     "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_PermsFnRecScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 25
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_PermsRecNonempty.tla": {
     "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_PermsRecNonemptyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_allocator/SchedulingAllocator_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_allocator/SchedulingAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SchedulingAllocator.tla",
       "tlaplus_examples_allocator/SchedulingAllocator_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 23
   },
   "tlaplus_examples_allocator/SimpleAllocator_proof_Mutex.tla": {
     "spec_id": "tlaplus_examples_allocator/SimpleAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SimpleAllocator.tla",
       "tlaplus_examples_allocator/SimpleAllocator_proof_MutexScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 34
   },
   "tlaplus_examples_allocator/SimpleAllocator_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_allocator/SimpleAllocator_proof.tla",
     "context": [
       "tlaplus_examples_allocator/SimpleAllocator.tla",
       "tlaplus_examples_allocator/SimpleAllocator_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "tlaplus_examples_barriers/Barriers_AllProcsInRdv.tla": {
     "spec_id": "tlaplus_examples_barriers/Barriers.tla",
@@ -4169,7 +4671,8 @@
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_AllProcsInRdvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_barriers/Barriers_AllProcsNotInRdv.tla": {
     "spec_id": "tlaplus_examples_barriers/Barriers.tla",
@@ -4177,7 +4680,8 @@
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_AllProcsNotInRdvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_barriers/Barriers_BarrierExclusion.tla": {
     "spec_id": "tlaplus_examples_barriers/Barriers.tla",
@@ -4185,7 +4689,8 @@
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_BarrierExclusionScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_barriers/Barriers_BarrierExclusion2.tla": {
     "spec_id": "tlaplus_examples_barriers/Barriers.tla",
@@ -4193,7 +4698,8 @@
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_BarrierExclusion2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_barriers/Barriers_FS_NonEmptySet.tla": {
     "spec_id": "tlaplus_examples_barriers/Barriers.tla",
@@ -4201,7 +4707,8 @@
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_FS_NonEmptySetScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_barriers/Barriers_FS_TwoElements.tla": {
     "spec_id": "tlaplus_examples_barriers/Barriers.tla",
@@ -4209,7 +4716,8 @@
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_FS_TwoElementsScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "tlaplus_examples_barriers/Barriers_FlushInvariant.tla": {
     "spec_id": "tlaplus_examples_barriers/Barriers.tla",
@@ -4217,7 +4725,8 @@
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_FlushInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 61
   },
   "tlaplus_examples_barriers/Barriers_Invariant.tla": {
     "spec_id": "tlaplus_examples_barriers/Barriers.tla",
@@ -4225,7 +4734,8 @@
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_InvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 255
   },
   "tlaplus_examples_barriers/Barriers_LockExclusion.tla": {
     "spec_id": "tlaplus_examples_barriers/Barriers.tla",
@@ -4233,7 +4743,8 @@
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_LockExclusionScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 21
   },
   "tlaplus_examples_barriers/Barriers_ProcSetSubSetsBound.tla": {
     "spec_id": "tlaplus_examples_barriers/Barriers.tla",
@@ -4241,7 +4752,8 @@
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_ProcSetSubSetsBoundScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_barriers/Barriers_Typing.tla": {
     "spec_id": "tlaplus_examples_barriers/Barriers.tla",
@@ -4249,105 +4761,120 @@
       "tlaplus_examples_barriers/Barrier.tla",
       "tlaplus_examples_barriers/BarriersModel.tla",
       "tlaplus_examples_barriers/Barriers_TypingScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcastScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast_TLC.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast_TLCScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 34
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_Init.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_InitScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 36
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_InitNoBcast.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_InitNoBcastScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 37
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_Next.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_NextScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 134
   },
   "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_SpecNoBcast.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_SpecNoBcastScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_bcastByz/bcastByz_NTFRel.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_NTFRelScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_bcastByz/bcastByz_ProcProp.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_ProcPropScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_bcastByz/bcastByz_UMFS_CardinalityType.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_UMFS_CardinalityTypeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_bcastByz/bcastByz_Unforg_Step1.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_Unforg_Step1Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_bcastByz/bcastByz_Unforg_Step2.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_Unforg_Step2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 91
   },
   "tlaplus_examples_bcastByz/bcastByz_Unforg_Step3.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_Unforg_Step3Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "tlaplus_examples_bcastByz/bcastByz_Unforg_Step4.tla": {
     "spec_id": "tlaplus_examples_bcastByz/bcastByz.tla",
     "context": [
       "tlaplus_examples_bcastByz/bcastByzModel.tla",
       "tlaplus_examples_bcastByz/bcastByz_Unforg_Step4Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_byihive/VoucherLifeCycle_proof_Spec_TypeOK_Consistent.tla": {
     "spec_id": "tlaplus_examples_byihive/VoucherLifeCycle_proof.tla",
     "context": [
       "tlaplus_examples_byihive/VoucherLifeCycle.tla",
       "tlaplus_examples_byihive/VoucherLifeCycle_proof_Spec_TypeOK_ConsistentScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_byzpaxos/BPConProof_BMessageLemma.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4357,7 +4884,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_byzpaxos/BPConProof_FiniteMsgsLemma.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4367,7 +4895,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_byzpaxos/BPConProof_FiniteSetHasMax.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4377,7 +4906,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "tlaplus_examples_byzpaxos/BPConProof_Invariance.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4387,7 +4917,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 145
   },
   "tlaplus_examples_byzpaxos/BPConProof_KnowsSafeAtDef.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4397,7 +4928,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_byzpaxos/BPConProof_MaxBallotLemma1.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4407,7 +4939,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_byzpaxos/BPConProof_MaxBallotLemma2.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4417,7 +4950,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 22
   },
   "tlaplus_examples_byzpaxos/BPConProof_MaxBallotProp.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4427,7 +4961,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_byzpaxos/BPConProof_MsgsLemma.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4437,7 +4972,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 65
   },
   "tlaplus_examples_byzpaxos/BPConProof_MsgsTypeLemma.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4447,7 +4983,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_byzpaxos/BPConProof_MsgsTypeLemmaPrime.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4457,7 +4994,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_byzpaxos/BPConProof_NextDef.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4467,7 +5005,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_byzpaxos/BPConProof_PMaxBalLemma3.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4477,7 +5016,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_byzpaxos/BPConProof_PNextDef.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4487,7 +5027,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma1.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4497,7 +5038,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma2.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4507,7 +5049,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma4.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4517,7 +5060,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "tlaplus_examples_byzpaxos/BPConProof_PmaxBalLemma5.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4527,7 +5071,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_byzpaxos/BPConProof_QuorumTheorem.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/BPConProof.tla",
@@ -4537,42 +5082,48 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_byzpaxos/Consensus_EnabledDef.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel_2.tla",
       "tlaplus_examples_byzpaxos/Consensus_EnabledDefScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_byzpaxos/Consensus_InductiveInvariance.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel.tla",
       "tlaplus_examples_byzpaxos/Consensus_InductiveInvarianceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_byzpaxos/Consensus_Invariance.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel.tla",
       "tlaplus_examples_byzpaxos/Consensus_InvarianceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_byzpaxos/Consensus_LiveSpecEquals.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel_2.tla",
       "tlaplus_examples_byzpaxos/Consensus_LiveSpecEqualsScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_byzpaxos/Consensus_Liveness.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/Consensus.tla",
     "context": [
       "tlaplus_examples_byzpaxos/ConsensusModel_2.tla",
       "tlaplus_examples_byzpaxos/Consensus_LivenessScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_byzpaxos/PConProof_NextDef.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/PConProof.tla",
@@ -4580,7 +5131,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/PConProof_NextDefScaffold.tla",
       "tlaplus_examples_byzpaxos/VoteProof.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_byzpaxos/VoteProof_FiniteSetHasMax.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4588,7 +5140,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_4.tla",
       "tlaplus_examples_byzpaxos/VoteProof_FiniteSetHasMaxScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "tlaplus_examples_byzpaxos/VoteProof_InductiveInvariance.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4596,7 +5149,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_3.tla",
       "tlaplus_examples_byzpaxos/VoteProof_InductiveInvarianceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 87
   },
   "tlaplus_examples_byzpaxos/VoteProof_InitImpliesInv.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4604,7 +5158,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_3.tla",
       "tlaplus_examples_byzpaxos/VoteProof_InitImpliesInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_byzpaxos/VoteProof_Liveness.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4612,7 +5167,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_4.tla",
       "tlaplus_examples_byzpaxos/VoteProof_LivenessScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 149
   },
   "tlaplus_examples_byzpaxos/VoteProof_NextDef.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4620,7 +5176,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_3.tla",
       "tlaplus_examples_byzpaxos/VoteProof_NextDefScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_byzpaxos/VoteProof_QuorumNonEmpty.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4628,7 +5185,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel.tla",
       "tlaplus_examples_byzpaxos/VoteProof_QuorumNonEmptyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_byzpaxos/VoteProof_SafeAtProp.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4636,7 +5194,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
       "tlaplus_examples_byzpaxos/VoteProof_SafeAtPropScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "tlaplus_examples_byzpaxos/VoteProof_SafeAtPropPrime.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4644,7 +5203,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
       "tlaplus_examples_byzpaxos/VoteProof_SafeAtPropPrimeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_byzpaxos/VoteProof_SafeLemma.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4652,7 +5212,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
       "tlaplus_examples_byzpaxos/VoteProof_SafeLemmaScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 22
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT0.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4660,7 +5221,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
       "tlaplus_examples_byzpaxos/VoteProof_VT0Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 22
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT0Prime.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4668,7 +5230,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
       "tlaplus_examples_byzpaxos/VoteProof_VT0PrimeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT1.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4676,7 +5239,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
       "tlaplus_examples_byzpaxos/VoteProof_VT1Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 13
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT1Prime.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4684,7 +5248,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_2.tla",
       "tlaplus_examples_byzpaxos/VoteProof_VT1PrimeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT2.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4692,7 +5257,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_3.tla",
       "tlaplus_examples_byzpaxos/VoteProof_VT2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT3.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4700,7 +5266,8 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_3.tla",
       "tlaplus_examples_byzpaxos/VoteProof_VT3Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 28
   },
   "tlaplus_examples_byzpaxos/VoteProof_VT4.tla": {
     "spec_id": "tlaplus_examples_byzpaxos/VoteProof.tla",
@@ -4708,49 +5275,56 @@
       "tlaplus_examples_byzpaxos/Consensus.tla",
       "tlaplus_examples_byzpaxos/VoteProofModel_4.tla",
       "tlaplus_examples_byzpaxos/VoteProof_VT4Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 23
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_Invariant1.tla": {
     "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_Invariant1Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 16
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_NotAnEdgeNoEdge.tla": {
     "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_NotAnEdgeNoEdgeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_Safety.tla": {
     "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_SafetyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 21
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_Thm_CountersConsistent.tla": {
     "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_Thm_CountersConsistentScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_TreeInvariant.tla": {
     "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_TreeInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 135
   },
   "tlaplus_examples_ewd687a/EWD687a_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_ewd687a/EWD687a_proof.tla",
     "context": [
       "tlaplus_examples_ewd687a/EWD687a.tla",
       "tlaplus_examples_ewd687a/EWD687a_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd840/EWD840_proof_EnabledSystem.tla": {
     "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
@@ -4759,7 +5333,8 @@
       "tlaplus_examples_ewd840/EWD840_proofModel.tla",
       "tlaplus_examples_ewd840/EWD840_proof_EnabledSystemScaffold.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_ewd840/EWD840_proof_Invariant.tla": {
     "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
@@ -4768,7 +5343,8 @@
       "tlaplus_examples_ewd840/EWD840_proofModel.tla",
       "tlaplus_examples_ewd840/EWD840_proof_InvariantScaffold.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_ewd840/EWD840_proof_Live.tla": {
     "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
@@ -4777,7 +5353,8 @@
       "tlaplus_examples_ewd840/EWD840_proofModel_2.tla",
       "tlaplus_examples_ewd840/EWD840_proof_LiveScaffold.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_ewd840/EWD840_proof_Round1.tla": {
     "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
@@ -4786,7 +5363,8 @@
       "tlaplus_examples_ewd840/EWD840_proofModel_2.tla",
       "tlaplus_examples_ewd840/EWD840_proof_Round1Scaffold.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla"
-    ]
+    ],
+    "reference_proof_steps": 19
   },
   "tlaplus_examples_ewd840/EWD840_proof_Round2.tla": {
     "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
@@ -4795,7 +5373,8 @@
       "tlaplus_examples_ewd840/EWD840_proofModel_2.tla",
       "tlaplus_examples_ewd840/EWD840_proof_Round2Scaffold.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla"
-    ]
+    ],
+    "reference_proof_steps": 25
   },
   "tlaplus_examples_ewd840/EWD840_proof_Round3.tla": {
     "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
@@ -4804,7 +5383,8 @@
       "tlaplus_examples_ewd840/EWD840_proofModel_2.tla",
       "tlaplus_examples_ewd840/EWD840_proof_Round3Scaffold.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla"
-    ]
+    ],
+    "reference_proof_steps": 26
   },
   "tlaplus_examples_ewd840/EWD840_proof_Safety.tla": {
     "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
@@ -4813,7 +5393,8 @@
       "tlaplus_examples_ewd840/EWD840_proofModel.tla",
       "tlaplus_examples_ewd840/EWD840_proof_SafetyScaffold.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_ewd840/EWD840_proof_SpecLive.tla": {
     "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
@@ -4822,7 +5403,8 @@
       "tlaplus_examples_ewd840/EWD840_proofModel_2.tla",
       "tlaplus_examples_ewd840/EWD840_proof_SpecLiveScaffold.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd840/EWD840_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_ewd840/EWD840_proof.tla",
@@ -4831,77 +5413,88 @@
       "tlaplus_examples_ewd840/EWD840_proofModel.tla",
       "tlaplus_examples_ewd840/EWD840_proof_TypeCorrectScaffold.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_CorrectDetection.tla": {
     "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_CorrectDetectionScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Enabled_ST.tla": {
     "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Enabled_STScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Live.tla": {
     "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_LiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_Quiescent.tla": {
     "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_QuiescentScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_ewd840/SyncTerminationDetection_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_ewd840/SyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd840/SyncTerminationDetection.tla",
       "tlaplus_examples_ewd840/SyncTerminationDetection_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_EnabledDT.tla": {
     "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_EnabledDTScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Liveness.tla": {
     "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_LivenessScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Safety.tla": {
     "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_SafetyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Stability.tla": {
     "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_StabilityScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_ewd998/AsyncTerminationDetection_proof.tla",
     "context": [
       "tlaplus_examples_ewd998/AsyncTerminationDetection.tla",
       "tlaplus_examples_ewd998/AsyncTerminationDetection_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagAddDom.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -4910,7 +5503,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_BagAddDomScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagAddOfMsg.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -4919,7 +5513,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_BagAddOfMsgScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 23
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagAddPreservesToks.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -4928,7 +5523,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_BagAddPreservesToksScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 18
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagAdd_pl_increments.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -4937,7 +5533,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_BagAdd_pl_incrementsScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 13
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagAdd_tok_preserves_pl.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -4946,7 +5543,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_BagAdd_tok_preserves_plScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 13
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemoveDom.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -4955,7 +5553,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemoveDomScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemoveOfMsg.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -4964,7 +5563,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemoveOfMsgScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 26
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemovePreservesToks.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -4973,7 +5573,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemovePreservesToksScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 20
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemove_pl_decrements.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -4982,7 +5583,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemove_pl_decrementsScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 14
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemove_tok_preserves_pl.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -4991,7 +5593,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_BagRemove_tok_preserves_plScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 16
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_EmptyBagDom.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5000,7 +5603,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_EmptyBagDomScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitNetworkOK.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5009,7 +5613,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_InitNetworkOKScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 33
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitNetworkUniqueTok.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5018,7 +5623,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_InitNetworkUniqueTokScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitPending.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5027,7 +5633,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_InitPendingScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 27
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitRefinement.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5036,7 +5643,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_InitRefinementScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitToken.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5045,7 +5653,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_InitTokenScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 24
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitTypeOK.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5054,7 +5663,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_InitTypeOKScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_InitiatorIsZero.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5063,7 +5673,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_InitiatorIsZeroScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_NewTokInMsg.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5072,7 +5683,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_NewTokInMsgScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_NodeFact.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5081,7 +5693,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_NodeFactScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_PendingIsPlCount.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5090,7 +5703,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_PendingIsPlCountScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_PlMsgInMsg.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5099,7 +5713,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_PlMsgInMsgScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_SetToBagSingleton.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5108,7 +5723,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_SetToBagSingletonScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5117,7 +5733,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_ewd998/EWD998PCal_proof_TypeOK_Step.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998PCal_proof.tla",
@@ -5126,7 +5743,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998PCal.tla",
       "tlaplus_examples_ewd998/EWD998PCal_proof_TypeOK_StepScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 340
   },
   "tlaplus_examples_ewd998/EWD998_proof_B0NoMessagePending.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5135,7 +5753,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_B0NoMessagePendingScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "tlaplus_examples_ewd998/EWD998_proof_Detection.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5144,7 +5763,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel_2.tla",
       "tlaplus_examples_ewd998/EWD998_proof_DetectionScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "tlaplus_examples_ewd998/EWD998_proof_EnabledAtMaster.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5153,7 +5773,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_EnabledAtMasterScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 19
   },
   "tlaplus_examples_ewd998/EWD998_proof_EnabledSystem.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5162,7 +5783,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_EnabledSystemScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_ewd998/EWD998_proof_Invariance.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5171,7 +5793,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_InvarianceScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 131
   },
   "tlaplus_examples_ewd998/EWD998_proof_Live.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5180,7 +5803,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel_2.tla",
       "tlaplus_examples_ewd998/EWD998_proof_LiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998_proof_NodeIsFinite.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5189,7 +5813,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_NodeIsFiniteScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998_proof_NodeIsNode.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5198,7 +5823,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel_2.tla",
       "tlaplus_examples_ewd998/EWD998_proof_NodeIsNodeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998_proof_PlusACI.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5207,7 +5833,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_PlusACIScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998_proof_Refinement.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5216,7 +5843,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel_2.tla",
       "tlaplus_examples_ewd998/EWD998_proof_RefinementScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 46
   },
   "tlaplus_examples_ewd998/EWD998_proof_Round1.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5225,7 +5853,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel_2.tla",
       "tlaplus_examples_ewd998/EWD998_proof_Round1Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 21
   },
   "tlaplus_examples_ewd998/EWD998_proof_Round2.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5234,7 +5863,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel_2.tla",
       "tlaplus_examples_ewd998/EWD998_proof_Round2Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 30
   },
   "tlaplus_examples_ewd998/EWD998_proof_Round3.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5243,7 +5873,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel_2.tla",
       "tlaplus_examples_ewd998/EWD998_proof_Round3Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 41
   },
   "tlaplus_examples_ewd998/EWD998_proof_Safety.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5252,7 +5883,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_SafetyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 29
   },
   "tlaplus_examples_ewd998/EWD998_proof_SpecLive.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5261,7 +5893,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel_2.tla",
       "tlaplus_examples_ewd998/EWD998_proof_SpecLiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998_proof_SumEmpty.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5270,7 +5903,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_SumEmptyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998_proof_SumIsInt.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5279,7 +5913,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_SumIsIntScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998_proof_SumIsNat.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5288,7 +5923,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_SumIsNatScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998_proof_SumSingleton.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5297,7 +5933,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_SumSingletonScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_ewd998/EWD998_proof_SumZero.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5306,7 +5943,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_SumZeroScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "tlaplus_examples_ewd998/EWD998_proof_TerminationDetectionInv.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5315,7 +5953,8 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel_2.tla",
       "tlaplus_examples_ewd998/EWD998_proof_TerminationDetectionInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_ewd998/EWD998_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_ewd998/EWD998_proof.tla",
@@ -5324,35 +5963,40 @@
       "tlaplus_examples_ewd998/EWD998.tla",
       "tlaplus_examples_ewd998/EWD998_proofModel.tla",
       "tlaplus_examples_ewd998/EWD998_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "tlaplus_examples_glowingRaccoon/clean_proof_NatMinNat.tla": {
     "spec_id": "tlaplus_examples_glowingRaccoon/clean_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/clean_proof_NatMinNatScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_glowingRaccoon/clean_proof_Preservation.tla": {
     "spec_id": "tlaplus_examples_glowingRaccoon/clean_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/clean_proof_PreservationScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 37
   },
   "tlaplus_examples_glowingRaccoon/clean_proof_PrimerPositive.tla": {
     "spec_id": "tlaplus_examples_glowingRaccoon/clean_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/clean_proof_PrimerPositiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_glowingRaccoon/clean_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_glowingRaccoon/clean_proof.tla",
     "context": [
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/clean_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 20
   },
   "tlaplus_examples_glowingRaccoon/stages_proof_NatMinNat.tla": {
     "spec_id": "tlaplus_examples_glowingRaccoon/stages_proof.tla",
@@ -5360,7 +6004,8 @@
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/stages.tla",
       "tlaplus_examples_glowingRaccoon/stages_proof_NatMinNatScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_glowingRaccoon/stages_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_glowingRaccoon/stages_proof.tla",
@@ -5368,147 +6013,168 @@
       "tlaplus_examples_glowingRaccoon/clean.tla",
       "tlaplus_examples_glowingRaccoon/stages.tla",
       "tlaplus_examples_glowingRaccoon/stages_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 19
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneHead.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneHeadScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneSend.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneSendScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneTail.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_AtMostOneTailScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BasicInvariant.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BasicInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 131
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedFromAtMostOne.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedFromAtMostOneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedNetworkInv.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedNetworkInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BroadcastType.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_BroadcastTypeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ClockInvariant.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ClockInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 129
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ContainsSend.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ContainsSendScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ContainsTail.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_ContainsTailScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_MessageTypeInThree.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_MessageTypeInThreeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsAtMostOne.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsAtMostOneScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsPrecedes.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsPrecedesScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsSend.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_NotContainsSendScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesHead.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesHeadScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesInTail.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesInTailScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 6
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesSend.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesSendScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesTail.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_PrecedesTailScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_Safety.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_SafetyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 7
   },
   "tlaplus_examples_lamport_mutex/LamportMutex_proofs_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_lamport_mutex/LamportMutex_proofs.tla",
     "context": [
       "tlaplus_examples_lamport_mutex/LamportMutex.tla",
       "tlaplus_examples_lamport_mutex/LamportMutex_proofs_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 25
   },
   "tlaplus_examples_locks_auxiliary_vars/LockHS_AddingVariables.tla": {
     "spec_id": "tlaplus_examples_locks_auxiliary_vars/LockHS.tla",
@@ -5518,7 +6184,8 @@
       "tlaplus_examples_locks_auxiliary_vars/LockHS_AddingVariablesScaffold.tla",
       "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
       "tlaplus_examples_locks_auxiliary_vars/Stuttering.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "tlaplus_examples_locks_auxiliary_vars/LockHS_IndInvHS.tla": {
     "spec_id": "tlaplus_examples_locks_auxiliary_vars/LockHS.tla",
@@ -5528,7 +6195,8 @@
       "tlaplus_examples_locks_auxiliary_vars/LockHS_IndInvHSScaffold.tla",
       "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
       "tlaplus_examples_locks_auxiliary_vars/Stuttering.tla"
-    ]
+    ],
+    "reference_proof_steps": 34
   },
   "tlaplus_examples_locks_auxiliary_vars/LockHS_MutualExclusionHS.tla": {
     "spec_id": "tlaplus_examples_locks_auxiliary_vars/LockHS.tla",
@@ -5538,7 +6206,8 @@
       "tlaplus_examples_locks_auxiliary_vars/LockHS_MutualExclusionHSScaffold.tla",
       "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
       "tlaplus_examples_locks_auxiliary_vars/Stuttering.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_locks_auxiliary_vars/LockHS_TypingHS.tla": {
     "spec_id": "tlaplus_examples_locks_auxiliary_vars/LockHS.tla",
@@ -5548,21 +6217,24 @@
       "tlaplus_examples_locks_auxiliary_vars/LockHS_TypingHSScaffold.tla",
       "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
       "tlaplus_examples_locks_auxiliary_vars/Stuttering.tla"
-    ]
+    ],
+    "reference_proof_steps": 12
   },
   "tlaplus_examples_locks_auxiliary_vars/Lock_MutualExclusion.tla": {
     "spec_id": "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/LockModel.tla",
       "tlaplus_examples_locks_auxiliary_vars/Lock_MutualExclusionScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 11
   },
   "tlaplus_examples_locks_auxiliary_vars/Lock_Typing.tla": {
     "spec_id": "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
     "context": [
       "tlaplus_examples_locks_auxiliary_vars/LockModel.tla",
       "tlaplus_examples_locks_auxiliary_vars/Lock_TypingScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_locks_auxiliary_vars/Peterson_IndInvariant.tla": {
     "spec_id": "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
@@ -5570,7 +6242,8 @@
       "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
       "tlaplus_examples_locks_auxiliary_vars/PetersonModel.tla",
       "tlaplus_examples_locks_auxiliary_vars/Peterson_IndInvariantScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 14
   },
   "tlaplus_examples_locks_auxiliary_vars/Peterson_Refinement.tla": {
     "spec_id": "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
@@ -5578,7 +6251,8 @@
       "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
       "tlaplus_examples_locks_auxiliary_vars/PetersonModel.tla",
       "tlaplus_examples_locks_auxiliary_vars/Peterson_RefinementScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 14
   },
   "tlaplus_examples_locks_auxiliary_vars/Peterson_Typing.tla": {
     "spec_id": "tlaplus_examples_locks_auxiliary_vars/Peterson.tla",
@@ -5586,139 +6260,159 @@
       "tlaplus_examples_locks_auxiliary_vars/Lock.tla",
       "tlaplus_examples_locks_auxiliary_vars/PetersonModel.tla",
       "tlaplus_examples_locks_auxiliary_vars/Peterson_TypingScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_spanning/spanning_proof_SntMsgInv.tla": {
     "spec_id": "tlaplus_examples_spanning/spanning_proof.tla",
     "context": [
       "tlaplus_examples_spanning/spanning.tla",
       "tlaplus_examples_spanning/spanning_proof_SntMsgInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_spanning/spanning_proof_SntMsgStep.tla": {
     "spec_id": "tlaplus_examples_spanning/spanning_proof.tla",
     "context": [
       "tlaplus_examples_spanning/spanning.tla",
       "tlaplus_examples_spanning/spanning_proof_SntMsgStepScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 67
   },
   "tlaplus_examples_sums_even/sums_even_T1.tla": {
     "spec_id": "tlaplus_examples_sums_even/sums_even.tla",
     "context": [
       "tlaplus_examples_sums_even/sums_even_T1Scaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 17
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvInit.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvInitScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 10
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvIsInductive.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvIsInductiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 14
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvReset.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvResetScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 239
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvStutter.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvStutterScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvSystem.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvSystemScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 1433
   },
   "tlaplus_examples_tcp/tcp_proof_IndInvUser.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_IndInvUserScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 601
   },
   "tlaplus_examples_tcp/tcp_proof_InvInit.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_InvInitScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_tcp/tcp_proof_InvIsAB.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_InvIsABScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_tcp/tcp_proof_NetworkType.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_NetworkTypeScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_tcp/tcp_proof_PeersAB.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_PeersABScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 26
   },
   "tlaplus_examples_tcp/tcp_proof_PrefixOneNonEmpty.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_PrefixOneNonEmptyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "tlaplus_examples_tcp/tcp_proof_PrefixTwoNonEmpty.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_PrefixTwoNonEmptyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 5
   },
   "tlaplus_examples_tcp/tcp_proof_SpecImpliesIndInv.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_SpecImpliesIndInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_tcp/tcp_proof_SpecImpliesInv.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_SpecImpliesInvScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 3
   },
   "tlaplus_examples_tcp/tcp_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_tcp/tcp_proof_TypeOKInductive.tla": {
     "spec_id": "tlaplus_examples_tcp/tcp_proof.tla",
     "context": [
       "tlaplus_examples_tcp/tcp.tla",
       "tlaplus_examples_tcp/tcp_proof_TypeOKInductiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 116
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_InitInv.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
@@ -5726,7 +6420,8 @@
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_InitInvScaffold.tla",
       "tlaplus_examples_transaction_commit/TCommit.tla"
-    ]
+    ],
+    "reference_proof_steps": 8
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_MajorityNonEmpty.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
@@ -5734,7 +6429,8 @@
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_MajorityNonEmptyScaffold.tla",
       "tlaplus_examples_transaction_commit/TCommit.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaxFnRec.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
@@ -5742,7 +6438,8 @@
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaxFnRecScaffold.tla",
       "tlaplus_examples_transaction_commit/TCommit.tla"
-    ]
+    ],
+    "reference_proof_steps": 22
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaximumIsMaxFn.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
@@ -5750,7 +6447,8 @@
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaximumIsMaxFnScaffold.tla",
       "tlaplus_examples_transaction_commit/TCommit.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaximumProp.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
@@ -5758,7 +6456,8 @@
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_MaximumPropScaffold.tla",
       "tlaplus_examples_transaction_commit/TCommit.tla"
-    ]
+    ],
+    "reference_proof_steps": 69
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_NextInv.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
@@ -5766,7 +6465,8 @@
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_NextInvScaffold.tla",
       "tlaplus_examples_transaction_commit/TCommit.tla"
-    ]
+    ],
+    "reference_proof_steps": 103
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_Init.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
@@ -5774,7 +6474,8 @@
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_InitScaffold.tla",
       "tlaplus_examples_transaction_commit/TCommit.tla"
-    ]
+    ],
+    "reference_proof_steps": 0
   },
   "tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_Invariant.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/PaxosCommit_proof.tla",
@@ -5782,14 +6483,16 @@
       "tlaplus_examples_transaction_commit/PaxosCommit.tla",
       "tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_InvariantScaffold.tla",
       "tlaplus_examples_transaction_commit/TCommit.tla"
-    ]
+    ],
+    "reference_proof_steps": 4
   },
   "tlaplus_examples_transaction_commit/TCommit_proof_TCorrect.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/TCommit_proof.tla",
     "context": [
       "tlaplus_examples_transaction_commit/TCommit.tla",
       "tlaplus_examples_transaction_commit/TCommit_proof_TCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 9
   },
   "tlaplus_examples_transaction_commit/TwoPhase_proof_Consistency.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/TwoPhase_proof.tla",
@@ -5797,7 +6500,8 @@
       "tlaplus_examples_transaction_commit/TCommit.tla",
       "tlaplus_examples_transaction_commit/TwoPhase.tla",
       "tlaplus_examples_transaction_commit/TwoPhase_proof_ConsistencyScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 2
   },
   "tlaplus_examples_transaction_commit/TwoPhase_proof_InvInductive.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/TwoPhase_proof.tla",
@@ -5805,7 +6509,8 @@
       "tlaplus_examples_transaction_commit/TCommit.tla",
       "tlaplus_examples_transaction_commit/TwoPhase.tla",
       "tlaplus_examples_transaction_commit/TwoPhase_proof_InvInductiveScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 14
   },
   "tlaplus_examples_transaction_commit/TwoPhase_proof_TypeCorrect.tla": {
     "spec_id": "tlaplus_examples_transaction_commit/TwoPhase_proof.tla",
@@ -5813,6 +6518,7 @@
       "tlaplus_examples_transaction_commit/TCommit.tla",
       "tlaplus_examples_transaction_commit/TwoPhase.tla",
       "tlaplus_examples_transaction_commit/TwoPhase_proof_TypeCorrectScaffold.tla"
-    ]
+    ],
+    "reference_proof_steps": 14
   }
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -312,7 +312,7 @@ uv run tlaps-bench score results/proof-completion/*/results.json
 
 Strict comparisons require every run to contain the same applicable task IDs.
 
-Each manifest entry maps its mode-relative task ID to the originating `.tla` path under `source/` (`spec_id`). Tasks from the same source module form one scoring group.
+Each manifest entry maps its mode-relative task ID to the originating `.tla` path under `source/` (`spec_id`). Tasks from the same source module form one scoring group. Proof Completion entries also include `reference_proof_steps`.
 
 The default primary score is the specification pass rate: a represented specification passes only when all of its selected tasks pass.
 

--- a/scripts/annotate_pc_reference_proof_steps.py
+++ b/scripts/annotate_pc_reference_proof_steps.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Annotate Proof Completion manifest entries with reference_proof_steps."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from dataset.proof_completion.reference_steps import (  # noqa: E402
+    find_reference_proof_steps,
+    source_index,
+)
+
+SUITE = PROJECT_ROOT / "benchmark" / "proof-completion"
+MANIFEST = SUITE / "manifest.json"
+SOURCE = PROJECT_ROOT / "source"
+
+
+def main() -> int:
+    raw = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise SystemExit(f"unexpected manifest root: {type(raw)}")
+
+    index = source_index(SOURCE)
+    updated: dict[str, dict] = {}
+    missing = 0
+    for task_key, entry in raw.items():
+        if not isinstance(entry, dict):
+            raise SystemExit(f"bad entry for {task_key!r}")
+        steps = find_reference_proof_steps(
+            task_key,
+            suite_root=SUITE,
+            source_root=SOURCE,
+            indexed_sources=index,
+        )
+        if steps is None:
+            missing += 1
+        updated[task_key] = {
+            "spec_id": entry["spec_id"],
+            "context": entry["context"],
+            "reference_proof_steps": steps,
+        }
+
+    MANIFEST.write_text(json.dumps(dict(sorted(updated.items())), indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Annotated {len(updated)} tasks ({missing} with null reference_proof_steps)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/annotate_pc_reference_proof_steps.py
+++ b/scripts/annotate_pc_reference_proof_steps.py
@@ -45,7 +45,9 @@ def main() -> int:
             "reference_proof_steps": steps,
         }
 
-    MANIFEST.write_text(json.dumps(dict(sorted(updated.items())), indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    MANIFEST.write_text(
+        json.dumps(dict(sorted(updated.items())), indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
     print(f"Annotated {len(updated)} tasks ({missing} with null reference_proof_steps)")
     return 0
 

--- a/src/common/task_contract.py
+++ b/src/common/task_contract.py
@@ -19,6 +19,12 @@ from common.tla_modules import RESOLVABLE_MODULES, referenced_modules
 
 MANIFEST_FILENAME = "manifest.json"
 
+_BASE_MANIFEST_ENTRY_KEYS = frozenset({"spec_id", "context"})
+_SUITE_MANIFEST_ENTRY_KEYS = {
+    "proof-completion": frozenset({"spec_id", "context", "reference_proof_steps"}),
+    "proof-from-scratch": _BASE_MANIFEST_ENTRY_KEYS,
+}
+
 BEGIN_AGENT_HELPERS = r"\* BEGIN AGENT HELPERS"
 END_AGENT_HELPERS = r"\* END AGENT HELPERS"
 BEGIN_AGENT_PROOF = r"\* BEGIN AGENT PROOF"
@@ -56,6 +62,7 @@ class TaskBoundary:
     spec_id: str
     task_path: Path
     context_paths: tuple[Path, ...]
+    reference_proof_steps: int | None = None
 
 
 @dataclass(frozen=True)
@@ -188,13 +195,47 @@ def _relative_tla_path(value: str, *, label: str) -> PurePosixPath:
     return path
 
 
-def _manifest_specification_id(task_key: str, entry: Any) -> str:
-    if type(entry) is not dict or set(entry) != {"spec_id", "context"}:
-        raise ManifestError(f"manifest entry {task_key!r} must be an object containing exactly 'spec_id' and 'context'")
+def _manifest_entry_keys(suite_name: str) -> frozenset[str]:
+    return _SUITE_MANIFEST_ENTRY_KEYS.get(suite_name, _BASE_MANIFEST_ENTRY_KEYS)
+
+
+def _manifest_entry_keys_message(suite_name: str) -> str:
+    preferred = ("spec_id", "context", "reference_proof_steps")
+    keys = [key for key in preferred if key in _manifest_entry_keys(suite_name)]
+    for key in sorted(_manifest_entry_keys(suite_name)):
+        if key not in keys:
+            keys.append(key)
+    if len(keys) == 1:
+        return f"exactly '{keys[0]}'"
+    if len(keys) == 2:
+        return f"exactly '{keys[0]}' and '{keys[1]}'"
+    return "exactly " + ", ".join(f"'{key}'" for key in keys[:-1]) + f", and '{keys[-1]}'"
+
+
+def _manifest_reference_proof_steps(task_key: str, entry: Mapping[str, Any], *, suite_name: str) -> int | None:
+    if suite_name != "proof-completion":
+        return None
+    steps = entry["reference_proof_steps"]
+    if steps is None:
+        return None
+    if type(steps) is not int or isinstance(steps, bool) or steps < 0:
+        raise ManifestError(
+            f"manifest entry {task_key!r} field 'reference_proof_steps' must be a non-negative integer or null"
+        )
+    return steps
+
+
+def _manifest_specification_id(task_key: str, entry: Any, *, suite_name: str) -> str:
+    expected = _manifest_entry_keys(suite_name)
+    if type(entry) is not dict or set(entry) != expected:
+        raise ManifestError(
+            f"manifest entry {task_key!r} must be an object containing {_manifest_entry_keys_message(suite_name)}"
+        )
     spec_id = entry["spec_id"]
     if type(spec_id) is not str:
         raise ManifestError(f"manifest entry {task_key!r} field 'spec_id' must be a string")
     _relative_tla_path(spec_id, label=f"manifest entry {task_key!r} field 'spec_id'")
+    _manifest_reference_proof_steps(task_key, entry, suite_name=suite_name)
     return spec_id
 
 
@@ -216,7 +257,7 @@ def load_manifest_specification_ids(suite_root: Path, *, suite_name: str) -> Map
         if type(task_key) is not str:
             raise ManifestError(f"{suite_name} manifest task keys must be strings")
         _relative_tla_path(task_key, label="manifest task key")
-        specification_ids[task_key] = _manifest_specification_id(task_key, entry)
+        specification_ids[task_key] = _manifest_specification_id(task_key, entry, suite_name=suite_name)
     return MappingProxyType(dict(sorted(specification_ids.items())))
 
 
@@ -327,7 +368,7 @@ def load_task_manifest(
     if type(raw) is not dict:
         raise ManifestError(f"{suite_name} manifest root must be a JSON object")
 
-    specifications: dict[str, tuple[str, Path, list[tuple[str, Path]]]] = {}
+    specifications: dict[str, tuple[str, Path, list[tuple[str, Path]], int | None]] = {}
     task_paths: dict[Path, str] = {}
 
     for task_key, entry in raw.items():
@@ -341,7 +382,8 @@ def load_task_manifest(
             raise ManifestError(f"manifest tasks {previous_task!r} and {task_key!r} resolve to the same file")
         task_paths[task_path] = task_key
 
-        spec_id = _manifest_specification_id(task_key, entry)
+        spec_id = _manifest_specification_id(task_key, entry, suite_name=suite_name)
+        reference_proof_steps = _manifest_reference_proof_steps(task_key, entry, suite_name=suite_name)
 
         context = entry["context"]
         if type(context) is not list:
@@ -373,12 +415,12 @@ def load_task_manifest(
             seen_context_paths.add(context_path)
             resolved_context.append((context_key, context_path))
 
-        specifications[task_key] = (spec_id, task_path, resolved_context)
+        specifications[task_key] = (spec_id, task_path, resolved_context, reference_proof_steps)
 
     boundaries: dict[str, TaskBoundary] = {}
     task_keys = set(specifications)
     for task_key in sorted(specifications):
-        spec_id, task_path, context_entries = specifications[task_key]
+        spec_id, task_path, context_entries, reference_proof_steps = specifications[task_key]
         context_paths: list[Path] = []
         for context_key, context_path in context_entries:
             if context_key == task_key or context_path == task_path:
@@ -396,6 +438,7 @@ def load_task_manifest(
             spec_id=spec_id,
             task_path=task_path,
             context_paths=resolved_paths,
+            reference_proof_steps=reference_proof_steps,
         )
 
     return MappingProxyType(boundaries)

--- a/src/dataset/proof_completion/generate.py
+++ b/src/dataset/proof_completion/generate.py
@@ -52,6 +52,7 @@ from common.proof_completion_contract import (
     parse_proof_completion_region,
 )
 from common.task_contract import MANIFEST_FILENAME
+from dataset.proof_completion.reference_steps import reference_proof_steps_for_name
 from dataset.specification_identity import source_spec_id
 
 COMMUNITY_MODULES = _tla_modules.COMMUNITY_MODULES
@@ -1583,6 +1584,7 @@ def emit_layered_source(
         manifest[task_key] = {
             "spec_id": spec_id,
             "context": sorted(set(context)),
+            "reference_proof_steps": reference_proof_steps_for_name(source_lines, target_thm["name"]),
         }
         audit_state.setdefault("scaffold_owner", {}).setdefault(f"{subdir}/{scaffold_module}.tla", []).append(task_key)
 

--- a/src/dataset/proof_completion/reference_steps.py
+++ b/src/dataset/proof_completion/reference_steps.py
@@ -1,0 +1,115 @@
+"""Count reference-proof steps for Proof Completion tasks."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+
+STEP_LINE_RE = re.compile(r"^[ \t]*<(\d+)")
+_THEOREM_HEADER_RE = re.compile(r"^(THEOREM|LEMMA|COROLLARY|PROPOSITION)\s+(\w+)\s*==")
+
+
+def strip_block_and_line_comments(text: str) -> str:
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_block = False
+    while i < n:
+        if not in_block and text.startswith("(*", i):
+            in_block = True
+            i += 2
+            continue
+        if in_block:
+            if text.startswith("*)", i):
+                in_block = False
+                i += 2
+            else:
+                i += 1
+            continue
+        if text.startswith("\\*", i):
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        out.append(text[i])
+        i += 1
+    return "".join(out)
+
+
+def count_reference_proof_steps(proof_lines: list[str]) -> int:
+    clean = strip_block_and_line_comments("\n".join(proof_lines))
+    return sum(1 for line in clean.splitlines() if STEP_LINE_RE.match(line))
+
+
+def reference_proof_steps_for_name(source_lines: list[str], theorem_name: str) -> int | None:
+    from dataset.proof_completion.generate import get_theorem_proof_lines, parse_theorems
+
+    for thm in parse_theorems(source_lines):
+        if thm.name == theorem_name and thm.has_proof:
+            proof_lines = get_theorem_proof_lines(source_lines, thm)
+            while proof_lines and not proof_lines[-1].strip():
+                proof_lines.pop()
+            while proof_lines:
+                trailing = proof_lines[-1].strip()
+                if not trailing or trailing.startswith("(*") or trailing.startswith("\\*"):
+                    proof_lines.pop()
+                    continue
+                break
+            return count_reference_proof_steps(proof_lines)
+    return None
+
+
+def target_theorem_name(task_path: Path) -> str | None:
+    try:
+        lines = task_path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError):
+        return None
+    for line in reversed(lines):
+        match = _THEOREM_HEADER_RE.match(line.strip())
+        if match:
+            return match.group(2)
+    return None
+
+
+def source_index(source_root: Path) -> dict[str, list[Path]]:
+    index: dict[str, list[Path]] = defaultdict(list)
+    for path in source_root.rglob("*.tla"):
+        try:
+            relative = path.relative_to(source_root)
+        except ValueError:
+            continue
+        if relative.parts:
+            index[relative.parts[0]].append(path)
+    return index
+
+
+def find_reference_proof_steps(
+    task_key: str,
+    *,
+    suite_root: Path,
+    source_root: Path,
+    indexed_sources: dict[str, list[Path]] | None = None,
+) -> int | None:
+    module_dir = task_key.split("/", 1)[0]
+    name_no_ext = Path(task_key).stem
+    theorem = target_theorem_name(suite_root / task_key)
+    if not theorem:
+        return None
+
+    index = indexed_sources if indexed_sources is not None else source_index(source_root)
+    candidates: list[Path] = []
+    for path in index.get(module_dir, []):
+        if name_no_ext.startswith(path.stem + "_"):
+            candidates.insert(0, path)
+        else:
+            candidates.append(path)
+
+    for source_path in candidates:
+        try:
+            source_lines = source_path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError):
+            continue
+        steps = reference_proof_steps_for_name(source_lines, theorem)
+        if steps is not None:
+            return steps
+    return None

--- a/tests/common/test_proof_completion_contract.py
+++ b/tests/common/test_proof_completion_contract.py
@@ -61,10 +61,11 @@ def test_loads_sorted_tasks_and_preserves_exact_context_order(tmp_path):
     _write_manifest(
         suite,
         {
-            "Zed/Zed_Target.tla": {"spec_id": "Fixture.tla", "context": []},
+            "Zed/Zed_Target.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0},
             "Alpha/Alpha_Target.tla": {
                 "spec_id": "Fixture.tla",
                 "context": ["Context/Scaffold.tla", "Context/Model.tla"],
+                "reference_proof_steps": 3,
             },
         },
     )
@@ -75,22 +76,47 @@ def test_loads_sorted_tasks_and_preserves_exact_context_order(tmp_path):
     assert boundaries["Alpha/Alpha_Target.tla"].task_path == task_a
     assert boundaries["Alpha/Alpha_Target.tla"].spec_id == "Fixture.tla"
     assert boundaries["Alpha/Alpha_Target.tla"].context_paths == (scaffold, model)
+    assert boundaries["Alpha/Alpha_Target.tla"].reference_proof_steps == 3
     assert boundaries["Zed/Zed_Target.tla"].task_path == task_z
+    assert boundaries["Zed/Zed_Target.tla"].reference_proof_steps == 0
 
 
 def test_manifest_requires_a_specification_identity(tmp_path):
     suite = tmp_path / "proof-completion"
     _write_task(suite, "Task.tla")
-    _write_manifest(suite, {"Task.tla": {"context": []}})
+    _write_manifest(suite, {"Task.tla": {"context": [], "reference_proof_steps": 0}})
 
-    with pytest.raises(ManifestError, match="exactly 'spec_id' and 'context'"):
+    with pytest.raises(ManifestError, match="exactly 'spec_id', 'context', and 'reference_proof_steps'"):
         load_proof_completion_manifest(suite)
+
+
+@pytest.mark.parametrize("bad_steps", [-1, True, 1.5, "3"])
+def test_manifest_rejects_invalid_reference_proof_steps(tmp_path, bad_steps):
+    suite = tmp_path / "proof-completion"
+    _write_task(suite, "Task.tla")
+    _write_manifest(
+        suite,
+        {"Task.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": bad_steps}},
+    )
+
+    with pytest.raises(ManifestError, match="reference_proof_steps"):
+        load_proof_completion_manifest(suite)
+
+
+def test_manifest_allows_null_reference_proof_steps(tmp_path):
+    suite = tmp_path / "proof-completion"
+    _write_task(suite, "Task.tla")
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": None}})
+
+    boundaries = load_proof_completion_manifest(suite)
+
+    assert boundaries["Task.tla"].reference_proof_steps is None
 
 
 def test_task_requires_exact_proof_markers(tmp_path):
     suite = tmp_path / "proof-completion"
     _write_module(suite, "Task.tla", body="THEOREM Target == TRUE\nPROOF OBVIOUS\n")
-    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": []}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}})
 
     with pytest.raises(ManifestError, match="Task.tla.*invalid editable regions"):
         load_proof_completion_manifest(suite)
@@ -103,7 +129,7 @@ def test_task_cannot_expose_a_helper_region(tmp_path):
         "Task.tla",
         body=f"{BEGIN_AGENT_HELPERS}\nHelper == TRUE\n{END_AGENT_HELPERS}\n",
     )
-    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": []}})
+    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}})
 
     with pytest.raises(ManifestError, match="must not contain an AGENT HELPERS region"):
         load_proof_completion_manifest(suite)
@@ -114,7 +140,10 @@ def test_manifest_context_must_cover_transitive_references(tmp_path):
     _write_task(suite, "Task.tla", body="EXTENDS Model\n")
     _write_module(suite, "Model.tla", body="EXTENDS Missing\n")
     _write_module(suite, "Missing.tla")
-    _write_manifest(suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": ["Model.tla"]}})
+    _write_manifest(
+        suite,
+        {"Task.tla": {"spec_id": "Fixture.tla", "context": ["Model.tla"], "reference_proof_steps": 0}},
+    )
 
     with pytest.raises(ManifestError, match="incomplete context.*Missing"):
         load_proof_completion_manifest(suite)

--- a/tests/dataset/test_layered_generator.py
+++ b/tests/dataset/test_layered_generator.py
@@ -113,7 +113,11 @@ def _write_task(root, subdir, name, body="THEOREM TRUE", defs_body="Inv == TRUE"
     d.mkdir(parents=True, exist_ok=True)
     (d / f"{name}.tla").write_text(build_task_module(name, f"{name}Defs", body))
     (d / f"{name}Defs.tla").write_text(f"---- MODULE {name}Defs ----\n{defs_body}\n====\n")
-    return f"{subdir}/{name}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{name}Defs.tla"], "reference_proof_steps": 0}
+    return f"{subdir}/{name}.tla", {
+        "spec_id": "Fixture.tla",
+        "context": [f"{subdir}/{name}Defs.tla"],
+        "reference_proof_steps": 0,
+    }
 
 
 def test_dataset_selection_bootstraps_from_flat_task_tree(tmp_path):
@@ -128,7 +132,9 @@ def test_dataset_selection_bootstraps_from_flat_task_tree(tmp_path):
 def test_layered_manifest_becomes_the_dataset_selection(tmp_path):
     _write_task(tmp_path, "Legacy", "Legacy_Thm")
     manifest_key = "Current/Current_Thm.tla"
-    (tmp_path / "manifest.json").write_text(json.dumps({manifest_key: {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}}))
+    (tmp_path / "manifest.json").write_text(
+        json.dumps({manifest_key: {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}})
+    )
 
     assert load_dataset_task_keys(str(tmp_path)) == {manifest_key}
 

--- a/tests/dataset/test_layered_generator.py
+++ b/tests/dataset/test_layered_generator.py
@@ -113,7 +113,7 @@ def _write_task(root, subdir, name, body="THEOREM TRUE", defs_body="Inv == TRUE"
     d.mkdir(parents=True, exist_ok=True)
     (d / f"{name}.tla").write_text(build_task_module(name, f"{name}Defs", body))
     (d / f"{name}Defs.tla").write_text(f"---- MODULE {name}Defs ----\n{defs_body}\n====\n")
-    return f"{subdir}/{name}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{name}Defs.tla"]}
+    return f"{subdir}/{name}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{name}Defs.tla"], "reference_proof_steps": 0}
 
 
 def test_dataset_selection_bootstraps_from_flat_task_tree(tmp_path):
@@ -128,7 +128,7 @@ def test_dataset_selection_bootstraps_from_flat_task_tree(tmp_path):
 def test_layered_manifest_becomes_the_dataset_selection(tmp_path):
     _write_task(tmp_path, "Legacy", "Legacy_Thm")
     manifest_key = "Current/Current_Thm.tla"
-    (tmp_path / "manifest.json").write_text(json.dumps({manifest_key: {"spec_id": "Fixture.tla", "context": []}}))
+    (tmp_path / "manifest.json").write_text(json.dumps({manifest_key: {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}}))
 
     assert load_dataset_task_keys(str(tmp_path)) == {manifest_key}
 
@@ -715,7 +715,7 @@ def _triviality_env(tmp_path, monkeypatch, verdicts):
         return verdicts[len(calls) - 1]
 
     monkeypatch.setattr(triviality_audit, "check_task", fake_check_task)
-    return {"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": []}}, calls
+    return {"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}}, calls
 
 
 def test_a_timed_out_task_is_rechecked_alone_on_the_graders_budget(tmp_path, monkeypatch):

--- a/tests/dataset/test_proof_completion_core.py
+++ b/tests/dataset/test_proof_completion_core.py
@@ -50,4 +50,4 @@ def test_core_tasks_expose_reference_proof_steps_for_website_complexity_bands():
 
     bands = Counter(_step_band(steps) for steps in steps_by_task.values())
     assert set(bands) == set(_CORE_STEP_BANDS)
-    assert sum(bands.values()) == 192
+    assert sum(bands.values()) == len(task_ids)

--- a/tests/dataset/test_proof_completion_core.py
+++ b/tests/dataset/test_proof_completion_core.py
@@ -1,10 +1,27 @@
 """The committed Proof Completion Core is a valid, stable task cohort."""
 
 import json
+from collections import Counter
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SUITE = REPO_ROOT / "benchmark" / "proof-completion"
+
+_CORE_STEP_BANDS = ("1-4", "5-12", "13-30", "31-50", "51-100", "101+")
+
+
+def _step_band(steps: int) -> str:
+    if steps <= 4:
+        return "1-4"
+    if steps <= 12:
+        return "5-12"
+    if steps <= 30:
+        return "13-30"
+    if steps <= 50:
+        return "31-50"
+    if steps <= 100:
+        return "51-100"
+    return "101+"
 
 
 def test_core_list_contains_192_unique_manifest_tasks_from_56_specifications():
@@ -17,3 +34,20 @@ def test_core_list_contains_192_unique_manifest_tasks_from_56_specifications():
     assert set(task_ids) <= set(manifest)
     assert all((SUITE / task_id).is_file() for task_id in task_ids)
     assert len({manifest[task_id]["spec_id"] for task_id in task_ids}) == 56
+
+
+def test_core_tasks_expose_reference_proof_steps_for_website_complexity_bands():
+    manifest = json.loads((SUITE / "manifest.json").read_text(encoding="utf-8"))
+    task_ids = [line.strip() for line in (SUITE / "core.txt").read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    steps_by_task = {}
+    for task_id in task_ids:
+        entry = manifest[task_id]
+        assert set(entry) == {"spec_id", "context", "reference_proof_steps"}, task_id
+        steps = entry["reference_proof_steps"]
+        assert type(steps) is int and steps > 0, f"Core task {task_id} must have a positive step count, got {steps!r}"
+        steps_by_task[task_id] = steps
+
+    bands = Counter(_step_band(steps) for steps in steps_by_task.values())
+    assert set(bands) == set(_CORE_STEP_BANDS)
+    assert sum(bands.values()) == 192

--- a/tests/dataset/test_proof_completion_layered.py
+++ b/tests/dataset/test_proof_completion_layered.py
@@ -492,7 +492,7 @@ def test_dataset_selection_bootstraps_from_the_flat_task_tree(tmp_path):
 
 def test_dataset_selection_prefers_an_existing_manifest(tmp_path):
     (tmp_path / "manifest.json").write_text(
-        json.dumps({"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": []}})
+        json.dumps({"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}})
     )
     (tmp_path / "Stray.tla").write_text("---- MODULE Stray ----\nTHEOREM TRUE\n====\n")
     assert load_dataset_task_keys(str(tmp_path)) == {"Group/Group_Thm.tla"}
@@ -501,7 +501,7 @@ def test_dataset_selection_prefers_an_existing_manifest(tmp_path):
 def test_dataset_selection_uses_complete_manifest_without_scanning_extra_flat_tasks(tmp_path):
     """Once migration is complete, the manifest is the whole dataset index."""
     (tmp_path / "manifest.json").write_text(
-        json.dumps({"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": ["Group/Group_ThmScaffold.tla"]}})
+        json.dumps({"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": ["Group/Group_ThmScaffold.tla"], "reference_proof_steps": 0}})
     )
     benor = tmp_path / "BenOr"
     benor.mkdir()
@@ -514,7 +514,7 @@ def test_dataset_selection_does_not_recount_manifest_context_layers(tmp_path):
     task-file rule — but the manifest already names it as context, so it must not
     be mistaken for an un-migrated task."""
     (tmp_path / "manifest.json").write_text(
-        json.dumps({"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": ["Group/Group_ThmScaffold.tla"]}})
+        json.dumps({"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": ["Group/Group_ThmScaffold.tla"], "reference_proof_steps": 0}})
     )
     group = tmp_path / "Group"
     group.mkdir()
@@ -530,7 +530,7 @@ def _emit_task(root, subdir, module, statement="THEOREM Thm == TRUE"):
     scaffold = f"{module}Scaffold"
     (directory / f"{scaffold}.tla").write_text(f"---- MODULE {scaffold} ----\nGiven == TRUE\n====\n")
     (directory / f"{module}.tla").write_text(build_task_module(module, scaffold, statement))
-    return f"{subdir}/{module}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{scaffold}.tla"]}
+    return f"{subdir}/{module}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{scaffold}.tla"], "reference_proof_steps": 0}
 
 
 def _finalize(root, manifest, audit_state=None, **kwargs):
@@ -670,7 +670,7 @@ def test_seed_staging_copies_the_current_dataset_verbatim(tmp_path):
     source = tmp_path / "dataset"
     (source / "Group").mkdir(parents=True)
     (source / "Group" / "Group_Thm.tla").write_text("theorem body")
-    (source / "manifest.json").write_text('{"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": []}}')
+    (source / "manifest.json").write_text('{"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}}')
     staging = tmp_path / "staging"
     staging.mkdir()
 
@@ -679,7 +679,7 @@ def test_seed_staging_copies_the_current_dataset_verbatim(tmp_path):
     assert (staging / "Group" / "Group_Thm.tla").read_text() == "theorem body"
     assert (
         staging / "manifest.json"
-    ).read_text() == '{"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": []}}'
+    ).read_text() == '{"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}}'
 
 
 def test_filtered_finalization_keeps_tasks_outside_the_filter(tmp_path):
@@ -760,7 +760,7 @@ def test_finalize_flags_a_scaffold_two_tasks_share(tmp_path):
     (tmp_path / "Group" / "Group_Two.tla").write_text(
         build_task_module("Group_Two", "Group_OneScaffold", "THEOREM Other == TRUE")
     )
-    manifest = {first: entry, second: {"spec_id": "Fixture.tla", "context": entry["context"]}}
+    manifest = {first: entry, second: {"spec_id": "Fixture.tla", "context": entry["context"], "reference_proof_steps": 0}}
     audit_state = {"scaffold_owner": {entry["context"][0]: [first, second]}}
     _finalize(tmp_path, manifest, audit_state)
 
@@ -824,7 +824,11 @@ def test_finalize_keeps_context_a_failing_run_would_have_swept(tmp_path):
 
 def test_finalize_refuses_a_manifest_the_evaluator_would_reject(tmp_path):
     key, entry = _emit_task(tmp_path, "Group", "Group_Thm")
-    entry = {"spec_id": "Fixture.tla", "context": [*entry["context"], "Group/Missing.tla"]}
+    entry = {
+        "spec_id": "Fixture.tla",
+        "context": [*entry["context"], "Group/Missing.tla"],
+        "reference_proof_steps": 0,
+    }
     with pytest.raises(ManifestError):
         _finalize(tmp_path, {key: entry})
 
@@ -838,7 +842,7 @@ def _dup_task(root, subdir, module, scaffold_body="Given == TRUE"):
     scaffold = f"{module}Scaffold"
     (directory / f"{scaffold}.tla").write_text(f"---- MODULE {scaffold} ----\n{scaffold_body}\n====\n")
     (directory / f"{module}.tla").write_text(build_task_module(module, scaffold, "THEOREM Thm == TRUE"))
-    return f"{subdir}/{module}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{scaffold}.tla"]}
+    return f"{subdir}/{module}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{scaffold}.tla"], "reference_proof_steps": 0}
 
 
 def test_an_approved_duplicate_keeps_only_the_canonical_copy(tmp_path):

--- a/tests/dataset/test_proof_completion_layered.py
+++ b/tests/dataset/test_proof_completion_layered.py
@@ -501,7 +501,15 @@ def test_dataset_selection_prefers_an_existing_manifest(tmp_path):
 def test_dataset_selection_uses_complete_manifest_without_scanning_extra_flat_tasks(tmp_path):
     """Once migration is complete, the manifest is the whole dataset index."""
     (tmp_path / "manifest.json").write_text(
-        json.dumps({"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": ["Group/Group_ThmScaffold.tla"], "reference_proof_steps": 0}})
+        json.dumps(
+            {
+                "Group/Group_Thm.tla": {
+                    "spec_id": "Fixture.tla",
+                    "context": ["Group/Group_ThmScaffold.tla"],
+                    "reference_proof_steps": 0,
+                }
+            }
+        )
     )
     benor = tmp_path / "BenOr"
     benor.mkdir()
@@ -514,7 +522,15 @@ def test_dataset_selection_does_not_recount_manifest_context_layers(tmp_path):
     task-file rule — but the manifest already names it as context, so it must not
     be mistaken for an un-migrated task."""
     (tmp_path / "manifest.json").write_text(
-        json.dumps({"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": ["Group/Group_ThmScaffold.tla"], "reference_proof_steps": 0}})
+        json.dumps(
+            {
+                "Group/Group_Thm.tla": {
+                    "spec_id": "Fixture.tla",
+                    "context": ["Group/Group_ThmScaffold.tla"],
+                    "reference_proof_steps": 0,
+                }
+            }
+        )
     )
     group = tmp_path / "Group"
     group.mkdir()
@@ -530,7 +546,11 @@ def _emit_task(root, subdir, module, statement="THEOREM Thm == TRUE"):
     scaffold = f"{module}Scaffold"
     (directory / f"{scaffold}.tla").write_text(f"---- MODULE {scaffold} ----\nGiven == TRUE\n====\n")
     (directory / f"{module}.tla").write_text(build_task_module(module, scaffold, statement))
-    return f"{subdir}/{module}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{scaffold}.tla"], "reference_proof_steps": 0}
+    return f"{subdir}/{module}.tla", {
+        "spec_id": "Fixture.tla",
+        "context": [f"{subdir}/{scaffold}.tla"],
+        "reference_proof_steps": 0,
+    }
 
 
 def _finalize(root, manifest, audit_state=None, **kwargs):
@@ -670,7 +690,9 @@ def test_seed_staging_copies_the_current_dataset_verbatim(tmp_path):
     source = tmp_path / "dataset"
     (source / "Group").mkdir(parents=True)
     (source / "Group" / "Group_Thm.tla").write_text("theorem body")
-    (source / "manifest.json").write_text('{"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}}')
+    (source / "manifest.json").write_text(
+        '{"Group/Group_Thm.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}}'
+    )
     staging = tmp_path / "staging"
     staging.mkdir()
 
@@ -760,7 +782,10 @@ def test_finalize_flags_a_scaffold_two_tasks_share(tmp_path):
     (tmp_path / "Group" / "Group_Two.tla").write_text(
         build_task_module("Group_Two", "Group_OneScaffold", "THEOREM Other == TRUE")
     )
-    manifest = {first: entry, second: {"spec_id": "Fixture.tla", "context": entry["context"], "reference_proof_steps": 0}}
+    manifest = {
+        first: entry,
+        second: {"spec_id": "Fixture.tla", "context": entry["context"], "reference_proof_steps": 0},
+    }
     audit_state = {"scaffold_owner": {entry["context"][0]: [first, second]}}
     _finalize(tmp_path, manifest, audit_state)
 
@@ -842,7 +867,11 @@ def _dup_task(root, subdir, module, scaffold_body="Given == TRUE"):
     scaffold = f"{module}Scaffold"
     (directory / f"{scaffold}.tla").write_text(f"---- MODULE {scaffold} ----\n{scaffold_body}\n====\n")
     (directory / f"{module}.tla").write_text(build_task_module(module, scaffold, "THEOREM Thm == TRUE"))
-    return f"{subdir}/{module}.tla", {"spec_id": "Fixture.tla", "context": [f"{subdir}/{scaffold}.tla"], "reference_proof_steps": 0}
+    return f"{subdir}/{module}.tla", {
+        "spec_id": "Fixture.tla",
+        "context": [f"{subdir}/{scaffold}.tla"],
+        "reference_proof_steps": 0,
+    }
 
 
 def test_an_approved_duplicate_keeps_only_the_canonical_copy(tmp_path):

--- a/tests/dataset/test_reference_proof_steps.py
+++ b/tests/dataset/test_reference_proof_steps.py
@@ -1,0 +1,36 @@
+"""Reference-proof step counting for Proof Completion."""
+
+from dataset.proof_completion.reference_steps import (
+    count_reference_proof_steps,
+    reference_proof_steps_for_name,
+)
+
+
+def test_count_reference_proof_steps_ignores_comments_and_direct_proofs():
+    assert count_reference_proof_steps(["BY DEF Foo"]) == 0
+    assert count_reference_proof_steps(["<1>1. TRUE", "  <2>1. TRUE", "<1> QED"]) == 3
+    assert count_reference_proof_steps(["\\* <1>1. commented", "(*", "<1>2. also commented", "*)", "<1>1. real"]) == 1
+
+
+def test_reference_proof_steps_for_name_returns_none_for_obvious():
+    lines = [
+        "---- MODULE M ----",
+        "THEOREM CompleteSafety == TRUE",
+        "PROOF OBVIOUS",
+        "====",
+    ]
+    assert reference_proof_steps_for_name(lines, "CompleteSafety") is None
+
+
+def test_reference_proof_steps_for_name_counts_structured_and_direct():
+    lines = [
+        "---- MODULE M ----",
+        "LEMMA Direct == TRUE",
+        "BY DEF Direct",
+        "THEOREM Structured == TRUE",
+        "<1>1. TRUE",
+        "<1> QED",
+        "====",
+    ]
+    assert reference_proof_steps_for_name(lines, "Direct") == 0
+    assert reference_proof_steps_for_name(lines, "Structured") == 2

--- a/tests/dataset/test_specification_identity.py
+++ b/tests/dataset/test_specification_identity.py
@@ -37,9 +37,7 @@ def test_current_manifests_map_every_task_to_an_existing_source_specification():
         manifests[mode] = manifest
         assert manifest
         expected_keys = (
-            {"spec_id", "context", "reference_proof_steps"}
-            if mode == "proof-completion"
-            else {"spec_id", "context"}
+            {"spec_id", "context", "reference_proof_steps"} if mode == "proof-completion" else {"spec_id", "context"}
         )
         for task_id, entry in manifest.items():
             assert set(entry) == expected_keys, task_id

--- a/tests/dataset/test_specification_identity.py
+++ b/tests/dataset/test_specification_identity.py
@@ -25,7 +25,7 @@ def test_identity_loader_rejects_a_manifest_entry_without_a_mapping(tmp_path):
     suite.mkdir()
     (suite / "manifest.json").write_text(json.dumps({"Task.tla": {"context": []}}), encoding="utf-8")
 
-    with pytest.raises(ManifestError, match="exactly 'spec_id' and 'context'"):
+    with pytest.raises(ManifestError, match="exactly 'spec_id', 'context', and 'reference_proof_steps'"):
         load_manifest_specification_ids(suite, suite_name="proof-completion")
 
 
@@ -36,9 +36,17 @@ def test_current_manifests_map_every_task_to_an_existing_source_specification():
         manifest = json.loads(path.read_text(encoding="utf-8"))
         manifests[mode] = manifest
         assert manifest
+        expected_keys = (
+            {"spec_id", "context", "reference_proof_steps"}
+            if mode == "proof-completion"
+            else {"spec_id", "context"}
+        )
         for task_id, entry in manifest.items():
-            assert set(entry) == {"spec_id", "context"}, task_id
+            assert set(entry) == expected_keys, task_id
             assert (SOURCE_ROOT / entry["spec_id"]).is_file(), task_id
+            if mode == "proof-completion":
+                steps = entry["reference_proof_steps"]
+                assert steps is None or (isinstance(steps, int) and not isinstance(steps, bool) and steps >= 0)
 
     shared_tasks = set(manifests["proof-completion"]) & set(manifests["proof-from-scratch"])
     assert shared_tasks

--- a/tests/evaluator/test_proof_completion_mode.py
+++ b/tests/evaluator/test_proof_completion_mode.py
@@ -89,7 +89,9 @@ def test_strict_mode_discovers_only_manifest_tasks_and_exact_context(tmp_path):
 def test_strict_mode_is_pickleable_after_discovery(tmp_path):
     suite = tmp_path / "proof-completion"
     task = _write_task(suite, "Example/Example_Target.tla")
-    _write_manifest(suite, {"Example/Example_Target.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}})
+    _write_manifest(
+        suite, {"Example/Example_Target.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}}
+    )
     mode = _mode(tmp_path)
     mode.get_benchmark_files()
 
@@ -173,7 +175,10 @@ def test_strict_cli_captures_all_inputs_before_backend_setup(tmp_path, monkeypat
     suite = benchmark_root / "proof-completion"
     task = _write_task(suite, "Suite/Task.tla", "EXTENDS Model\n")
     model = _write_module(suite, "Context/Model.tla", "Value == TRUE\n")
-    _write_manifest(suite, {"Suite/Task.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"], "reference_proof_steps": 0}})
+    _write_manifest(
+        suite,
+        {"Suite/Task.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"], "reference_proof_steps": 0}},
+    )
     task_source = task.read_bytes()
     model_source = model.read_bytes()
     mode = ProofCompletion(str(benchmark_root), "/checker")

--- a/tests/evaluator/test_proof_completion_mode.py
+++ b/tests/evaluator/test_proof_completion_mode.py
@@ -62,10 +62,11 @@ def test_strict_mode_discovers_only_manifest_tasks_and_exact_context(tmp_path):
     _write_manifest(
         suite,
         {
-            "Zed/Zed_Target.tla": {"spec_id": "Fixture.tla", "context": []},
+            "Zed/Zed_Target.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0},
             "Alpha/Alpha_Target.tla": {
                 "spec_id": "Fixture.tla",
                 "context": ["Context/ModelB.tla", "Context/ModelA.tla"],
+                "reference_proof_steps": 0,
             },
         },
     )
@@ -88,7 +89,7 @@ def test_strict_mode_discovers_only_manifest_tasks_and_exact_context(tmp_path):
 def test_strict_mode_is_pickleable_after_discovery(tmp_path):
     suite = tmp_path / "proof-completion"
     task = _write_task(suite, "Example/Example_Target.tla")
-    _write_manifest(suite, {"Example/Example_Target.tla": {"spec_id": "Fixture.tla", "context": []}})
+    _write_manifest(suite, {"Example/Example_Target.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}})
     mode = _mode(tmp_path)
     mode.get_benchmark_files()
 
@@ -154,7 +155,7 @@ def test_marker_in_symlinked_directory_cannot_downgrade_to_legacy(tmp_path):
 def test_strict_and_legacy_modes_select_matching_prompts(tmp_path):
     strict_suite = tmp_path / "strict" / "proof-completion"
     _write_task(strict_suite, "Task.tla")
-    _write_manifest(strict_suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": []}})
+    _write_manifest(strict_suite, {"Task.tla": {"spec_id": "Fixture.tla", "context": [], "reference_proof_steps": 0}})
     legacy_suite = tmp_path / "legacy" / "proof-completion"
     legacy_suite.mkdir(parents=True)
 
@@ -172,7 +173,7 @@ def test_strict_cli_captures_all_inputs_before_backend_setup(tmp_path, monkeypat
     suite = benchmark_root / "proof-completion"
     task = _write_task(suite, "Suite/Task.tla", "EXTENDS Model\n")
     model = _write_module(suite, "Context/Model.tla", "Value == TRUE\n")
-    _write_manifest(suite, {"Suite/Task.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"]}})
+    _write_manifest(suite, {"Suite/Task.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"], "reference_proof_steps": 0}})
     task_source = task.read_bytes()
     model_source = model.read_bytes()
     mode = ProofCompletion(str(benchmark_root), "/checker")


### PR DESCRIPTION
Summary :

- Adds reference_proof_steps to every Proof Completion task in the manifest, based on the human reference proof.
- Generation and the annotate script keep this field up to date. The website can pair core.txt with these counts to report pass rates by complexity.

Test plan :
- [ ] `uv run pytest tests/dataset/test_proof_completion_core.py tests/dataset/test_reference_proof_steps.py tests/common/test_proof_completion_contract.py tests/dataset/test_specification_identity.py`
- [ ] Pick a Core task in benchmark/proof-completion/manifest.json and confirm reference_proof_steps looks right