### PR TITLE
Fix LiteLLM one-shot output and request limits

### DIFF
--- a/src/evaluator/backends/litellm_oneshot.py
+++ b/src/evaluator/backends/litellm_oneshot.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from .base import detect_firewall_hosts
 from .litellm_common import DEFAULT_MODEL, ENV_KEYS, REASONING_EFFORT_VALUES, check_auth, credential_mounts
 from .oneshot import OneShotBackend
@@ -14,6 +16,11 @@ class LiteLLMOneShotBackend(OneShotBackend):
     install_script = "install-litellm-oneshot.sh"
     env_keys = ENV_KEYS
     reasoning_effort_values = REASONING_EFFORT_VALUES
+    capabilities = replace(
+        OneShotBackend.capabilities,
+        cooperative_deadline=True,
+        timeout_drain_grace=10.0,
+    )
 
     def __init__(self, model: str | None = None):
         self.model = model or DEFAULT_MODEL

--- a/src/evaluator/backends/oneshot_runner.py
+++ b/src/evaluator/backends/oneshot_runner.py
@@ -1114,11 +1114,11 @@ def _response_finish_reason(response: object) -> str | None:
     return finish_reason if isinstance(finish_reason, str) and finish_reason else None
 
 
-def _litellm_max_tokens(litellm: object, model: str) -> int:
-    """Use installed LiteLLM metadata without a provider lookup or network preflight."""
+def _litellm_max_tokens(litellm: object, model: str) -> int | None:
+    """Return the provider model limit from installed LiteLLM metadata."""
     model_cost = getattr(litellm, "model_cost", {})
     if not isinstance(model_cost, dict):
-        return 32_768
+        return None
     candidates = (model, model.split("/", 1)[-1])
     for candidate in candidates:
         metadata = model_cost.get(candidate)
@@ -1127,8 +1127,8 @@ def _litellm_max_tokens(litellm: object, model: str) -> int:
         for key in ("max_output_tokens", "max_tokens"):
             limit = metadata.get(key)
             if isinstance(limit, int) and not isinstance(limit, bool) and limit > 0:
-                return min(32_768, limit)
-    return 32_768
+                return limit
+    return None
 
 
 def _litellm_response_cost(litellm: object, response: object) -> tuple[float, str] | None:
@@ -1152,7 +1152,7 @@ def _litellm_response_cost(litellm: object, response: object) -> tuple[float, st
 def _litellm_audit(
     prompt: str,
     model: str,
-    max_tokens: int = 32_768,
+    max_tokens: int | None = None,
     reasoning_effort: str | None = None,
 ) -> dict[str, object]:
     request: dict[str, object] = {"model": model, "messages": [{"role": "user", "content": prompt}]}
@@ -1177,25 +1177,34 @@ def _litellm_audit(
         ).hexdigest(),
         "system_supplied": False,
         "tools_supplied": False,
-        "max_tokens": max_tokens,
     }
+    if max_tokens is not None:
+        audit["max_tokens"] = max_tokens
     if reasoning_effort is not None:
         audit["reasoning_effort"] = reasoning_effort
     return audit
 
 
-def run_litellm(prompt: str, model: str, reasoning_effort: str | None = None) -> ProviderResult:
+def run_litellm(
+    prompt: str,
+    model: str,
+    reasoning_effort: str | None = None,
+    timeout: float | None = None,
+) -> ProviderResult:
     request: dict[str, object] = {"model": model, "messages": [{"role": "user", "content": prompt}]}
     if reasoning_effort is not None:
         request["reasoning_effort"] = reasoning_effort
     audit = _litellm_audit(prompt, model, reasoning_effort=reasoning_effort)
+    if timeout is not None:
+        audit["timeout_seconds"] = timeout
     try:
         import litellm
     except ImportError as exc:
         raise ProviderRunError("litellm is not installed", audit) from exc
 
     max_tokens = _litellm_max_tokens(litellm, model)
-    audit["max_tokens"] = max_tokens
+    if max_tokens is not None:
+        audit["max_tokens"] = max_tokens
 
     # This disables LiteLLM's own retry orchestration. Provider transports may
     # have behavior below this adapter boundary, so this is intentionally not
