### PR TITLE
Add shared TLAPS task-audit skill for Codex and Claude

### DIFF
--- a/.agents/skills/tlaps-task-audit/SKILL.md
+++ b/.agents/skills/tlaps-task-audit/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: tlaps-task-audit
+description: Audit TLAPS Bench proof-completion tasks and cohorts for task integrity, theorem provability evidence, answer leakage, source-reference quality, difficulty signals, stale run artifacts, and model failure causes. Use when reviewing TLAPS task quality, trimming benchmark cohorts, investigating suspicious tasks, analyzing one-shot or agentic results, or preparing a shareable task-audit report.
+---
+
+# TLAPS Task Audit
+
+Audit each task with evidence from the task, its scaffold, its context, and the checker. Keep task faults separate from source-proof defects, model failures, and difficulty.
+
+## Read the audit rules
+
+Read [references/audit-rubric.md](references/audit-rubric.md) before you classify a task.
+
+Read [references/repository-workflow.md](references/repository-workflow.md) before you run repository commands.
+
+Read [references/trace-analysis.md](references/trace-analysis.md) when the scope includes stored model runs.
+
+Use the files in `assets/` when you write batch and final reports.
+
+## Protect the audit target
+
+Treat the benchmark, source, results, and session files as read-only.
+
+Write audit outputs under `.notes/<audit-id>/` unless the user gives another path.
+
+Do not repair or remove a task during an audit. Ask for a separate change after the report.
+
+Record the current commit, benchmark mode, task-list source, and checker command.
+
+## Build an exact inventory
+
+Run the inventory script before a cohort audit:
+
+```bash
+python3 .agents/skills/tlaps-task-audit/scripts/build_audit_inventory.py \
+  --repo . \
+  --mode proof-completion \
+  --task-list core \
+  --batch-size 10 \
+  --output .notes/<audit-id>/inventory.json
+```
+
+The script rejects empty lists, duplicate IDs, unknown IDs, and missing task files. It records file hashes and exact batch assignments.
+
+Do not hard-code a task count. Use the generated inventory.
+
+## Audit each task
+
+For each task, do these checks:
+
+1. Confirm that the inventory maps the task to the correct specification and context files.
+2. Inspect the target theorem and every trusted statement in the scaffold.
+3. Run a SANY check on the unchanged task.
+4. Search for a formula-equivalent theorem or direct answer in the trusted context.
+5. Stage the exact manifest context with `scripts/stage_audit_case.py`.
+6. Test each suspected shortcut with the authoritative checker.
+7. Inspect the original source proof and record its status on a separate axis.
+8. Establish theorem provability with a checker-valid proof when one is available.
+9. Inspect run artifacts only after the task audit when the scope includes results.
+
+Use the exact classification axes from the rubric. Do not replace them with one mixed verdict.
+
+## Use strong evidence
+
+Report a confirmed fault only when direct evidence proves the fault.
+
+A model failure does not prove a task fault.
+
+A failed, omitted, or incomplete source proof does not prove a task fault.
+
+Do not repair every historical source proof to make the validator pass. Record its status and continue unless provability is the audit question.
+
+A task that is easy can still be correct. Report difficulty as a separate benchmark-policy signal.
+
+Treat stale run input as a run-alignment issue. Audit the current task separately.
+
+For a confirmed answer leak, save the minimal checker-valid proof and its checker result.
+
+Separate observed facts from explanations that you infer.
+
+## Audit a large cohort
+
+Use the inventory batch assignments when several agents share the audit.
+
+Give each agent exact task IDs. Require one Markdown note and one JSON sidecar per batch.
+
+Do not let batch agents edit benchmark files, source files, result files, or other batch reports.
+
+After all batches finish, run:
+
+```bash
+python3 .agents/skills/tlaps-task-audit/scripts/validate_audit_coverage.py \
+  --inventory .notes/<audit-id>/inventory.json \
+  --reports-dir .notes/<audit-id>/batches \
+  --summary-output .notes/<audit-id>/coverage-summary.json
+```
+
+Independently review every `NEEDS_REVIEW` and `CONFIRMED_FAULT` result. Also review all pass results with unusually short proofs.
+
+## Deliver the report
+
+Use [assets/final-report.md](assets/final-report.md) for the final report.
+
+State the exact cohort and current commit. Give counts for every classification axis.
+
+Put confirmed faults first. Put review items next. Keep model behavior in a separate section.
+
+Include commands, concise checker output, and file locations. Explain the effect of each fault on benchmark validity.
+
+Do not claim access to hidden or encrypted reasoning. Analyze only observable prompts, outputs, tool events, usage, and checker logs.

--- a/.agents/skills/tlaps-task-audit/agents/openai.yaml
+++ b/.agents/skills/tlaps-task-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TLAPS Task Audit"
+  short_description: "Audit TLAPS benchmark task quality"
+  default_prompt: "Use $tlaps-task-audit to audit the selected TLAPS benchmark tasks and write an evidence-backed report."

--- a/.agents/skills/tlaps-task-audit/assets/batch-report.json
+++ b/.agents/skills/tlaps-task-audit/assets/batch-report.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "batch": 1,
+  "tasks": [
+    {
+      "ordinal": 1,
+      "task_id": "Module/Exact_Task_ID.tla",
+      "task_integrity": "PASS",
+      "provability": "NOT_DEMONSTRATED",
+      "leakage": "NONE_FOUND",
+      "difficulty": "NOT_ASSESSED",
+      "source_reference": "NOT_ASSESSED",
+      "run_alignment": "NOT_ASSESSED",
+      "model_outcome": "NOT_ASSESSED",
+      "summary": "State the result in one sentence.",
+      "evidence": [
+        "State one observed fact and its file or checker result."
+      ],
+      "commands": [
+        "State each exact command that produced evidence."
+      ]
+    }
+  ]
+}

