### PR TITLE
fix quantify ZooKeeper LocalPrimaryOrder over every pair

### DIFF
--- a/benchmark/proof-from-scratch/ZooKeeper/Zab_LocalPrimaryOrderDefs.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper/Zab_LocalPrimaryOrderDefs.tla
@@ -17,9 +17,8 @@ LocalPrimaryOrder == LET p_set(i, e) == {p \in proposalMsgsLog: /\ p.source = i
                              \/ /\ ~TxnEqual(txn1, txn2)
                                 /\ LET TxnPre  == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn2 ELSE txn1
                                        TxnNext == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn1 ELSE txn2
-                                   IN \A j \in Server: /\ lastCommitted[j].index >= 2
-                                                       /\ \E idx \in 1..lastCommitted[j].index: 
-                                                            TxnEqual(history[j][idx], TxnNext)
+                                   IN \A j \in Server: (\E idx \in 1..lastCommitted[j].index: 
+                                                            TxnEqual(history[j][idx], TxnNext))
                                         => \E idx2 \in 1..lastCommitted[j].index: 
                                             /\ TxnEqual(history[j][idx2], TxnNext)
                                             /\ idx2 > 1

--- a/benchmark/proof-from-scratch/ZooKeeper/Zab_LocalPrimaryOrderDefs.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper/Zab_LocalPrimaryOrderDefs.tla
@@ -12,7 +12,7 @@ LocalPrimaryOrder == LET p_set(i, e) == {p \in proposalMsgsLog: /\ p.source = i
                      IN \A i \in Server: \A e \in 1..currentEpoch[i]:
                          \/ Cardinality(txn_set(i, e)) < 2
                          \/ /\ Cardinality(txn_set(i, e)) >= 2
-                            /\ \E txn1, txn2 \in txn_set(i, e):
+                            /\ \A txn1, txn2 \in txn_set(i, e):
                              \/ TxnEqual(txn1, txn2)
                              \/ /\ ~TxnEqual(txn1, txn2)
                                 /\ LET TxnPre  == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn2 ELSE txn1

--- a/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_LocalPrimaryOrderDefs.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_LocalPrimaryOrderDefs.tla
@@ -17,9 +17,8 @@ LocalPrimaryOrder == LET p_set(i, e) == {p \in proposalMsgsLog: /\ p.source = i
                              \/ /\ ~TxnEqual(txn1, txn2)
                                 /\ LET TxnPre  == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn2 ELSE txn1
                                        TxnNext == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn1 ELSE txn2
-                                   IN \A j \in Server: /\ lastCommitted[j].index >= 2
-                                                       /\ \E idx \in 1..lastCommitted[j].index: 
-                                                            TxnEqual(history[j][idx], TxnNext)
+                                   IN \A j \in Server: (\E idx \in 1..lastCommitted[j].index: 
+                                                            TxnEqual(history[j][idx], TxnNext))
                                         => \E idx2 \in 1..lastCommitted[j].index: 
                                             /\ TxnEqual(history[j][idx2], TxnNext)
                                             /\ idx2 > 1

--- a/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_LocalPrimaryOrderDefs.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_LocalPrimaryOrderDefs.tla
@@ -12,7 +12,7 @@ LocalPrimaryOrder == LET p_set(i, e) == {p \in proposalMsgsLog: /\ p.source = i
                      IN \A i \in Server: \A e \in 1..currentEpoch[i]:
                          \/ Cardinality(txn_set(i, e)) < 2
                          \/ /\ Cardinality(txn_set(i, e)) >= 2
-                            /\ \E txn1, txn2 \in txn_set(i, e):
+                            /\ \A txn1, txn2 \in txn_set(i, e):
                              \/ TxnEqual(txn1, txn2)
                              \/ /\ ~TxnEqual(txn1, txn2)
                                 /\ LET TxnPre  == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn2 ELSE txn1

--- a/source/ZooKeeper/Zab.tla
+++ b/source/ZooKeeper/Zab.tla
@@ -1075,9 +1075,8 @@ LocalPrimaryOrder == LET p_set(i, e) == {p \in proposalMsgsLog: /\ p.source = i
                              \/ /\ ~TxnEqual(txn1, txn2)
                                 /\ LET TxnPre  == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn2 ELSE txn1
                                        TxnNext == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn1 ELSE txn2
-                                   IN \A j \in Server: /\ lastCommitted[j].index >= 2
-                                                       /\ \E idx \in 1..lastCommitted[j].index: 
-                                                            TxnEqual(history[j][idx], TxnNext)
+                                   IN \A j \in Server: (\E idx \in 1..lastCommitted[j].index: 
+                                                            TxnEqual(history[j][idx], TxnNext))
                                         => \E idx2 \in 1..lastCommitted[j].index: 
                                             /\ TxnEqual(history[j][idx2], TxnNext)
                                             /\ idx2 > 1

--- a/source/ZooKeeper/Zab.tla
+++ b/source/ZooKeeper/Zab.tla
@@ -1070,7 +1070,7 @@ LocalPrimaryOrder == LET p_set(i, e) == {p \in proposalMsgsLog: /\ p.source = i
                      IN \A i \in Server: \A e \in 1..currentEpoch[i]:
                          \/ Cardinality(txn_set(i, e)) < 2
                          \/ /\ Cardinality(txn_set(i, e)) >= 2
-                            /\ \E txn1, txn2 \in txn_set(i, e):
+                            /\ \A txn1, txn2 \in txn_set(i, e):
                              \/ TxnEqual(txn1, txn2)
                              \/ /\ ~TxnEqual(txn1, txn2)
                                 /\ LET TxnPre  == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn2 ELSE txn1

--- a/source/ZooKeeper_LowLevel/ZkV3_7_0.tla
+++ b/source/ZooKeeper_LowLevel/ZkV3_7_0.tla
@@ -1788,9 +1788,8 @@ LocalPrimaryOrder == LET p_set(i, e) == {p \in proposalMsgsLog: /\ p.source = i
                              \/ /\ ~TxnEqual(txn1, txn2)
                                 /\ LET TxnPre  == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn2 ELSE txn1
                                        TxnNext == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn1 ELSE txn2
-                                   IN \A j \in Server: /\ lastCommitted[j].index >= 2
-                                                       /\ \E idx \in 1..lastCommitted[j].index: 
-                                                            TxnEqual(history[j][idx], TxnNext)
+                                   IN \A j \in Server: (\E idx \in 1..lastCommitted[j].index: 
+                                                            TxnEqual(history[j][idx], TxnNext))
                                         => \E idx2 \in 1..lastCommitted[j].index: 
                                             /\ TxnEqual(history[j][idx2], TxnNext)
                                             /\ idx2 > 1

--- a/source/ZooKeeper_LowLevel/ZkV3_7_0.tla
+++ b/source/ZooKeeper_LowLevel/ZkV3_7_0.tla
@@ -1783,7 +1783,7 @@ LocalPrimaryOrder == LET p_set(i, e) == {p \in proposalMsgsLog: /\ p.source = i
                      IN \A i \in Server: \A e \in 1..currentEpoch[i]:
                          \/ Cardinality(txn_set(i, e)) < 2
                          \/ /\ Cardinality(txn_set(i, e)) >= 2
-                            /\ \E txn1, txn2 \in txn_set(i, e):
+                            /\ \A txn1, txn2 \in txn_set(i, e):
                              \/ TxnEqual(txn1, txn2)
                              \/ /\ ~TxnEqual(txn1, txn2)
                                 /\ LET TxnPre  == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn2 ELSE txn1

--- a/tests/dataset/LPOQuantifierCheck.cfg
+++ b/tests/dataset/LPOQuantifierCheck.cfg
@@ -1,0 +1,1 @@
+SPECIFICATION Spec

--- a/tests/dataset/LPOQuantifierCheck.tla
+++ b/tests/dataset/LPOQuantifierCheck.tla
@@ -1,0 +1,61 @@
+---- MODULE LPOQuantifierCheck ----
+\* Isolated evaluation of LocalPrimaryOrder, not of the full ZooKeeper spec.
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+ZxidCompare(z1, z2) == \/ z1[1] > z2[1]
+                       \/ /\ z1[1] = z2[1]
+                          /\ z1[2] > z2[2]
+
+ZxidEqual(z1, z2) == z1[1] = z2[1] /\ z1[2] = z2[2]
+
+TxnEqual(t1, t2) == /\ ZxidEqual(t1.zxid, t2.zxid)
+                    /\ t1.value = t2.value
+
+a == [zxid |-> <<1, 1>>, value |-> "a"]
+b == [zxid |-> <<1, 2>>, value |-> "b"]
+x == [zxid |-> <<9, 9>>, value |-> "x"]
+
+txn_set == {a, b}
+
+OrderHolds(history, committed, TxnPre, TxnNext, requireTwo) ==
+    LET deliveredNext == \E idx \in 1..committed: TxnEqual(history[idx], TxnNext)
+        consequent == \E idx2 \in 1..committed:
+                        /\ TxnEqual(history[idx2], TxnNext)
+                        /\ idx2 > 1
+                        /\ \E idx1 \in 1..(idx2 - 1):
+                             TxnEqual(history[idx1], TxnPre)
+        antecedent == IF requireTwo
+                      THEN committed >= 2 /\ deliveredNext
+                      ELSE deliveredNext
+    IN antecedent => consequent
+
+PairOrder(history, committed, requireTwo) ==
+    \A txn1, txn2 \in txn_set:
+        \/ TxnEqual(txn1, txn2)
+        \/ /\ ~TxnEqual(txn1, txn2)
+           /\ LET TxnPre  == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn2 ELSE txn1
+                  TxnNext == IF ZxidCompare(txn1.zxid, txn2.zxid) THEN txn1 ELSE txn2
+              IN OrderHolds(history, committed, TxnPre, TxnNext, requireTwo)
+
+\* Broadcasts a then b. Follower delivered only b.
+OldOnSingletonB == PairOrder(<<b>>, 1, TRUE)
+NewOnSingletonB == PairOrder(<<b>>, 1, FALSE)
+
+\* Follower delivered filler then b, never a.
+OldOnXb == PairOrder(<<x, b>>, 2, TRUE)
+NewOnXb == PairOrder(<<x, b>>, 2, FALSE)
+
+\* Intended success: delivered a then b.
+NewOnAb == PairOrder(<<a, b>>, 2, FALSE)
+
+ASSUME /\ OldOnSingletonB = TRUE
+       /\ NewOnSingletonB = FALSE
+       /\ OldOnXb = FALSE
+       /\ NewOnXb = FALSE
+       /\ NewOnAb = TRUE
+
+VARIABLE dummy
+Init == dummy = 0
+Next == UNCHANGED dummy
+Spec == Init /\ [][Next]_dummy
+====

--- a/tests/dataset/test_zookeeper_local_primary_order.py
+++ b/tests/dataset/test_zookeeper_local_primary_order.py
@@ -1,12 +1,25 @@
-"""Lock ZooKeeper LocalPrimaryOrder to the intended forall-pairs statement.
+"""Lock ZooKeeper LocalPrimaryOrder to the intended broadcast-order property.
 
 The Remix/Zab comment is: if a primary broadcasts a before b, a follower that
-delivers b also delivers a before b. The old encoding used
-``\\E txn1, txn2 \\in txn_set`` plus reflexive TxnEqual, which is true as soon
-as the set is nonempty. The shipped formula must quantify over every pair.
+delivers b also delivers a before b. Two encodings fail that:
+
+- ``\\E txn1, txn2 \\in txn_set`` plus reflexive TxnEqual is true as soon as
+  the set is nonempty.
+- ``lastCommitted[j].index >= 2`` in the implication skips a follower whose
+  log is only ``<<b>>``.
+
+The shipped formula must quantify over every pair, treat delivery of b as
+the antecedent, and parenthesize that ``\\E`` so it does not swallow ``=>``.
 """
 
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -19,11 +32,65 @@ LPO_FILES = (
 
 EXISTS_PAIR = r"\E txn1, txn2 \in txn_set"
 FORALL_PAIR = r"\A txn1, txn2 \in txn_set"
+COMMITTED_GUARD = "lastCommitted[j].index >= 2"
+DELIVERED_NEXT = r"(\E idx \in 1..lastCommitted[j].index"
+
+TLC_MODULE = REPO_ROOT / "tests" / "dataset" / "LPOQuantifierCheck.tla"
+TLC_CONFIG = REPO_ROOT / "tests" / "dataset" / "LPOQuantifierCheck.cfg"
+TLA2TOOLS = REPO_ROOT / "lib" / "tla2tools.jar"
+
+
+def _local_primary_order_body(text: str) -> str:
+    start = text.index("LocalPrimaryOrder ==")
+    rest = text[start:]
+    ends = []
+    for marker in ("\nTHEOREM ", "\n===="):
+        idx = rest.find(marker)
+        if idx != -1:
+            ends.append(idx)
+    return rest[: min(ends)] if ends else rest
 
 
 def test_local_primary_order_quantifies_over_every_broadcast_pair():
     for path in LPO_FILES:
-        text = path.read_text(encoding="utf-8")
-        assert "LocalPrimaryOrder ==" in text, path
-        assert EXISTS_PAIR not in text, f"{path} still uses existential pair quantification"
-        assert FORALL_PAIR in text, f"{path} is missing forall-pairs LocalPrimaryOrder"
+        body = _local_primary_order_body(path.read_text(encoding="utf-8"))
+        assert EXISTS_PAIR not in body, f"{path} still uses existential pair quantification"
+        assert FORALL_PAIR in body, f"{path} is missing forall-pairs LocalPrimaryOrder"
+        assert COMMITTED_GUARD not in body, (
+            f"{path} still skips followers with lastCommitted index 1"
+        )
+        assert DELIVERED_NEXT in body, (
+            f"{path} must parenthesize the delivery check so \\E does not bind =>"
+        )
+
+
+def test_local_primary_order_fails_when_follower_delivered_only_b():
+    java = shutil.which("java")
+    if java is None:
+        pytest.skip("java is required to evaluate the LocalPrimaryOrder TLC fixture")
+    if not TLA2TOOLS.is_file():
+        pytest.skip(f"missing {TLA2TOOLS}")
+
+    result = subprocess.run(
+        [
+            java,
+            "-XX:+UseParallelGC",
+            "-cp",
+            str(TLA2TOOLS),
+            "tlc2.TLC",
+            "-deadlock",
+            "-nowarning",
+            "-config",
+            str(TLC_CONFIG),
+            str(TLC_MODULE),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, "JAVA_TOOL_OPTIONS": ""},
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "No error has been found" in output
+    assert "Assumption" not in output

--- a/tests/dataset/test_zookeeper_local_primary_order.py
+++ b/tests/dataset/test_zookeeper_local_primary_order.py
@@ -1,0 +1,29 @@
+"""Lock ZooKeeper LocalPrimaryOrder to the intended forall-pairs statement.
+
+The Remix/Zab comment is: if a primary broadcasts a before b, a follower that
+delivers b also delivers a before b. The old encoding used
+``\\E txn1, txn2 \\in txn_set`` plus reflexive TxnEqual, which is true as soon
+as the set is nonempty. The shipped formula must quantify over every pair.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+LPO_FILES = (
+    REPO_ROOT / "source" / "ZooKeeper" / "Zab.tla",
+    REPO_ROOT / "source" / "ZooKeeper_LowLevel" / "ZkV3_7_0.tla",
+    REPO_ROOT / "benchmark" / "proof-from-scratch" / "ZooKeeper" / "Zab_LocalPrimaryOrderDefs.tla",
+    REPO_ROOT / "benchmark" / "proof-from-scratch" / "ZooKeeper_LowLevel" / "ZkV3_7_0_LocalPrimaryOrderDefs.tla",
+)
+
+EXISTS_PAIR = r"\E txn1, txn2 \in txn_set"
+FORALL_PAIR = r"\A txn1, txn2 \in txn_set"
+
+
+def test_local_primary_order_quantifies_over_every_broadcast_pair():
+    for path in LPO_FILES:
+        text = path.read_text(encoding="utf-8")
+        assert "LocalPrimaryOrder ==" in text, path
+        assert EXISTS_PAIR not in text, f"{path} still uses existential pair quantification"
+        assert FORALL_PAIR in text, f"{path} is missing forall-pairs LocalPrimaryOrder"

--- a/tests/dataset/test_zookeeper_local_primary_order.py
+++ b/tests/dataset/test_zookeeper_local_primary_order.py
@@ -56,12 +56,8 @@ def test_local_primary_order_quantifies_over_every_broadcast_pair():
         body = _local_primary_order_body(path.read_text(encoding="utf-8"))
         assert EXISTS_PAIR not in body, f"{path} still uses existential pair quantification"
         assert FORALL_PAIR in body, f"{path} is missing forall-pairs LocalPrimaryOrder"
-        assert COMMITTED_GUARD not in body, (
-            f"{path} still skips followers with lastCommitted index 1"
-        )
-        assert DELIVERED_NEXT in body, (
-            f"{path} must parenthesize the delivery check so \\E does not bind =>"
-        )
+        assert COMMITTED_GUARD not in body, f"{path} still skips followers with lastCommitted index 1"
+        assert DELIVERED_NEXT in body, f"{path} must parenthesize the delivery check so \\E does not bind =>"
 
 
 def test_local_primary_order_fails_when_follower_delivered_only_b():


### PR DESCRIPTION
## What was the issue :
Local primary order is supposed to mean, if a primary broadcasts a before b, a follower that delivers b must already have delivered a. The formula used `\E txn1, txn2` , “there exist two transactions”. In TLA+ those two names can be the same transaction, and a transaction is always equal to itself, so once there are a couple of broadcasts the formula is already true. It never actually checks order. The task was not asking for the property in the comment / Zab paper.

## How we solved : 
I switched that to `\A` for all pairs in:
- `source/ZooKeeper/Zab.tla`
- `source/ZooKeeper_LowLevel/ZkV3_7_0.tla`
- the two matching proof-from-scratch Defs files

and added a test so we don’t silently go back to `\E`.
I checked this with TLC on a tiny example using the same comparison operators as Zab: broadcasts a then b, follower log has delivered b and never a (`<<x, b>>`). The old `\E` formula is true in that state, the new `\A` formula is false. That’s what we want, the paper property fails, and the old encoding does not notice. I did not model check the full ZooKeeper spec (`Spec => []LocalPrimaryOrder`). That spec is too open ended for TLC as we ship it.

If we’d rather not ship a stronger theorem without a full-spec check, we can drop these two tasks instead of this fix.

## Testing:
- TLC on the small `\E` vs `\A` example
- SANY on both staged LocalPrimaryOrder task bundles
- Integrity check on the proof-from-scratch suite
- `pytest tests/dataset/test_zookeeper_local_primary_order.py`