@@ -1207,11 +1216,17 @@ def run_litellm(prompt: str, model: str, reasoning_effort: str | None = None) ->
         audit["litellm_completion_invocations"] = 1
         audit["model_requests"] = 1
         audit["request_attempts"] = 1
-        response = litellm.completion(
+        completion_options: dict[str, object] = {
             **request,
-            stream=False,
-            max_tokens=max_tokens,
-            num_retries=0,
+            "stream": False,
+            "num_retries": 0,
+        }
+        if max_tokens is not None:
+            completion_options["max_tokens"] = max_tokens
+        if timeout is not None:
+            completion_options["timeout"] = timeout
+        response = litellm.completion(
+            **completion_options,
         )
         usage = _get(response, "usage")
         request_input = _optional_nonnegative_int(_get(usage, "prompt_tokens"))
@@ -1244,11 +1259,14 @@ def run_litellm(prompt: str, model: str, reasoning_effort: str | None = None) ->
             response_cost, cost_source = cost_evidence
             detail["costs"] = [{"amount": response_cost, "unit": "usd", "source": cost_source}]
         usage_details = (detail,)
-        text = _response_text(response)
         finish_reason = _response_finish_reason(response)
         if finish_reason is not None:
             audit["finish_reason"] = finish_reason
             detail["finish_reason"] = finish_reason
+        if finish_reason == "length":
+            limit = f" {max_tokens}-token" if max_tokens is not None else ""
+            raise RuntimeError(f"one-shot provider exhausted its{limit} output limit")
+        text = _response_text(response)
     except Exception as exc:
         raise ProviderRunError(
             str(exc),
@@ -1703,21 +1721,26 @@ class _LiteLLMProvider:
         prompt: str,
         model: str,
         _workspace: str,
-        _deadline: float | None,
+        deadline: float | None,
         reasoning_effort: str | None = None,
     ) -> None:
         self.prompt = prompt
         self.model = model
         self.reasoning_effort = reasoning_effort
+        self.deadline = deadline
 
     @property
     def audit(self) -> dict[str, object]:
         return _litellm_audit(self.prompt, self.model, reasoning_effort=self.reasoning_effort)
 
     def invoke(self, _on_timeout: Callable[[ProviderTimeoutError], None]) -> ProviderResult:
-        if self.reasoning_effort is None:
-            return run_litellm(self.prompt, self.model)
-        return run_litellm(self.prompt, self.model, self.reasoning_effort)
+        timeout = max(self.deadline - time.time(), 0.001) if self.deadline is not None else None
+        options: dict[str, object] = {}
+        if self.reasoning_effort is not None:
+            options["reasoning_effort"] = self.reasoning_effort
+        if timeout is not None:
+            options["timeout"] = timeout
+        return run_litellm(self.prompt, self.model, **options)
 
 
 class _CopilotProvider:

--- a/tests/evaluator/test_oneshot_backends.py
+++ b/tests/evaluator/test_oneshot_backends.py
@@ -164,6 +164,8 @@ def test_shared_command_and_capabilities(tmp_path):
     assert backend.capabilities.max_continuations == 0
     assert backend.capabilities.default_infra_retries == 3
     assert backend.capabilities.max_infra_retries is None
+    assert backend.capabilities.cooperative_deadline is True
+    assert backend.capabilities.timeout_drain_grace == 10.0
 
 
 def test_shared_command_uses_module_runner_for_native_execution(tmp_path):

--- a/tests/evaluator/test_oneshot_runner.py
+++ b/tests/evaluator/test_oneshot_runner.py
@@ -823,7 +823,6 @@ def test_litellm_makes_one_call_with_no_tools_system_or_retries(monkeypatch):
             "model": "provider/model",
             "messages": [{"role": "user", "content": "EXACT PROMPT"}],
             "stream": False,
-            "max_tokens": 32_768,
             "num_retries": 0,
         }
     ]