--- a/.agents/skills/tlaps-task-audit/assets/batch-report.md
+++ b/.agents/skills/tlaps-task-audit/assets/batch-report.md
@@ -1,0 +1,51 @@
+# Batch <NN> task audit
+
+## Scope
+
+- Repository commit: `<commit>`
+- Benchmark mode: `<mode>`
+- Task-list source: `<task-list>`
+- Inventory file: `<path>`
+- Assigned tasks: `<first ordinal>` to `<last ordinal>`
+
+## Summary
+
+| Axis | Counts |
+|---|---|
+| Task integrity | `<counts>` |
+| Provability evidence | `<counts>` |
+| Answer leakage | `<counts>` |
+| Difficulty | `<counts>` |
+| Source-reference quality | `<counts>` |
+| Run alignment | `<counts>` |
+| Model outcome | `<counts>` |
+
+## Task results
+
+| Ordinal | Canonical task ID | Integrity | Provability | Leakage | Difficulty | Source reference | Run alignment | Model outcome |
+|---:|---|---|---|---|---|---|---|---|
+| `<n>` | `<exact task ID>` | `<value>` | `<value>` | `<value>` | `<value>` | `<value>` | `<value>` | `<value>` |
+
+## Findings
+
+### `<ordinal>. <canonical task ID>`
+
+- Result: `<one-sentence result>`
+- Observed evidence: `<direct evidence>`
+- Interpretation: `<inference, or None>`
+- Checker command: `<exact command, or Not run>`
+- Checker result: `<exit code and concise result>`
+- Evidence files: `<durable paths>`
+- Next action: `<required action, or None>`
+
+## Commands
+
+```bash
+<exact commands>
+```
+
+## Limits
+
+State all checks that did not finish. State all evidence that was not available.
+
+Write the matching machine-readable file as `batch-<NN>.json`. Copy the structure from `assets/batch-report.json`.

--- a/.agents/skills/tlaps-task-audit/assets/final-report.md
+++ b/.agents/skills/tlaps-task-audit/assets/final-report.md
@@ -1,0 +1,96 @@
+# TLAPS benchmark task audit
+
+## Executive summary
+
+State the exact cohort, commit, and audit date.
+
+Give the number of audited tasks. List confirmed faults first. Keep possible issues separate.
+
+Do not describe source-proof defects or easy tasks as task faults.
+
+## Scope and method
+
+- Repository commit: `<commit>`
+- Benchmark mode: `<mode>`
+- Task-list source: `<task-list>`
+- Inventory file: `<path>`
+- Tasks audited: `<count>`
+- Stored runs audited: `<count or Not included>`
+- Checker setup: `<version, container mode, and timeout>`
+
+Explain the audit method in short steps.
+
+## Results
+
+| Axis | Value | Count |
+|---|---|---:|
+| Task integrity | `PASS` | `<n>` |
+| Task integrity | `NEEDS_REVIEW` | `<n>` |
+| Task integrity | `CONFIRMED_FAULT` | `<n>` |
+| Provability | `<value>` | `<n>` |
+| Leakage | `<value>` | `<n>` |
+| Difficulty | `<value>` | `<n>` |
+| Source reference | `<value>` | `<n>` |
+| Run alignment | `<value>` | `<n>` |
+| Model outcome | `<value>` | `<n>` |
+
+## Confirmed task faults
+
+For each fault, include:
+
+1. The canonical task ID.
+2. The exact defect.
+3. The minimal reproduction.
+4. The checker result.
+5. The effect on benchmark validity.
+6. The recommended correction.
+
+If there are no confirmed faults, write `No confirmed task faults.`
+
+## Items that need review
+
+For each item, state the evidence gap and the next decisive check.
+
+If there are no review items, write `No unresolved task-quality items.`
+
+## Source-reference findings
+
+List source proofs that omit steps, fail, time out, or are missing.
+
+State clearly that these findings do not establish task faults.
+
+## Difficulty findings
+
+List trivial candidates and the evidence for each one.
+
+Treat removal as a separate benchmark-policy choice.
+
+## Model behavior
+
+Include this section only when the scope includes stored runs.
+
+Separate syntax failures, unproved obligations, infrastructure failures, protocol failures, and resource limits.
+
+Describe repeated observable patterns. Do not claim access to hidden reasoning.
+
+## Coverage and quality controls
+
+State whether the coverage validator passed.
+
+State how many findings received independent review.
+
+List stale inputs and incomplete checks.
+
+## Commands
+
+```bash
+<exact commands used during the audit>
+```
+
+## Recommended actions
+
+Order actions by benchmark impact. Separate required corrections from optional policy changes.
+
+## Limits
+
+State all timeouts, unavailable evidence, and untested assumptions.

