### PR TITLE
Remove four Core tasks with invalid reference proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Results land in `results/<mode>/<backend>/<timestamp>/`.
 Scale up, or switch task type:
 
 ```bash
-# Proof-completion Core: 190 selected tasks, 4 in parallel
+# Proof-completion Core: 186 selected tasks, 4 in parallel
 uv run tlaps-bench run --task-list core --jobs 4 --timeout 7200
 
 # Full proof-completion suite: 4 in parallel, 2h timeout each

--- a/benchmark/proof-completion/core.txt
+++ b/benchmark/proof-completion/core.txt
@@ -1,13 +1,9 @@
 Allocator/Allocator_AllocateMutex.tla
 AtomicBakery/AtomicBakeryWithoutSMT_GGIrreflexive.tla
-AtomicBakery/AtomicBakeryWithoutSMT_InductiveInvariant.tla
 AtomicBakery/AtomicBakeryWithoutSMT_InitImpliesTypeOK.tla
 AtomicBakery/AtomicBakeryWithoutSMT_Safety.tla
 AtomicBakery/AtomicBakeryWithoutSMT_TypeOKInvariant.tla
 Consensus/Consensus_Invariance.tla
-Consensus/PaxosProof_struct_lemma.tla
-Data/Sets_CardinalitySetMinus.tla
-Data/Sets_FiniteSubset.tla
 Data/Sets_IntervalCardinality.tla
 Data/Sets_PigeonHole.tla
 Euclid/GCD_GCD1.tla

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -271,13 +271,13 @@ uv run tlaps-bench run [flags]
 
 Run `uv run tlaps-bench run --help` for the full flag list.
 
-The default remains the complete suite. To run the committed 190-task Proof Completion Core:
+The default remains the complete suite. To run the committed 186-task Proof Completion Core:
 
 ```bash
 uv run tlaps-bench run --mode proof-completion --task-list core
 ```
 
-The current Core selects 190 tasks across 56 specifications. Full remains the default when `--task-list` is omitted.
+The current Core selects 186 tasks across 55 specifications. Full remains the default when `--task-list` is omitted.
 
 `core` is a registered name for the current mode's committed `core.txt`; Proof Completion provides it today. Explicit file paths remain supported. Task lists use exact manifest IDs rather than substring matching. Unavailable cohorts, missing files, unknown IDs, duplicates, and empty lists fail before authentication, image setup, or model preflight. A task-list run records its resolved cohort in `task-list.json` inside the output directory.
 

--- a/tests/dataset/test_proof_completion_core.py
+++ b/tests/dataset/test_proof_completion_core.py
@@ -24,16 +24,33 @@ def _step_band(steps: int) -> str:
     return "101+"
 
 
-def test_core_list_contains_190_unique_manifest_tasks_from_56_specifications():
+def test_core_list_contains_186_unique_manifest_tasks_from_55_specifications():
     manifest = json.loads((SUITE / "manifest.json").read_text(encoding="utf-8"))
     task_ids = [line.strip() for line in (SUITE / "core.txt").read_text(encoding="utf-8").splitlines() if line.strip()]
 
-    assert len(task_ids) == 190
+    assert len(task_ids) == 186
     assert task_ids == sorted(task_ids)
     assert len(task_ids) == len(set(task_ids))
     assert set(task_ids) <= set(manifest)
     assert all((SUITE / task_id).is_file() for task_id in task_ids)
-    assert len({manifest[task_id]["spec_id"] for task_id in task_ids}) == 56
+    assert len({manifest[task_id]["spec_id"] for task_id in task_ids}) == 55
+
+
+def test_core_excludes_tasks_with_invalid_reference_proofs():
+    task_ids = {line.strip() for line in (SUITE / "core.txt").read_text(encoding="utf-8").splitlines() if line.strip()}
+    assert "AtomicBakery/AtomicBakeryWithoutSMT_InductiveInvariant.tla" not in task_ids
+    assert "Consensus/PaxosProof_struct_lemma.tla" not in task_ids
+    assert "Data/Sets_CardinalitySetMinus.tla" not in task_ids
+    assert "Data/Sets_FiniteSubset.tla" not in task_ids
+    # Still present in Full
+    for task_id in (
+        "AtomicBakery/AtomicBakeryWithoutSMT_InductiveInvariant.tla",
+        "Consensus/PaxosProof_struct_lemma.tla",
+        "Data/Sets_CardinalitySetMinus.tla",
+        "Data/Sets_FiniteSubset.tla",
+    ):
+        assert (SUITE / task_id).is_file()
+        assert task_id in json.loads((SUITE / "manifest.json").read_text(encoding="utf-8"))
 
 
 def test_core_tasks_expose_reference_proof_steps_for_website_complexity_bands():

--- a/tests/evaluator/test_task_list.py
+++ b/tests/evaluator/test_task_list.py
@@ -71,7 +71,7 @@ def test_core_name_resolves_for_proof_completion_only():
 
     resolved = runner._resolve_task_list("core", proof_completion)
     assert resolved == str(REPO_ROOT / "benchmark" / "proof-completion" / "core.txt")
-    assert len(runner._load_task_list(resolved)) == 190
+    assert len(runner._load_task_list(resolved)) == 186
     with pytest.raises(ValueError, match="named task list 'core'.*proof-from-scratch"):
         runner._resolve_task_list("core", proof_from_scratch)
 


### PR DESCRIPTION
Summary :
- Remove 4 Proof Completion Core tasks whose human reference proofs do not validate cleanly.
- Keep them in Full (`manifest.json` unchanged).
- Update Core docs/tests: 190 → 186 tasks, 56 → 55 specifications.

Why these were removed :


| Task | Result | Reason |
|---|---|---|
| `AtomicBakeryWithoutSMT_InductiveInvariant` | FAIL | Reference proof fails (`3/246` obligations) |
| `PaxosProof_struct_lemma` | OMITTED | Target proof contains `PROOF OMITTED` on the preservation step |
| `Sets_CardinalitySetMinus` | OMITTED | Target proof contains `PROOF OMITTED` on the cardinality equality |
| `Sets_FiniteSubset` | FAIL | Reference proof fails (`1/52` obligations) |

They are not useful on a scored Core set until the source proofs are repaired.

Test plan :
- Run uv run pytest tests/dataset/test_proof_completion_core.py tests/evaluator/test_task_list.py
- Check that the 4 tasks are gone from core.txt, but the .tla files are still in the Full suite
- Optional: validate each dropped task again and confirm they still FAIL or show OMITTED