@@ -841,9 +840,11 @@ def test_litellm_makes_one_call_with_no_tools_system_or_retries(monkeypatch):
     assert result.audit["wire_audited"] is False
     assert result.audit["litellm_retries_disabled"] is True
 
-    reasoned_result = oneshot_runner.run_litellm("EXACT PROMPT", "provider/model", "low")
+    reasoned_result = oneshot_runner.run_litellm("EXACT PROMPT", "provider/model", "low", 7_200.0)
     assert calls[-1]["reasoning_effort"] == "low"
+    assert calls[-1]["timeout"] == 7_200.0
     assert reasoned_result.audit["reasoning_effort"] == "low"
+    assert reasoned_result.audit["timeout_seconds"] == 7_200.0
     assert result.audit["system_supplied"] is False
     assert result.audit["tools_supplied"] is False
     assert result.audit["finish_reason"] == "stop"
@@ -910,7 +911,7 @@ def test_litellm_falls_back_to_completion_cost_and_omits_unpriceable(monkeypatch
     assert "costs" not in detail
 
 
-def test_litellm_clamps_output_budget_to_installed_model_metadata(monkeypatch):
+def test_litellm_uses_full_output_budget_from_installed_model_metadata(monkeypatch):
     calls: list[dict] = []
 
     def completion(**kwargs):
@@ -922,14 +923,45 @@ def test_litellm_clamps_output_budget_to_installed_model_metadata(monkeypatch):
 
     fake_litellm = types.ModuleType("litellm")
     fake_litellm.completion = completion
-    fake_litellm.model_cost = {"provider/small-model": {"max_output_tokens": 8_192}}
+    fake_litellm.model_cost = {"provider/large-model": {"max_output_tokens": 128_000}}
     monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
 
-    result = oneshot_runner.run_litellm("EXACT PROMPT", "provider/small-model")
+    result = oneshot_runner.run_litellm("EXACT PROMPT", "provider/large-model")
 
-    assert calls[0]["max_tokens"] == 8_192
-    assert result.audit["max_tokens"] == 8_192
+    assert calls[0]["max_tokens"] == 128_000
+    assert result.audit["max_tokens"] == 128_000
     assert (result.input_tokens, result.output_tokens) == (None, None)
+
+
+def test_litellm_length_failure_keeps_finish_reason_and_usage(monkeypatch):
+    response = SimpleNamespace(
+        id="msg-truncated",
+        model="provider/large-model",
+        choices=[SimpleNamespace(message=SimpleNamespace(content=""), finish_reason="length")],
+        usage=SimpleNamespace(prompt_tokens=123, completion_tokens=128_000),
+    )
+    fake_litellm = types.ModuleType("litellm")
+    fake_litellm.completion = lambda **_kwargs: response
+    fake_litellm.completion_cost = lambda **_kwargs: 6.5
+    fake_litellm.model_cost = {"provider/large-model": {"max_output_tokens": 128_000}}
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    with pytest.raises(oneshot_runner.ProviderRunError, match="128000-token output limit") as exc_info:
+        oneshot_runner.run_litellm("EXACT PROMPT", "provider/large-model")
+
+    assert exc_info.value.audit["finish_reason"] == "length"
+    assert (exc_info.value.input_tokens, exc_info.value.output_tokens) == (123, 128_000)
+    assert exc_info.value.usage_details == (
+        {
+            "source": "litellm_response_usage",
+            "input_tokens": 123,
+            "output_tokens": 128_000,
+            "model": "provider/large-model",
+            "request_id": "msg-truncated",
+            "costs": [{"amount": 6.5, "unit": "usd", "source": "litellm.completion_cost"}],
+            "finish_reason": "length",
+        },
+    )
 
 
 def test_main_preserves_missing_litellm_usage_as_null(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
Fixes two limits that caused valid LiteLLM one-shot runs to fail.

The runner previously limited every LiteLLM response to 32,768 output tokens. It now uses the full output limit reported by LiteLLM for the selected model. If model metadata is unavailable, the runner does not add its own token limit.

The runner also used LiteLLM’s default 600-second request timeout. It now passes the benchmark deadline to LiteLLM. Long model requests can therefore use the full configured benchmark timeout.