--- a/.agents/skills/tlaps-task-audit/references/audit-rubric.md
+++ b/.agents/skills/tlaps-task-audit/references/audit-rubric.md
@@ -1,0 +1,180 @@
+# TLAPS task-audit rubric
+
+Use all classification axes. Do not combine them into one verdict.
+
+## 1. Task integrity
+
+Choose one value.
+
+### `PASS`
+
+Use `PASS` when the task structure is correct and you found no direct task defect.
+
+The original source proof can omit steps or fail with the current TLAPM version. That source condition does not make the extracted theorem invalid.
+
+### `NEEDS_REVIEW`
+
+Use `NEEDS_REVIEW` when evidence indicates a possible task defect, but you cannot prove it.
+
+State the missing evidence. Give the next command or analysis that can resolve the item.
+
+### `CONFIRMED_FAULT`
+
+Use `CONFIRMED_FAULT` only when direct evidence establishes one of these conditions:
+
+- The unchanged task, scaffold, or required context cannot parse.
+- Required context is missing or mapped to the wrong task.
+- A valid counterexample or formal contradiction disproves the target theorem.
+- A trusted scaffold statement gives a checker-valid answer to the target.
+- The task target does not match its intended source theorem.
+- The checker accepts a forbidden solution.
+- The checker rejects a known-valid proof because the task package is broken.
+
+Save the smallest reproducible case. Include the exact checker command and result.
+
+## 2. Provability evidence
+
+Choose one value.
+
+### `CHECKER_PROVED`
+
+A known proof of the target passes the authoritative checker in the canonical task context.
+
+### `SUPPORTED`
+
+A maintainer or expert supports the theorem, but no current checker-valid proof is available in this audit.
+
+Name the source of this support. Do not present it as a checker result.
+
+### `NOT_DEMONSTRATED`
+
+The audit did not establish or disprove the theorem.
+
+This value does not mean that the theorem is false.
+
+### `DISPROVED`
+
+A valid counterexample or formal contradiction disproves the theorem.
+
+Use `CONFIRMED_FAULT` for task integrity when you use this value.
+
+## 3. Answer leakage
+
+Choose one value.
+
+### `NONE_FOUND`
+
+The audit found no direct answer in the trusted task context.
+
+### `CANDIDATE`
+
+A trusted statement appears equivalent to the target, but the shortcut did not pass the authoritative checker.
+
+Use `NEEDS_REVIEW` for task integrity until the audit resolves this candidate.
+
+### `CONFIRMED`
+
+A minimal shortcut uses trusted context and passes the authoritative checker.
+
+Use `CONFIRMED_FAULT` for task integrity. Save the minimal proof and checker output.
+
+Do not classify normal helper lemmas as leaks. A helper is valid when the target still needs material proof work.
+
+## 4. Difficulty and benchmark value
+
+Choose one value.
+
+### `INFORMATIVE`
+
+Available evidence indicates that the task gives useful model separation or requires material proof work.
+
+### `TRIVIAL_CANDIDATE`
+
+The task accepts a very short valid proof or has a high pass rate across relevant models.
+
+This value is not a task fault. Task removal needs a separate benchmark-policy decision.
+
+### `NOT_ASSESSED`
+
+The audit did not assess difficulty.
+
+Do not infer difficulty from one model result alone.
+
+## 5. Source-reference quality
+
+Choose one value.
+
+### `PASSES`
+
+The extracted source proof passes the selected current checker.
+
+### `OMITS_STEPS`
+
+The source intentionally or historically leaves proof steps incomplete.
+
+### `FAILS_CURRENT_TLAPM`
+
+The source proof reaches TLAPM but does not prove all obligations with the current setup.
+
+### `TIMEOUT`
+
+The source-proof check exceeded its stated time limit.
+
+### `MISSING`
+
+The audit cannot locate the mapped source theorem or proof.
+
+### `NOT_ASSESSED`
+
+The audit did not check the source proof.
+
+These values describe reference quality only. `OMITS_STEPS` and `FAILS_CURRENT_TLAPM` do not establish a task fault.
+
+## 6. Run alignment
+
+Use this axis only when the audit includes stored runs.
+
+- `CURRENT`: The captured task, scaffold, and context match the audited commit.
+- `STALE`: One or more captured inputs differ from the audited commit.
+- `MISSING`: Required run input is absent.
+- `NOT_ASSESSED`: The audit does not include stored runs.
+
+If a run is stale, do not use its outcome as the current task result.
+
+## 7. Model outcome
+
+Use this axis only when the audit includes model runs.
+
+- `PASS`: The submitted proof passed the grader.
+- `SANY_SYNTAX`: SANY rejected the submitted module.
+- `TLAPS_UNPROVED`: SANY accepted the module, but TLAPM left obligations unproved.
+- `INFRA`: Infrastructure prevented a valid grading result.
+- `PROTOCOL`: The run violated the expected agent or output protocol.
+- `RESOURCE`: A time or memory limit prevented completion.
+- `UNKNOWN`: Evidence does not identify the failure stage.
+- `NOT_ASSESSED`: The audit does not include a model run.
+
+Model outcome is diagnostic evidence. It does not decide task integrity.
+
+## Evidence strength
+
+Use this evidence order from strongest to weakest:
+
+1. An authoritative checker replay in the canonical task context.
+2. A direct parse result, exact file comparison, or manifest comparison.
+3. A valid formal counterexample or proof.
+4. A maintainer statement about theorem intent or provability.
+5. Source comments, historical proofs, or repository history.
+6. A model result or model-generated explanation.
+
+Label inferences. Do not convert a repeated model failure into a confirmed task fault.
+
+## Project policy examples
+
+Use these examples to prevent known audit errors.
+
+- If the source target says `PROOF OMITTED`, classify source quality as `OMITS_STEPS`. Do not reject the task for this reason alone.
+- If the historical source proof fails a few obligations, classify source quality as `FAILS_CURRENT_TLAPM`. Investigate provability separately.
+- If the scaffold exposes a formula-identical lemma and `PROOF BY ThatLemma` passes, report a confirmed answer leak and a confirmed task fault.
+- If a valid theorem is too easy, report `TRIVIAL_CANDIDATE`. Keep task integrity as `PASS`.
+- If a stored run used an old scaffold, report `STALE`. Audit the current task before you report its present quality.

--- a/.agents/skills/tlaps-task-audit/references/repository-workflow.md
+++ b/.agents/skills/tlaps-task-audit/references/repository-workflow.md
@@ -1,0 +1,158 @@
+# Repository workflow
+
+This reference describes the current TLAPS Bench file layout and audit commands.
+
+## Task structure
+
+Proof-completion files are under `benchmark/proof-completion/`.
+
+`manifest.json` maps each task ID to its source specification and context files.
+
+A task ID is relative to the mode directory. Example:
+
+```text
+Allocator/Allocator_AllocateMutex.tla
+```
+
+The task file contains the target theorem. The agent proof is between these markers:
+
+```text
+\* BEGIN AGENT PROOF
+...
+\* END AGENT PROOF
+```
+
+The task usually extends a scaffold module. The scaffold contains definitions and trusted earlier lemmas.
+
+Some trusted earlier lemmas use `PROOF OMITTED`. This is intentional task context. It is not a fault by itself.
+
+The mapped original specification is under `source/<spec_id>`.
+
+## Inventory commands
+
+Create an inventory for the registered Core list:
+
+```bash
+python3 .agents/skills/tlaps-task-audit/scripts/build_audit_inventory.py \
+  --repo . --mode proof-completion --task-list core \
+  --batch-size 10 --output .notes/<audit-id>/inventory.json
+```
+
+Use `--task-list full` to select every task in the mode manifest.
+
+You can also pass a task-list file path.
+
+## Task checks
+
+Run the fast syntax check on one unchanged task:
+
+```bash
+uv run python -m src.common.check_proof \
+  --mode proof-completion --sany-only --no-git-track \
+  --benchmark-dir benchmark/proof-completion/<module-dir> \
+  benchmark/proof-completion/<task-id>
+```
+
+Stage the exact manifest context before you test a candidate:
+
+```bash
+audit_case_dir=$(mktemp -d)
+python3 .agents/skills/tlaps-task-audit/scripts/stage_audit_case.py \
+  --repo . --mode proof-completion --task '<task-id>' \
+  --output-dir "$audit_case_dir"
+```
+
+The script creates `canonical/` and `candidate/` directories. It copies only the target and the context files from the manifest.
+
+Edit only the target file in `candidate/`. Then run the authoritative proof check:
+
+```bash
+COMMUNITY_LIB="$PWD/lib/community" uv run python -m src.common.check_proof \
+  --mode proof-completion --no-git-track --no-cache \
+  --canonical-replay-required \
+  --benchmark-dir "$audit_case_dir/canonical" \
+  "$audit_case_dir/candidate/<target-file>.tla"
+```
+
+Use the same container mode and timeout as the benchmark run when you compare results.
+
+Do not edit the canonical task or the staged canonical directory. Do not add unrelated sibling tasks to the staged context.
+
+Set `COMMUNITY_LIB` for temporary candidates. A file under `/tmp` does not find the repository community library automatically.
+
+Record the candidate proof, exit code, proved-obligation count, failed-obligation count, and relevant diagnostics.
+
+## Source-reference checks
+
+Run the repository validator when the audit includes source-reference quality:
+
+```bash
+uv run tlaps-bench validate \
+  --filter '<task-or-spec-pattern>' --jobs 1 --timeout 900 \
+  --output .notes/<audit-id>/source-validation.md
+```
+
+This command tests the extracted reference proof. It does not prove that a task is invalid when the reference fails.
+
+Record placeholders, failed obligations, parser errors, and timeouts as source-reference results.
+
+## Leakage checks
+
+Compare the target formula with all trusted scaffold statements.
+
+Ignore theorem names, whitespace, comments, and harmless formatting differences during the first comparison.
+
+Inspect substitutions, bound-variable renaming, module instances, and definition expansion before you claim equivalence.
+
+If a possible shortcut exists, create the smallest candidate proof. Run it through the same checker path as a benchmark submission.
+
+Classify the leak as `CONFIRMED` only after the checker accepts the shortcut.
+
+## Stored-run checks
+
+Compare these captured inputs with the audited commit when they are available:
+
+- Task file
+- Scaffold file
+- All manifest context files
+- Mode and task-list metadata
+- Checker and container version
+
+Classify mismatched captured input as `STALE`.
+
+Use only observable trace data. This data includes prompts, responses, tool calls, usage events, final files, and checker logs.
+
+Do not claim access to encrypted reasoning text.
+
+## Large-cohort controls
+
+Use exact inventory batches. Give each worker its canonical task IDs.
+
+Require one JSON sidecar per batch. The coverage script reads these files.
+
+For one task, create a one-line task-list file in the audit output directory. Build a one-task inventory, and name the sidecar `batch-01.json`.
+
+Run the coverage script after all batch reports exist:
+
+```bash
+python3 .agents/skills/tlaps-task-audit/scripts/validate_audit_coverage.py \
+  --inventory .notes/<audit-id>/inventory.json \
+  --reports-dir .notes/<audit-id>/batches \
+  --summary-output .notes/<audit-id>/coverage-summary.json
+```
+
+The script checks exact task IDs, duplicates, omissions, batch assignments, enum values, and required evidence fields.
+
+Review every non-pass finding independently. Replay each confirmed fault from a clean temporary directory.
+
+## Known reporting traps
+
+Do not use an abbreviated file name when the report can use the canonical task ID.
+
+Do not call an admitted helper lemma a leak unless it gives the target answer.
+
+Do not treat contradictory informational text from a checker as the final result. Use its exit code and final structured result.
+
+Do not store the only copy of important evidence under `/tmp`.
+
+Do not add root-cause counts when one failed proof has several overlapping causes.

--- a/.agents/skills/tlaps-task-audit/references/trace-analysis.md
+++ b/.agents/skills/tlaps-task-audit/references/trace-analysis.md
@@ -1,0 +1,109 @@
+# Observable model-trace analysis
+
+Use this reference only when the audit includes stored runs.
+
+Audit task quality first. Analyze model behavior after you establish the current task state.
+
+## Confirm run alignment
+
+Compare the captured task and context with the audited commit.
+
+If any input differs, classify the run as `STALE`. Do not report that run as the current task result.
+
+Confirm the model, approach, reasoning effort, timeout, checker version, and benchmark mode.
+
+## Use observable evidence
+
+You can analyze these artifacts:
+
+- The exact prompt and task files
+- The model response
+- Tool-call and tool-result events
+- The final materialized module
+- SANY and TLAPM output
+- Grader results
+- Token, request, time, and cost records
+
+Do not claim access to hidden or encrypted reasoning.
+
+## Find the first decisive failure
+
+Start at the earliest stage that prevents success.
+
+Use one primary model-outcome class from the audit rubric.
+
+Then describe one or more observed failure patterns. Pattern labels can overlap, so do not add their counts as if they were exclusive.
+
+## Common failure patterns
+
+### Syntax and proof-language errors
+
+Look for missing separators, malformed proof levels, invalid `QED` placement, and duplicate bound names.
+
+Run SANY on a temporary copy to recover full diagnostics when a stored log truncates them.
+
+### Invented or incorrect names
+
+Check every operator, theorem, tactic, fairness rule, and module name against the available context.
+
+Common failures include plausible but nonexistent helper names and the wrong variant of a real theorem.
+
+### Hierarchical context loss
+
+Inspect nested `ASSUME`, `CASE`, `SUFFICES`, `PICK`, and `TAKE` steps.
+
+Facts from a parent step do not always enter a child obligation automatically. Check whether the proof cites the enclosing step or introduces the premise again.
+
+Do not call this pattern from proof shape alone. Confirm it in the failed obligation context.
+
+### Automation without prerequisites
+
+Look for broad `SMT`, `BY`, or backend calls that omit definitions, witnesses, type facts, or enclosing assumptions.
+
+Enabledness, temporal reasoning, fairness, and quantified witnesses often need explicit intermediate steps.
+
+### Definition or API mismatch
+
+Check whether the proof expands an unavailable definition or applies a theorem with the wrong statement.
+
+Compare the submitted name with the exact trusted context before you call it a hallucination.
+
+### Cascading obligations
+
+A large failed-obligation count can come from one early missing fact.
+
+Find the first independent failure. Separate it from later cascade failures.
+
+### Infrastructure and resource failures
+
+Keep network, authentication, quota, timeout, memory, and process failures separate from proof failures.
+
+Rerun only affected infrastructure cases when the user asks for recovery.
+
+## Checker-log cautions
+
+Use the exit code, structured result, and final gate verdict as primary evidence.
+
+Some logs can contain contradictory informational lines about cheating. Do not classify a run from one such line.
+
+Confirm whether SANY parsed the final module before you classify a result as `TLAPS_UNPROVED`.
+
+## Cross-task analysis
+
+Group tasks by exact, evidence-backed patterns.
+
+Give representative task IDs and concise diagnostics for each pattern.
+
+Report the denominator for every rate. Exclude stale or non-comparable runs from current-result rates.
+
+Keep task faults, model failures, and infrastructure failures in separate totals.
+
+Describe successful counterexamples when they weaken a broad failure claim.
+
+## Report language
+
+Use `observed` for direct artifact evidence.
+
+Use `likely` only when the explanation is an inference.
+
+State what additional check can confirm each unresolved explanation.

--- a/.agents/skills/tlaps-task-audit/scripts/build_audit_inventory.py
+++ b/.agents/skills/tlaps-task-audit/scripts/build_audit_inventory.py
@@ -1,0 +1,245 @@
+"""Build a stable inventory for a TLAPS Bench task audit."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+BEGIN_MARKER = r"\* BEGIN AGENT PROOF"
+END_MARKER = r"\* END AGENT PROOF"
+
+
+class AuditInputError(ValueError):
+    """Report an invalid audit input without a traceback."""
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def repo_relative(path: Path, repo: Path) -> str:
+    return path.resolve().relative_to(repo).as_posix()
+
+
+def git_commit(repo: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AuditInputError(f"Cannot read the Git commit: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def load_json_object(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise AuditInputError(f"Cannot read JSON file {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise AuditInputError(f"Expected a JSON object in {path}")
+    return data
+
+
+def resolve_task_list(
+    value: str, repo: Path, mode_dir: Path, manifest: dict[str, Any]
+) -> tuple[list[str], str, str | None]:
+    if value == "full":
+        return sorted(manifest), "manifest:full", None
+
+    raw_path = Path(value)
+    candidates = [raw_path] if raw_path.is_absolute() else [repo / raw_path, Path.cwd() / raw_path]
+    candidates.append(mode_dir / f"{value}.txt")
+
+    list_path = next((path.resolve() for path in candidates if path.is_file()), None)
+    if list_path is None:
+        raise AuditInputError(f"Unknown task list {value!r}. Pass 'full', a registered name, or a file path.")
+
+    lines = list_path.read_text(encoding="utf-8").splitlines()
+    task_ids = [line.strip() for line in lines if line.strip() and not line.lstrip().startswith("#")]
+    try:
+        source = repo_relative(list_path, repo)
+    except ValueError:
+        source = str(list_path)
+    return task_ids, source, sha256_file(list_path)
+
+
+def validate_task_ids(task_ids: list[str], manifest: dict[str, Any]) -> None:
+    if not task_ids:
+        raise AuditInputError("The selected task list is empty.")
+
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for task_id in task_ids:
+        if task_id in seen and task_id not in duplicates:
+            duplicates.append(task_id)
+        seen.add(task_id)
+    if duplicates:
+        raise AuditInputError(f"Duplicate task IDs: {', '.join(duplicates)}")
+
+    unknown = [task_id for task_id in task_ids if task_id not in manifest]
+    if unknown:
+        raise AuditInputError(f"Unknown task IDs: {', '.join(unknown)}")
+
+
+def required_file(path: Path, label: str) -> None:
+    if not path.is_file():
+        raise AuditInputError(f"Missing {label}: {path}")
+
+
+def build_task_record(
+    *,
+    ordinal: int,
+    batch_size: int,
+    task_id: str,
+    entry: Any,
+    repo: Path,
+    mode_dir: Path,
+) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise AuditInputError(f"Manifest entry for {task_id} is not an object.")
+
+    spec_id = entry.get("spec_id")
+    contexts = entry.get("context")
+    if not isinstance(spec_id, str) or not spec_id:
+        raise AuditInputError(f"Manifest entry for {task_id} has no valid spec_id.")
+    if not isinstance(contexts, list) or not contexts or not all(isinstance(item, str) for item in contexts):
+        raise AuditInputError(f"Manifest entry for {task_id} has no valid context list.")
+
+    target_path = mode_dir / task_id
+    source_path = repo / "source" / spec_id
+    required_file(target_path, "task file")
+    required_file(source_path, "source file")
+
+    target_text = target_path.read_text(encoding="utf-8")
+    if target_text.count(BEGIN_MARKER) != 1 or target_text.count(END_MARKER) != 1:
+        raise AuditInputError(f"Task {task_id} does not contain one complete agent-proof marker pair.")
+    if target_text.index(BEGIN_MARKER) >= target_text.index(END_MARKER):
+        raise AuditInputError(f"Task {task_id} has reversed agent-proof markers.")
+
+    context_records: list[dict[str, str]] = []
+    for context_id in contexts:
+        context_path = mode_dir / context_id
+        required_file(context_path, "context file")
+        context_records.append(
+            {
+                "path": repo_relative(context_path, repo),
+                "sha256": sha256_file(context_path),
+            }
+        )
+
+    reference_steps = entry.get("reference_proof_steps")
+    if reference_steps is not None and (not isinstance(reference_steps, int) or reference_steps < 0):
+        raise AuditInputError(f"Manifest entry for {task_id} has invalid reference_proof_steps.")
+
+    return {
+        "ordinal": ordinal,
+        "batch": ((ordinal - 1) // batch_size) + 1,
+        "task_id": task_id,
+        "spec_id": spec_id,
+        "reference_proof_steps": reference_steps,
+        "target": {
+            "path": repo_relative(target_path, repo),
+            "sha256": sha256_file(target_path),
+        },
+        "context": context_records,
+        "source": {
+            "path": repo_relative(source_path, repo),
+            "sha256": sha256_file(source_path),
+        },
+    }
+
+
+def write_json_atomic(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".", help="Repository root. Default: current directory.")
+    parser.add_argument("--mode", default="proof-completion", help="Benchmark mode directory name.")
+    parser.add_argument(
+        "--task-list",
+        default="core",
+        help="Registered list name, 'full', or a task-list file path.",
+    )
+    parser.add_argument("--batch-size", type=int, default=10, help="Tasks per audit batch.")
+    parser.add_argument("--output", required=True, help="Output inventory JSON path.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        repo = Path(args.repo).resolve()
+        if args.batch_size < 1:
+            raise AuditInputError("--batch-size must be greater than zero.")
+
+        mode_dir = repo / "benchmark" / args.mode
+        manifest_path = mode_dir / "manifest.json"
+        required_file(manifest_path, "manifest")
+        manifest = load_json_object(manifest_path)
+
+        task_ids, task_list_source, task_list_hash = resolve_task_list(args.task_list, repo, mode_dir, manifest)
+        validate_task_ids(task_ids, manifest)
+
+        tasks = [
+            build_task_record(
+                ordinal=ordinal,
+                batch_size=args.batch_size,
+                task_id=task_id,
+                entry=manifest[task_id],
+                repo=repo,
+                mode_dir=mode_dir,
+            )
+            for ordinal, task_id in enumerate(task_ids, start=1)
+        ]
+
+        inventory = {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "git_commit": git_commit(repo),
+            "mode": args.mode,
+            "manifest": {
+                "path": repo_relative(manifest_path, repo),
+                "sha256": sha256_file(manifest_path),
+            },
+            "task_list": {
+                "source": task_list_source,
+                "sha256": task_list_hash,
+            },
+            "batch_size": args.batch_size,
+            "task_count": len(tasks),
+            "batch_count": tasks[-1]["batch"],
+            "tasks": tasks,
+        }
+        output_path = Path(args.output)
+        if not output_path.is_absolute():
+            output_path = repo / output_path
+        write_json_atomic(output_path, inventory)
+        print(f"Wrote {len(tasks)} tasks in {inventory['batch_count']} batches to {output_path}")
+        return 0
+    except AuditInputError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/tlaps-task-audit/scripts/stage_audit_case.py
+++ b/.agents/skills/tlaps-task-audit/scripts/stage_audit_case.py
@@ -1,0 +1,122 @@
+"""Stage exact canonical and candidate directories for one TLAPS task audit."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+
+class StageError(ValueError):
+    """Report an invalid staging request without a traceback."""
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise StageError(f"Cannot read manifest {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise StageError(f"Manifest {path} is not a JSON object.")
+    return data
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".", help="Repository root. Default: current directory.")
+    parser.add_argument("--mode", default="proof-completion", help="Benchmark mode directory name.")
+    parser.add_argument("--task", required=True, help="Exact mode-relative task ID.")
+    parser.add_argument("--output-dir", required=True, help="New or empty audit-case directory.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        repo = Path(args.repo).resolve()
+        mode_dir = repo / "benchmark" / args.mode
+        manifest_path = mode_dir / "manifest.json"
+        manifest = load_manifest(manifest_path)
+        if args.task not in manifest:
+            raise StageError(f"Unknown task ID: {args.task}")
+
+        entry = manifest[args.task]
+        if not isinstance(entry, dict):
+            raise StageError(f"Manifest entry for {args.task} is not an object.")
+        contexts = entry.get("context")
+        if not isinstance(contexts, list) or not contexts or not all(isinstance(item, str) for item in contexts):
+            raise StageError(f"Manifest entry for {args.task} has no valid context list.")
+
+        source_paths = [mode_dir / args.task, *(mode_dir / item for item in contexts)]
+        missing = [str(path) for path in source_paths if not path.is_file()]
+        if missing:
+            raise StageError(f"Missing task context files: {', '.join(missing)}")
+
+        basenames = [path.name for path in source_paths]
+        duplicates = sorted({name for name in basenames if basenames.count(name) > 1})
+        if duplicates:
+            raise StageError(f"Context file-name collision: {', '.join(duplicates)}")
+
+        output_dir = Path(args.output_dir).resolve()
+        if output_dir.exists() and any(output_dir.iterdir()):
+            raise StageError(f"Output directory is not empty: {output_dir}")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        canonical_dir = output_dir / "canonical"
+        candidate_dir = output_dir / "candidate"
+        canonical_dir.mkdir()
+        candidate_dir.mkdir()
+
+        files: list[dict[str, Any]] = []
+        for index, source_path in enumerate(source_paths):
+            canonical_path = canonical_dir / source_path.name
+            candidate_path = candidate_dir / source_path.name
+            shutil.copy2(source_path, canonical_path)
+            shutil.copy2(source_path, candidate_path)
+            files.append(
+                {
+                    "role": "target" if index == 0 else "context",
+                    "task_relative_path": source_path.relative_to(mode_dir).as_posix(),
+                    "staged_name": source_path.name,
+                    "sha256": sha256_file(source_path),
+                }
+            )
+
+        metadata = {
+            "schema_version": SCHEMA_VERSION,
+            "mode": args.mode,
+            "task_id": args.task,
+            "target_file": source_paths[0].name,
+            "canonical_dir": str(canonical_dir),
+            "candidate_dir": str(candidate_dir),
+            "community_lib": str(repo / "lib" / "community"),
+            "files": files,
+        }
+        metadata_path = output_dir / "case.json"
+        metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+
+        print(f"Staged {len(files)} files for {args.task}")
+        print(f"Edit only: {candidate_dir / source_paths[0].name}")
+        print(f"Canonical directory: {canonical_dir}")
+        print(f"Metadata: {metadata_path}")
+        return 0
+    except (OSError, StageError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/tlaps-task-audit/scripts/validate_audit_coverage.py
+++ b/.agents/skills/tlaps-task-audit/scripts/validate_audit_coverage.py
@@ -1,0 +1,244 @@
+"""Validate exact task coverage and classifications in batch audit JSON files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+REPORT_PATTERN = re.compile(r"^batch-(\d+)\.json$")
+
+AXES: dict[str, set[str]] = {
+    "task_integrity": {"PASS", "NEEDS_REVIEW", "CONFIRMED_FAULT"},
+    "provability": {"CHECKER_PROVED", "SUPPORTED", "NOT_DEMONSTRATED", "DISPROVED"},
+    "leakage": {"NONE_FOUND", "CANDIDATE", "CONFIRMED"},
+    "difficulty": {"INFORMATIVE", "TRIVIAL_CANDIDATE", "NOT_ASSESSED"},
+    "source_reference": {
+        "PASSES",
+        "OMITS_STEPS",
+        "FAILS_CURRENT_TLAPM",
+        "TIMEOUT",
+        "MISSING",
+        "NOT_ASSESSED",
+    },
+    "run_alignment": {"CURRENT", "STALE", "MISSING", "NOT_ASSESSED"},
+    "model_outcome": {
+        "PASS",
+        "SANY_SYNTAX",
+        "TLAPS_UNPROVED",
+        "INFRA",
+        "PROTOCOL",
+        "RESOURCE",
+        "UNKNOWN",
+        "NOT_ASSESSED",
+    },
+}
+
+
+def read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"Cannot read {path}: {error}") from error
+
+
+def write_json_atomic(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inventory", required=True, help="Inventory JSON from build_audit_inventory.py.")
+    parser.add_argument("--reports-dir", required=True, help="Directory that contains batch-<NN>.json files.")
+    parser.add_argument("--summary-output", help="Optional output path for the validated summary JSON.")
+    return parser.parse_args()
+
+
+def validate_report_task(
+    record: Any,
+    *,
+    path: Path,
+    expected_by_id: dict[str, dict[str, Any]],
+    declared_batch: int,
+    seen: dict[str, Path],
+    errors: list[str],
+) -> None:
+    location = f"{path} task entry"
+    if not isinstance(record, dict):
+        errors.append(f"{location} is not an object.")
+        return
+
+    task_id = record.get("task_id")
+    if not isinstance(task_id, str):
+        errors.append(f"{location} has no string task_id.")
+        return
+    if task_id not in expected_by_id:
+        errors.append(f"{path} contains unknown task ID {task_id!r}.")
+        return
+    if task_id in seen:
+        errors.append(f"Task {task_id} appears in both {seen[task_id]} and {path}.")
+        return
+    seen[task_id] = path
+
+    expected = expected_by_id[task_id]
+    if declared_batch != expected["batch"]:
+        errors.append(f"Task {task_id} is in batch {declared_batch}, but inventory assigns batch {expected['batch']}.")
+    if record.get("ordinal") != expected["ordinal"]:
+        errors.append(f"Task {task_id} has ordinal {record.get('ordinal')!r}; expected {expected['ordinal']}.")
+
+    for field, allowed in AXES.items():
+        value = record.get(field)
+        if value not in allowed:
+            errors.append(f"Task {task_id} has invalid {field} {value!r}. Allowed: {', '.join(sorted(allowed))}.")
+
+    summary = record.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        errors.append(f"Task {task_id} has no non-empty summary.")
+    evidence = record.get("evidence")
+    if (
+        not isinstance(evidence, list)
+        or not evidence
+        or not all(isinstance(item, str) and item.strip() for item in evidence)
+    ):
+        errors.append(f"Task {task_id} must contain a non-empty evidence string list.")
+    commands = record.get("commands", [])
+    if not isinstance(commands, list) or not all(isinstance(item, str) for item in commands):
+        errors.append(f"Task {task_id} commands must be a string list.")
+
+    integrity = record.get("task_integrity")
+    provability = record.get("provability")
+    leakage = record.get("leakage")
+    if provability == "DISPROVED" and integrity != "CONFIRMED_FAULT":
+        errors.append(f"Task {task_id} is DISPROVED but is not a CONFIRMED_FAULT.")
+    if leakage == "CANDIDATE" and integrity != "NEEDS_REVIEW":
+        errors.append(f"Task {task_id} has a leakage CANDIDATE but is not NEEDS_REVIEW.")
+    if leakage == "CONFIRMED" and integrity != "CONFIRMED_FAULT":
+        errors.append(f"Task {task_id} has CONFIRMED leakage but is not a CONFIRMED_FAULT.")
+
+
+def main() -> int:
+    args = parse_args()
+    inventory_path = Path(args.inventory).resolve()
+    reports_dir = Path(args.reports_dir).resolve()
+    errors: list[str] = []
+
+    try:
+        inventory = read_json(inventory_path)
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    if not isinstance(inventory, dict) or inventory.get("schema_version") != SCHEMA_VERSION:
+        print(f"error: Unsupported inventory schema in {inventory_path}", file=sys.stderr)
+        return 2
+    inventory_tasks = inventory.get("tasks")
+    if not isinstance(inventory_tasks, list):
+        print(f"error: Inventory {inventory_path} has no task list.", file=sys.stderr)
+        return 2
+
+    expected_by_id: dict[str, dict[str, Any]] = {}
+    for item in inventory_tasks:
+        if not isinstance(item, dict) or not isinstance(item.get("task_id"), str):
+            errors.append("Inventory contains an invalid task record.")
+            continue
+        expected_by_id[item["task_id"]] = item
+
+    if not reports_dir.is_dir():
+        print(f"error: Reports directory does not exist: {reports_dir}", file=sys.stderr)
+        return 2
+
+    report_files: list[tuple[int, Path]] = []
+    for path in sorted(reports_dir.glob("batch-*.json")):
+        match = REPORT_PATTERN.match(path.name)
+        if match:
+            report_files.append((int(match.group(1)), path))
+
+    expected_batches = set(range(1, int(inventory.get("batch_count", 0)) + 1))
+    actual_batches = {batch for batch, _ in report_files}
+    missing_batches = sorted(expected_batches - actual_batches)
+    extra_batches = sorted(actual_batches - expected_batches)
+    if missing_batches:
+        errors.append(f"Missing batch report files: {missing_batches}")
+    if extra_batches:
+        errors.append(f"Unexpected batch report files: {extra_batches}")
+    if len(actual_batches) != len(report_files):
+        errors.append("Two report file names resolve to the same numeric batch.")
+
+    seen: dict[str, Path] = {}
+    records: list[dict[str, Any]] = []
+    for filename_batch, path in report_files:
+        try:
+            report = read_json(path)
+        except ValueError as error:
+            errors.append(str(error))
+            continue
+        if not isinstance(report, dict):
+            errors.append(f"{path} is not a JSON object.")
+            continue
+        if report.get("schema_version") != SCHEMA_VERSION:
+            errors.append(f"{path} has an unsupported schema_version.")
+        declared_batch = report.get("batch")
+        if declared_batch != filename_batch:
+            errors.append(f"{path} declares batch {declared_batch!r}; its file name declares {filename_batch}.")
+        tasks = report.get("tasks")
+        if not isinstance(tasks, list):
+            errors.append(f"{path} has no task list.")
+            continue
+        for record in tasks:
+            validate_report_task(
+                record,
+                path=path,
+                expected_by_id=expected_by_id,
+                declared_batch=filename_batch,
+                seen=seen,
+                errors=errors,
+            )
+            if isinstance(record, dict) and record.get("task_id") in expected_by_id:
+                records.append(record)
+
+    missing_tasks = [task_id for task_id in expected_by_id if task_id not in seen]
+    if missing_tasks:
+        errors.append(f"Missing task results: {', '.join(missing_tasks)}")
+
+    if errors:
+        print("Audit coverage validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    ordered_records = sorted(records, key=lambda item: expected_by_id[item["task_id"]]["ordinal"])
+    counts: dict[str, dict[str, int]] = {}
+    for field in AXES:
+        counter = Counter(record[field] for record in ordered_records)
+        counts[field] = dict(sorted(counter.items()))
+
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "inventory": str(inventory_path),
+        "git_commit": inventory.get("git_commit"),
+        "mode": inventory.get("mode"),
+        "task_list": inventory.get("task_list"),
+        "task_count": len(ordered_records),
+        "batch_count": len(report_files),
+        "coverage_complete": True,
+        "counts": counts,
+    }
+    if args.summary_output:
+        write_json_atomic(Path(args.summary_output).resolve(), summary)
+
+    print(f"Coverage complete: {len(ordered_records)} tasks in {len(report_files)} batches")
+    for field, values in counts.items():
+        rendered = ", ".join(f"{value}={count}" for value, count in values.items())
+        print(f"{field}: {rendered}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/tlaps-task-audit
+++ b/.claude/skills/tlaps-task-audit
@@ -1,0 +1,1 @@
+../../.agents/skills/tlaps-task-audit

--- a/.gitignore
+++ b/.gitignore
@@ -305,3 +305,5 @@ AGENTS.md
 !.claude/skills/tlaps-task-audit
 .ralph
 .cursor
+
+.notes/

--- a/.gitignore
+++ b/.gitignore
@@ -299,6 +299,9 @@ CLAUDE.md
 AGENTS.md
 .pi
 .kiro
-.claude
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/tlaps-task-audit
 .ralph
 .cursor


### PR DESCRIPTION
Adds a project skill for audits of TLAPS benchmark tasks.

The audit rubric separates task integrity from theorem provability, answer leakage, source-proof quality, difficulty, stale data, and model results. 

A missing or failed source proof does not automatically make a task invalid. A task requires direct evidence before it receives a fault verdict. 

The skill includes scripts for task inventories, exact checker contexts, and audit coverage. It also includes report templates and trace-analysis guidance.