### PR TITLE
Expose proof libraries to proof-from-scratch tasks

### DIFF
--- a/benchmark/proof-from-scratch/Allocator/Allocator_InitMutex.tla
+++ b/benchmark/proof-from-scratch/Allocator/Allocator_InitMutex.tla
@@ -1,5 +1,11 @@
 ---- MODULE Allocator_InitMutex ----
 EXTENDS Allocator_InitMutexDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM InitMutex == Init => Mutex

--- a/benchmark/proof-from-scratch/Allocator/Allocator_InitTypeInvariant.tla
+++ b/benchmark/proof-from-scratch/Allocator/Allocator_InitTypeInvariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE Allocator_InitTypeInvariant ----
 EXTENDS Allocator_InitTypeInvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM InitTypeInvariant == Init => TypeInvariant

--- a/benchmark/proof-from-scratch/Allocator/Allocator_NextMutex.tla
+++ b/benchmark/proof-from-scratch/Allocator/Allocator_NextMutex.tla
@@ -1,5 +1,11 @@
 ---- MODULE Allocator_NextMutex ----
 EXTENDS Allocator_NextMutexDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM NextMutex == TypeInvariant /\ Mutex /\ Next => Mutex'

--- a/benchmark/proof-from-scratch/Allocator/Allocator_NextTypeInvariant.tla
+++ b/benchmark/proof-from-scratch/Allocator/Allocator_NextTypeInvariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE Allocator_NextTypeInvariant ----
 EXTENDS Allocator_NextTypeInvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM NextTypeInvariant == TypeInvariant /\ Next => TypeInvariant'

--- a/benchmark/proof-from-scratch/AtomicBakery/AtomicBakeryWithoutSMT_Safety.tla
+++ b/benchmark/proof-from-scratch/AtomicBakery/AtomicBakeryWithoutSMT_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE AtomicBakeryWithoutSMT_Safety ----
 EXTENDS AtomicBakeryWithoutSMT_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Safety == Spec => [] MutualExclusion

--- a/benchmark/proof-from-scratch/AtomicBakery/AtomicBakery_MutualExclusion.tla
+++ b/benchmark/proof-from-scratch/AtomicBakery/AtomicBakery_MutualExclusion.tla
@@ -1,5 +1,11 @@
 ---- MODULE AtomicBakery_MutualExclusion ----
 EXTENDS AtomicBakery_MutualExclusionDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []MutualExclusion

--- a/benchmark/proof-from-scratch/Bakery/Bakery_MutualExclusion.tla
+++ b/benchmark/proof-from-scratch/Bakery/Bakery_MutualExclusion.tla
@@ -1,5 +1,11 @@
 ---- MODULE Bakery_MutualExclusion ----
 EXTENDS Bakery_MutualExclusionDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []MutualExclusion

--- a/benchmark/proof-from-scratch/BubbleSort/BubbleSort_IsPermOfExchange.tla
+++ b/benchmark/proof-from-scratch/BubbleSort/BubbleSort_IsPermOfExchange.tla
@@ -1,5 +1,11 @@
 ---- MODULE BubbleSort_IsPermOfExchange ----
 EXTENDS BubbleSort_IsPermOfExchangeDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM IsPermOfExchange == 

--- a/benchmark/proof-from-scratch/BubbleSort/BubbleSort_IsPermOfTransitive.tla
+++ b/benchmark/proof-from-scratch/BubbleSort/BubbleSort_IsPermOfTransitive.tla
@@ -1,5 +1,11 @@
 ---- MODULE BubbleSort_IsPermOfTransitive ----
 EXTENDS BubbleSort_IsPermOfTransitiveDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM IsPermOfTransitive == 

--- a/benchmark/proof-from-scratch/BubbleSort/BubbleSort_line202.tla
+++ b/benchmark/proof-from-scratch/BubbleSort/BubbleSort_line202.tla
@@ -1,5 +1,11 @@
 ---- MODULE BubbleSort_line202 ----
 EXTENDS BubbleSort_line202Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => [](pc = "Done" => IsSorted(A) /\ IsPermOf(A, A0))

--- a/benchmark/proof-from-scratch/Cantor/Cantor10_NoSetContainsAllValues.tla
+++ b/benchmark/proof-from-scratch/Cantor/Cantor10_NoSetContainsAllValues.tla
@@ -1,5 +1,11 @@
 ---- MODULE Cantor10_NoSetContainsAllValues ----
 EXTENDS Cantor10_NoSetContainsAllValuesDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM NoSetContainsAllValues ==

--- a/benchmark/proof-from-scratch/Cantor/Cantor1_cantor.tla
+++ b/benchmark/proof-from-scratch/Cantor/Cantor1_cantor.tla
@@ -1,5 +1,11 @@
 ---- MODULE Cantor1_cantor ----
 EXTENDS Cantor1_cantorDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM cantor ==

--- a/benchmark/proof-from-scratch/Cantor/Cantor5_cantor.tla
+++ b/benchmark/proof-from-scratch/Cantor/Cantor5_cantor.tla
@@ -1,5 +1,11 @@
 ---- MODULE Cantor5_cantor ----
 EXTENDS Cantor5_cantorDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM cantor ==

--- a/benchmark/proof-from-scratch/Cantor/Cantor8_Cantor.tla
+++ b/benchmark/proof-from-scratch/Cantor/Cantor8_Cantor.tla
@@ -1,5 +1,11 @@
 ---- MODULE Cantor8_Cantor ----
 EXTENDS Cantor8_CantorDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Cantor ==

--- a/benchmark/proof-from-scratch/Cantor/Cantor9_Cantor.tla
+++ b/benchmark/proof-from-scratch/Cantor/Cantor9_Cantor.tla
@@ -1,5 +1,11 @@
 ---- MODULE Cantor9_Cantor ----
 EXTENDS Cantor9_CantorDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Cantor ==

--- a/benchmark/proof-from-scratch/Consensus/Consensus_Invariance.tla
+++ b/benchmark/proof-from-scratch/Consensus/Consensus_Invariance.tla
@@ -1,5 +1,11 @@
 ---- MODULE Consensus_Invariance ----
 EXTENDS Consensus_InvarianceDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Invariance == Spec => []Inv

--- a/benchmark/proof-from-scratch/Consensus/PaxosProof_StructOK1.tla
+++ b/benchmark/proof-from-scratch/Consensus/PaxosProof_StructOK1.tla
@@ -1,5 +1,11 @@
 ---- MODULE PaxosProof_StructOK1 ----
 EXTENDS PaxosProof_StructOK1Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []StructOK1

--- a/benchmark/proof-from-scratch/Consensus/PaxosProof_line130.tla
+++ b/benchmark/proof-from-scratch/Consensus/PaxosProof_line130.tla
@@ -1,5 +1,11 @@
 ---- MODULE PaxosProof_line130 ----
 EXTENDS PaxosProof_line130Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Next /\ Inv => V!Next \/ UNCHANGED <<votes,maxBal>>

--- a/benchmark/proof-from-scratch/Consensus/PaxosProof_line91.tla
+++ b/benchmark/proof-from-scratch/Consensus/PaxosProof_line91.tla
@@ -1,5 +1,11 @@
 ---- MODULE PaxosProof_line91 ----
 EXTENDS PaxosProof_line91Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM \A b \in Ballot, v \in Value : 

--- a/benchmark/proof-from-scratch/Consensus/Voting_AllSafeAtZero.tla
+++ b/benchmark/proof-from-scratch/Consensus/Voting_AllSafeAtZero.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_AllSafeAtZero ----
 EXTENDS Voting_AllSafeAtZeroDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM AllSafeAtZero == \A v \in Value : SafeAt(0, v)

--- a/benchmark/proof-from-scratch/Consensus/Voting_ChoosableThm.tla
+++ b/benchmark/proof-from-scratch/Consensus/Voting_ChoosableThm.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_ChoosableThm ----
 EXTENDS Voting_ChoosableThmDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM ChoosableThm ==

--- a/benchmark/proof-from-scratch/Consensus/Voting_Consistent.tla
+++ b/benchmark/proof-from-scratch/Consensus/Voting_Consistent.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_Consistent ----
 EXTENDS Voting_ConsistentDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Consistent == Spec => []Consistency

--- a/benchmark/proof-from-scratch/Consensus/Voting_Invariant.tla
+++ b/benchmark/proof-from-scratch/Consensus/Voting_Invariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_Invariant ----
 EXTENDS Voting_InvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Invariant == Spec => []Inv

--- a/benchmark/proof-from-scratch/Consensus/Voting_QuorumNonEmpty.tla
+++ b/benchmark/proof-from-scratch/Consensus/Voting_QuorumNonEmpty.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_QuorumNonEmpty ----
 EXTENDS Voting_QuorumNonEmptyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM QuorumNonEmpty == \A Q \in Quorum : Q # {}

--- a/benchmark/proof-from-scratch/Consensus/Voting_Refinement.tla
+++ b/benchmark/proof-from-scratch/Consensus/Voting_Refinement.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_Refinement ----
 EXTENDS Voting_RefinementDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Refinement == Spec => C!Spec

--- a/benchmark/proof-from-scratch/Data/GraphTheorem_line62.tla
+++ b/benchmark/proof-from-scratch/Data/GraphTheorem_line62.tla
@@ -1,5 +1,11 @@
 ---- MODULE GraphTheorem_line62 ----
 EXTENDS GraphTheorem_line62Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM

--- a/benchmark/proof-from-scratch/Data/SequencesTheorems_RemoveSeq.tla
+++ b/benchmark/proof-from-scratch/Data/SequencesTheorems_RemoveSeq.tla
@@ -1,5 +1,11 @@
 ---- MODULE SequencesTheorems_RemoveSeq ----
 EXTENDS SequencesTheorems_RemoveSeqDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM RemoveSeq ==

--- a/benchmark/proof-from-scratch/Data/Sets_CardinalityOneConverse.tla
+++ b/benchmark/proof-from-scratch/Data/Sets_CardinalityOneConverse.tla
@@ -1,5 +1,11 @@
 ---- MODULE Sets_CardinalityOneConverse ----
 EXTENDS Sets_CardinalityOneConverseDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM CardinalityOneConverse ==

--- a/benchmark/proof-from-scratch/Data/Sets_CardinalityTwo.tla
+++ b/benchmark/proof-from-scratch/Data/Sets_CardinalityTwo.tla
@@ -1,5 +1,11 @@
 ---- MODULE Sets_CardinalityTwo ----
 EXTENDS Sets_CardinalityTwoDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM CardinalityTwo == \A m, p : m # p => 

--- a/benchmark/proof-from-scratch/Data/Sets_FiniteSubset.tla
+++ b/benchmark/proof-from-scratch/Data/Sets_FiniteSubset.tla
@@ -1,5 +1,11 @@
 ---- MODULE Sets_FiniteSubset ----
 EXTENDS Sets_FiniteSubsetDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM FiniteSubset ==

--- a/benchmark/proof-from-scratch/Data/Sets_IntervalCardinality.tla
+++ b/benchmark/proof-from-scratch/Data/Sets_IntervalCardinality.tla
@@ -1,5 +1,11 @@
 ---- MODULE Sets_IntervalCardinality ----
 EXTENDS Sets_IntervalCardinalityDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM IntervalCardinality ==  

--- a/benchmark/proof-from-scratch/Data/Sets_IsBijectionInverse.tla
+++ b/benchmark/proof-from-scratch/Data/Sets_IsBijectionInverse.tla
@@ -1,5 +1,11 @@
 ---- MODULE Sets_IsBijectionInverse ----
 EXTENDS Sets_IsBijectionInverseDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM IsBijectionInverse ==

--- a/benchmark/proof-from-scratch/Data/Sets_IsBijectionTransitive.tla
+++ b/benchmark/proof-from-scratch/Data/Sets_IsBijectionTransitive.tla
@@ -1,5 +1,11 @@
 ---- MODULE Sets_IsBijectionTransitive ----
 EXTENDS Sets_IsBijectionTransitiveDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM IsBijectionTransitive ==

--- a/benchmark/proof-from-scratch/Data/Sets_PigeonHole.tla
+++ b/benchmark/proof-from-scratch/Data/Sets_PigeonHole.tla
@@ -1,5 +1,11 @@
 ---- MODULE Sets_PigeonHole ----
 EXTENDS Sets_PigeonHoleDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM PigeonHole ==

--- a/benchmark/proof-from-scratch/EWD840/EWD840_TerminationDetection.tla
+++ b/benchmark/proof-from-scratch/EWD840/EWD840_TerminationDetection.tla
@@ -1,5 +1,11 @@
 ---- MODULE EWD840_TerminationDetection ----
 EXTENDS EWD840_TerminationDetectionDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []TerminationDetection

--- a/benchmark/proof-from-scratch/Euclid/EuclidEx_PartialCorrectness.tla
+++ b/benchmark/proof-from-scratch/Euclid/EuclidEx_PartialCorrectness.tla
@@ -1,5 +1,11 @@
 ---- MODULE EuclidEx_PartialCorrectness ----
 EXTENDS EuclidEx_PartialCorrectnessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []PartialCorrectness

--- a/benchmark/proof-from-scratch/Euclid/Euclid_Correctness.tla
+++ b/benchmark/proof-from-scratch/Euclid/Euclid_Correctness.tla
@@ -1,5 +1,11 @@
 ---- MODULE Euclid_Correctness ----
 EXTENDS Euclid_CorrectnessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Correctness == Spec => []ResultCorrect

--- a/benchmark/proof-from-scratch/Euclid/GCD_GCD1.tla
+++ b/benchmark/proof-from-scratch/Euclid/GCD_GCD1.tla
@@ -1,5 +1,11 @@
 ---- MODULE GCD_GCD1 ----
 EXTENDS GCD_GCD1Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM GCD1 == \A m \in Nat \ {0} : GCD(m, m) = m

--- a/benchmark/proof-from-scratch/Euclid/GCD_GCD2.tla
+++ b/benchmark/proof-from-scratch/Euclid/GCD_GCD2.tla
@@ -1,5 +1,11 @@
 ---- MODULE GCD_GCD2 ----
 EXTENDS GCD_GCD2Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM GCD2 == \A m, n \in Nat \ {0} : GCD(m, n) = GCD(n, m)

--- a/benchmark/proof-from-scratch/Euclid/GCD_GCD3.tla
+++ b/benchmark/proof-from-scratch/Euclid/GCD_GCD3.tla
@@ -1,5 +1,11 @@
 ---- MODULE GCD_GCD3 ----
 EXTENDS GCD_GCD3Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM GCD3 == \A m, n \in Nat \ {0} : 

--- a/benchmark/proof-from-scratch/OpenAddressing/OpenAddressing_CompleteAsSafety.tla
+++ b/benchmark/proof-from-scratch/OpenAddressing/OpenAddressing_CompleteAsSafety.tla
@@ -1,5 +1,11 @@
 ---- MODULE OpenAddressing_CompleteAsSafety ----
 EXTENDS OpenAddressing_CompleteAsSafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []CompleteAsSafety

--- a/benchmark/proof-from-scratch/OpenAddressing/OpenAddressing_Consistent.tla
+++ b/benchmark/proof-from-scratch/OpenAddressing/OpenAddressing_Consistent.tla
@@ -1,5 +1,11 @@
 ---- MODULE OpenAddressing_Consistent ----
 EXTENDS OpenAddressing_ConsistentDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Consistent

--- a/benchmark/proof-from-scratch/OpenAddressing/OpenAddressing_Contains.tla
+++ b/benchmark/proof-from-scratch/OpenAddressing/OpenAddressing_Contains.tla
@@ -1,5 +1,11 @@
 ---- MODULE OpenAddressing_Contains ----
 EXTENDS OpenAddressing_ContainsDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Contains

--- a/benchmark/proof-from-scratch/OpenAddressing/OpenAddressing_Duplicates.tla
+++ b/benchmark/proof-from-scratch/OpenAddressing/OpenAddressing_Duplicates.tla
@@ -1,5 +1,11 @@
 ---- MODULE OpenAddressing_Duplicates ----
 EXTENDS OpenAddressing_DuplicatesDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Duplicates

--- a/benchmark/proof-from-scratch/OpenAddressing/OpenAddressing_Sorted.tla
+++ b/benchmark/proof-from-scratch/OpenAddressing/OpenAddressing_Sorted.tla
@@ -1,5 +1,11 @@
 ---- MODULE OpenAddressing_Sorted ----
 EXTENDS OpenAddressing_SortedDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Sorted

--- a/benchmark/proof-from-scratch/Paxos/Consensus_Inv.tla
+++ b/benchmark/proof-from-scratch/Paxos/Consensus_Inv.tla
@@ -1,5 +1,11 @@
 ---- MODULE Consensus_Inv ----
 EXTENDS Consensus_InvDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Inv

--- a/benchmark/proof-from-scratch/Paxos/PaxosHistVar_Consistent.tla
+++ b/benchmark/proof-from-scratch/Paxos/PaxosHistVar_Consistent.tla
@@ -1,5 +1,11 @@
 ---- MODULE PaxosHistVar_Consistent ----
 EXTENDS PaxosHistVar_ConsistentDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Consistent == Spec => []Consistency

--- a/benchmark/proof-from-scratch/Paxos/PaxosHistVar_Invariant.tla
+++ b/benchmark/proof-from-scratch/Paxos/PaxosHistVar_Invariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE PaxosHistVar_Invariant ----
 EXTENDS PaxosHistVar_InvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Invariant == Spec => []Inv

--- a/benchmark/proof-from-scratch/Paxos/Paxos_Consistent.tla
+++ b/benchmark/proof-from-scratch/Paxos/Paxos_Consistent.tla
@@ -1,5 +1,11 @@
 ---- MODULE Paxos_Consistent ----
 EXTENDS Paxos_ConsistentDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Consistent == Spec => []Consistency

--- a/benchmark/proof-from-scratch/Paxos/Paxos_Invariant.tla
+++ b/benchmark/proof-from-scratch/Paxos/Paxos_Invariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE Paxos_Invariant ----
 EXTENDS Paxos_InvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Invariant == Spec => []Inv

--- a/benchmark/proof-from-scratch/Paxos/Paxos_Refinement.tla
+++ b/benchmark/proof-from-scratch/Paxos/Paxos_Refinement.tla
@@ -1,5 +1,11 @@
 ---- MODULE Paxos_Refinement ----
 EXTENDS Paxos_RefinementDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Refinement == Spec => C!Spec

--- a/benchmark/proof-from-scratch/Peterson/Peterson_Liveness.tla
+++ b/benchmark/proof-from-scratch/Peterson/Peterson_Liveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE Peterson_Liveness ----
 EXTENDS Peterson_LivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM FairSpec => Liveness

--- a/benchmark/proof-from-scratch/Peterson/Peterson_MutualExclusion.tla
+++ b/benchmark/proof-from-scratch/Peterson/Peterson_MutualExclusion.tla
@@ -1,5 +1,11 @@
 ---- MODULE Peterson_MutualExclusion ----
 EXTENDS Peterson_MutualExclusionDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []MutualExclusion

--- a/benchmark/proof-from-scratch/Record/Record_SV_Spec.tla
+++ b/benchmark/proof-from-scratch/Record/Record_SV_Spec.tla
@@ -1,5 +1,11 @@
 ---- MODULE Record_SV_Spec ----
 EXTENDS Record_SV_SpecDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => SV!Spec

--- a/benchmark/proof-from-scratch/SimpleMutex/SimpleMutex_Safety.tla
+++ b/benchmark/proof-from-scratch/SimpleMutex/SimpleMutex_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE SimpleMutex_Safety ----
 EXTENDS SimpleMutex_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Safety == Spec => []MutualExclusion

--- a/benchmark/proof-from-scratch/SimpleMutex/SimpleMutex_line140.tla
+++ b/benchmark/proof-from-scratch/SimpleMutex/SimpleMutex_line140.tla
@@ -1,5 +1,11 @@
 ---- MODULE SimpleMutex_line140 ----
 EXTENDS SimpleMutex_line140Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM

--- a/benchmark/proof-from-scratch/SumAndMax/SumAndMax_Correctness.tla
+++ b/benchmark/proof-from-scratch/SumAndMax/SumAndMax_Correctness.tla
@@ -1,5 +1,11 @@
 ---- MODULE SumAndMax_Correctness ----
 EXTENDS SumAndMax_CorrectnessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Correctness

--- a/benchmark/proof-from-scratch/ZooKeeper/Zab_Agreement.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper/Zab_Agreement.tla
@@ -1,5 +1,11 @@
 ---- MODULE Zab_Agreement ----
 EXTENDS Zab_AgreementDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Agreement

--- a/benchmark/proof-from-scratch/ZooKeeper/Zab_GlobalPrimaryOrder.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper/Zab_GlobalPrimaryOrder.tla
@@ -1,5 +1,11 @@
 ---- MODULE Zab_GlobalPrimaryOrder ----
 EXTENDS Zab_GlobalPrimaryOrderDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []GlobalPrimaryOrder

--- a/benchmark/proof-from-scratch/ZooKeeper/Zab_Integrity.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper/Zab_Integrity.tla
@@ -1,5 +1,11 @@
 ---- MODULE Zab_Integrity ----
 EXTENDS Zab_IntegrityDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Integrity

--- a/benchmark/proof-from-scratch/ZooKeeper/Zab_Leadership1.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper/Zab_Leadership1.tla
@@ -1,5 +1,11 @@
 ---- MODULE Zab_Leadership1 ----
 EXTENDS Zab_Leadership1Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Leadership1

--- a/benchmark/proof-from-scratch/ZooKeeper/Zab_Leadership2.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper/Zab_Leadership2.tla
@@ -1,5 +1,11 @@
 ---- MODULE Zab_Leadership2 ----
 EXTENDS Zab_Leadership2Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Leadership2

--- a/benchmark/proof-from-scratch/ZooKeeper/Zab_LocalPrimaryOrder.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper/Zab_LocalPrimaryOrder.tla
@@ -1,5 +1,11 @@
 ---- MODULE Zab_LocalPrimaryOrder ----
 EXTENDS Zab_LocalPrimaryOrderDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []LocalPrimaryOrder

--- a/benchmark/proof-from-scratch/ZooKeeper/Zab_PrefixConsistency.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper/Zab_PrefixConsistency.tla
@@ -1,5 +1,11 @@
 ---- MODULE Zab_PrefixConsistency ----
 EXTENDS Zab_PrefixConsistencyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []PrefixConsistency

--- a/benchmark/proof-from-scratch/ZooKeeper/Zab_PrimaryIntegrity.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper/Zab_PrimaryIntegrity.tla
@@ -1,5 +1,11 @@
 ---- MODULE Zab_PrimaryIntegrity ----
 EXTENDS Zab_PrimaryIntegrityDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []PrimaryIntegrity

--- a/benchmark/proof-from-scratch/ZooKeeper/Zab_TotalOrder.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper/Zab_TotalOrder.tla
@@ -1,5 +1,11 @@
 ---- MODULE Zab_TotalOrder ----
 EXTENDS Zab_TotalOrderDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []TotalOrder

--- a/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_Agreement.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_Agreement.tla
@@ -1,5 +1,11 @@
 ---- MODULE ZkV3_7_0_Agreement ----
 EXTENDS ZkV3_7_0_AgreementDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Agreement

--- a/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_GlobalPrimaryOrder.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_GlobalPrimaryOrder.tla
@@ -1,5 +1,11 @@
 ---- MODULE ZkV3_7_0_GlobalPrimaryOrder ----
 EXTENDS ZkV3_7_0_GlobalPrimaryOrderDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []GlobalPrimaryOrder

--- a/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_Integrity.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_Integrity.tla
@@ -1,5 +1,11 @@
 ---- MODULE ZkV3_7_0_Integrity ----
 EXTENDS ZkV3_7_0_IntegrityDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Integrity

--- a/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_Leadership1.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_Leadership1.tla
@@ -1,5 +1,11 @@
 ---- MODULE ZkV3_7_0_Leadership1 ----
 EXTENDS ZkV3_7_0_Leadership1Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Leadership1

--- a/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_Leadership2.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_Leadership2.tla
@@ -1,5 +1,11 @@
 ---- MODULE ZkV3_7_0_Leadership2 ----
 EXTENDS ZkV3_7_0_Leadership2Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Leadership2

--- a/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_LocalPrimaryOrder.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_LocalPrimaryOrder.tla
@@ -1,5 +1,11 @@
 ---- MODULE ZkV3_7_0_LocalPrimaryOrder ----
 EXTENDS ZkV3_7_0_LocalPrimaryOrderDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []LocalPrimaryOrder

--- a/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_PrefixConsistency.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_PrefixConsistency.tla
@@ -1,5 +1,11 @@
 ---- MODULE ZkV3_7_0_PrefixConsistency ----
 EXTENDS ZkV3_7_0_PrefixConsistencyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []PrefixConsistency

--- a/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_PrimaryIntegrity.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_PrimaryIntegrity.tla
@@ -1,5 +1,11 @@
 ---- MODULE ZkV3_7_0_PrimaryIntegrity ----
 EXTENDS ZkV3_7_0_PrimaryIntegrityDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []PrimaryIntegrity

--- a/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_TotalOrder.tla
+++ b/benchmark/proof-from-scratch/ZooKeeper_LowLevel/ZkV3_7_0_TotalOrder.tla
@@ -1,5 +1,11 @@
 ---- MODULE ZkV3_7_0_TotalOrder ----
 EXTENDS ZkV3_7_0_TotalOrderDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []TotalOrder

--- a/benchmark/proof-from-scratch/etcd_raft/etcd_raft_CommittedIsDurable.tla
+++ b/benchmark/proof-from-scratch/etcd_raft/etcd_raft_CommittedIsDurable.tla
@@ -1,5 +1,11 @@
 ---- MODULE etcd_raft_CommittedIsDurable ----
 EXTENDS etcd_raft_CommittedIsDurableDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM CommittedIsDurable == Spec => []CommittedIsDurableInv

--- a/benchmark/proof-from-scratch/etcd_raft/etcd_raft_ElectionSafety.tla
+++ b/benchmark/proof-from-scratch/etcd_raft/etcd_raft_ElectionSafety.tla
@@ -1,5 +1,11 @@
 ---- MODULE etcd_raft_ElectionSafety ----
 EXTENDS etcd_raft_ElectionSafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM ElectionSafety == Spec => []ElectionSafetyInv

--- a/benchmark/proof-from-scratch/etcd_raft/etcd_raft_LeaderCompleteness.tla
+++ b/benchmark/proof-from-scratch/etcd_raft/etcd_raft_LeaderCompleteness.tla
@@ -1,5 +1,11 @@
 ---- MODULE etcd_raft_LeaderCompleteness ----
 EXTENDS etcd_raft_LeaderCompletenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM LeaderCompleteness == Spec => []LeaderCompletenessInv

--- a/benchmark/proof-from-scratch/etcd_raft/etcd_raft_LogInv.tla
+++ b/benchmark/proof-from-scratch/etcd_raft/etcd_raft_LogInv.tla
@@ -1,5 +1,11 @@
 ---- MODULE etcd_raft_LogInv ----
 EXTENDS etcd_raft_LogInvDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []LogInv

--- a/benchmark/proof-from-scratch/etcd_raft/etcd_raft_LogMatching.tla
+++ b/benchmark/proof-from-scratch/etcd_raft/etcd_raft_LogMatching.tla
@@ -1,5 +1,11 @@
 ---- MODULE etcd_raft_LogMatching ----
 EXTENDS etcd_raft_LogMatchingDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM LogMatching == Spec => []LogMatchingInv

--- a/benchmark/proof-from-scratch/etcd_raft/etcd_raft_MoreThanOneLeader.tla
+++ b/benchmark/proof-from-scratch/etcd_raft/etcd_raft_MoreThanOneLeader.tla
@@ -1,5 +1,11 @@
 ---- MODULE etcd_raft_MoreThanOneLeader ----
 EXTENDS etcd_raft_MoreThanOneLeaderDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM MoreThanOneLeader == Spec => []MoreThanOneLeaderInv

--- a/benchmark/proof-from-scratch/etcd_raft/etcd_raft_MoreUpToDate.tla
+++ b/benchmark/proof-from-scratch/etcd_raft/etcd_raft_MoreUpToDate.tla
@@ -1,5 +1,11 @@
 ---- MODULE etcd_raft_MoreUpToDate ----
 EXTENDS etcd_raft_MoreUpToDateDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM MoreUpToDate == Spec => []MoreUpToDateCorrectInv

--- a/benchmark/proof-from-scratch/etcd_raft/etcd_raft_QuorumLog.tla
+++ b/benchmark/proof-from-scratch/etcd_raft/etcd_raft_QuorumLog.tla
@@ -1,5 +1,11 @@
 ---- MODULE etcd_raft_QuorumLog ----
 EXTENDS etcd_raft_QuorumLogDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM QuorumLog == Spec => []QuorumLogInv

--- a/benchmark/proof-from-scratch/ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocol_Liveness.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocol_Liveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_alternating_bit_protocol_Liveness ----
 EXTENDS ivy_examples_alternating_bit_protocol_LivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Liveness == Spec => DataDelivery

--- a/benchmark/proof-from-scratch/ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocol_Safety.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_alternating_bit_protocol/ivy_examples_alternating_bit_protocol_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_alternating_bit_protocol_Safety ----
 EXTENDS ivy_examples_alternating_bit_protocol_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Safety == SafetySpec => []ReceiverValuesFromSender

--- a/benchmark/proof-from-scratch/ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_CorrectnessLiveness.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_CorrectnessLiveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_hybrid_reliable_broadcast_cisa_CorrectnessLiveness ----
 EXTENDS ivy_examples_hybrid_reliable_broadcast_cisa_CorrectnessLivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM CorrectnessLiveness == Spec => Correctness

--- a/benchmark/proof-from-scratch/ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_RelayLiveness.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_RelayLiveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_hybrid_reliable_broadcast_cisa_RelayLiveness ----
 EXTENDS ivy_examples_hybrid_reliable_broadcast_cisa_RelayLivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM RelayLiveness == Spec => Relay

--- a/benchmark/proof-from-scratch/ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_Safety.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_hybrid_reliable_broadcast_cisa/ivy_examples_hybrid_reliable_broadcast_cisa_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_hybrid_reliable_broadcast_cisa_Safety ----
 EXTENDS ivy_examples_hybrid_reliable_broadcast_cisa_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Safety == SafetySpec => []Unforgeability

--- a/benchmark/proof-from-scratch/ivy_examples_split_queue_2_new/ivy_examples_split_queue_2_new_Liveness.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_split_queue_2_new/ivy_examples_split_queue_2_new_Liveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_split_queue_2_new_Liveness ----
 EXTENDS ivy_examples_split_queue_2_new_LivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Liveness == Spec => WorkCompletion

--- a/benchmark/proof-from-scratch/ivy_examples_ticket/ivy_examples_ticket_Liveness.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_ticket/ivy_examples_ticket_Liveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_ticket_Liveness ----
 EXTENDS ivy_examples_ticket_LivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Liveness == Spec => NonStarvation

--- a/benchmark/proof-from-scratch/ivy_examples_ticket/ivy_examples_ticket_Safety.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_ticket/ivy_examples_ticket_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_ticket_Safety ----
 EXTENDS ivy_examples_ticket_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Safety == SafetySpec => []MutualExclusion

--- a/benchmark/proof-from-scratch/ivy_examples_ticket_nested/ivy_examples_ticket_nested_Liveness.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_ticket_nested/ivy_examples_ticket_nested_Liveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_ticket_nested_Liveness ----
 EXTENDS ivy_examples_ticket_nested_LivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Liveness == Spec => NonStarvation

--- a/benchmark/proof-from-scratch/ivy_examples_ticket_nested/ivy_examples_ticket_nested_Safety.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_ticket_nested/ivy_examples_ticket_nested_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_ticket_nested_Safety ----
 EXTENDS ivy_examples_ticket_nested_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Safety == SafetySpec => []MutualExclusion

--- a/benchmark/proof-from-scratch/ivy_examples_tlb/ivy_examples_tlb_Liveness.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_tlb/ivy_examples_tlb_Liveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_tlb_Liveness ----
 EXTENDS ivy_examples_tlb_LivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Liveness == Spec => NonStarvation

--- a/benchmark/proof-from-scratch/ivy_examples_tlb/ivy_examples_tlb_Safety.tla
+++ b/benchmark/proof-from-scratch/ivy_examples_tlb/ivy_examples_tlb_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE ivy_examples_tlb_Safety ----
 EXTENDS ivy_examples_tlb_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Safety == SafetySpec => []NoError

--- a/benchmark/proof-from-scratch/tlaplus_examples_Bakery-Boulangerie/Bakery_MutualExclusion.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_Bakery-Boulangerie/Bakery_MutualExclusion.tla
@@ -1,5 +1,11 @@
 ---- MODULE Bakery_MutualExclusion ----
 EXTENDS Bakery_MutualExclusionDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []MutualExclusion

--- a/benchmark/proof-from-scratch/tlaplus_examples_Bakery-Boulangerie/Bakery_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_Bakery-Boulangerie/Bakery_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE Bakery_TypeCorrect ----
 EXTENDS Bakery_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_Bakery-Boulangerie/Boulanger_MutualExclusion.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_Bakery-Boulangerie/Boulanger_MutualExclusion.tla
@@ -1,5 +1,11 @@
 ---- MODULE Boulanger_MutualExclusion ----
 EXTENDS Boulanger_MutualExclusionDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []MutualExclusion

--- a/benchmark/proof-from-scratch/tlaplus_examples_Bakery-Boulangerie/Boulanger_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_Bakery-Boulangerie/Boulanger_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE Boulanger_TypeCorrect ----
 EXTENDS Boulanger_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs_BQS_Spec.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_BlockingQueue/BlockingQueueFair_proofs_BQS_Spec.tla
@@ -1,5 +1,11 @@
 ---- MODULE BlockingQueueFair_proofs_BQS_Spec ----
 EXTENDS BlockingQueueFair_proofs_BQS_SpecDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => BQS!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_DeadlockFreedom.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_DeadlockFreedom.tla
@@ -1,5 +1,11 @@
 ---- MODULE BlockingQueueSplit_proofs_DeadlockFreedom ----
 EXTENDS BlockingQueueSplit_proofs_DeadlockFreedomDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM DeadlockFreedom == Spec => []A!Invariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_IInvRefines.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_IInvRefines.tla
@@ -1,5 +1,11 @@
 ---- MODULE BlockingQueueSplit_proofs_IInvRefines ----
 EXTENDS BlockingQueueSplit_proofs_IInvRefinesDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM IInvRefines == ASSUME IInv PROVE A!IInv

--- a/benchmark/proof-from-scratch/tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_Implements.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_BlockingQueue/BlockingQueueSplit_proofs_Implements.tla
@@ -1,5 +1,11 @@
 ---- MODULE BlockingQueueSplit_proofs_Implements ----
 EXTENDS BlockingQueueSplit_proofs_ImplementsDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Implements == Spec => A!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_BlockingQueue/BlockingQueue_proofs_DeadlockFreedom.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_BlockingQueue/BlockingQueue_proofs_DeadlockFreedom.tla
@@ -1,5 +1,11 @@
 ---- MODULE BlockingQueue_proofs_DeadlockFreedom ----
 EXTENDS BlockingQueue_proofs_DeadlockFreedomDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM DeadlockFreedom == Spec => []Invariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_AtMostOneCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE CigaretteSmokers_proof_AtMostOneCorrect ----
 EXTENDS CigaretteSmokers_proof_AtMostOneCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM AtMostOneCorrect == Spec => []AtMostOne

--- a/benchmark/proof-from-scratch/tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_CigaretteSmokers/CigaretteSmokers_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE CigaretteSmokers_proof_TypeCorrect ----
 EXTENDS CigaretteSmokers_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_CoffeeCan/CoffeeCan_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_CoffeeCan/CoffeeCan_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE CoffeeCan_proof_TypeCorrect ----
 EXTENDS CoffeeCan_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_DieHard/DieHard_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_DieHard/DieHard_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE DieHard_proof_TypeCorrect ----
 EXTENDS DieHard_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_FiniteMonotonic/CRDT_proof_Convergence.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FiniteMonotonic/CRDT_proof_Convergence.tla
@@ -1,5 +1,11 @@
 ---- MODULE CRDT_proof_Convergence ----
 EXTENDS CRDT_proof_ConvergenceDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM FairSpec => Convergence

--- a/benchmark/proof-from-scratch/tlaplus_examples_FiniteMonotonic/CRDT_proof_Monotonicity.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FiniteMonotonic/CRDT_proof_Monotonicity.tla
@@ -1,5 +1,11 @@
 ---- MODULE CRDT_proof_Monotonicity ----
 EXTENDS CRDT_proof_MonotonicityDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => Monotonicity

--- a/benchmark/proof-from-scratch/tlaplus_examples_FiniteMonotonic/CRDT_proof_OGLiveness.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FiniteMonotonic/CRDT_proof_OGLiveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE CRDT_proof_OGLiveness ----
 EXTENDS CRDT_proof_OGLivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM OGLiveness == OGSpec => <>(\A n, o \in Node : counter[n] = counter[o])

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_CacheDataCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_CacheDataCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_CacheDataCorrect ----
 EXTENDS FlashWithMutex_CacheDataCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM CacheDataCorrect == Spec => []CacheDataProp

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_CacheStateCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_CacheStateCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_CacheStateCorrect ----
 EXTENDS FlashWithMutex_CacheStateCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM CacheStateCorrect == Spec => []CacheStateProp

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_DirProgressCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_DirProgressCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_DirProgressCorrect ----
 EXTENDS FlashWithMutex_DirProgressCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM DirProgressCorrect == FairSpec => DirProgress

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_InvProgressCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_InvProgressCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_InvProgressCorrect ----
 EXTENDS FlashWithMutex_InvProgressCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM InvProgressCorrect == FairSpec => InvProgress

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_1_Correct.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_1_Correct.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_Lemma_1_Correct ----
 EXTENDS FlashWithMutex_Lemma_1_CorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Lemma_1_Correct == Spec => []Lemma_1

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_2_Correct.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_2_Correct.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_Lemma_2_Correct ----
 EXTENDS FlashWithMutex_Lemma_2_CorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Lemma_2_Correct == Spec => []Lemma_2

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_3_Correct.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_3_Correct.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_Lemma_3_Correct ----
 EXTENDS FlashWithMutex_Lemma_3_CorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Lemma_3_Correct == Spec => []Lemma_3

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_4_Correct.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_4_Correct.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_Lemma_4_Correct ----
 EXTENDS FlashWithMutex_Lemma_4_CorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Lemma_4_Correct == Spec => []Lemma_4

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_5_Correct.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_Lemma_5_Correct.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_Lemma_5_Correct ----
 EXTENDS FlashWithMutex_Lemma_5_CorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Lemma_5_Correct == Spec => []Lemma_5

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_MemDataCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_MemDataCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_MemDataCorrect ----
 EXTENDS FlashWithMutex_MemDataCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM MemDataCorrect == Spec => []MemDataProp

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_NakcProgressCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_NakcProgressCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_NakcProgressCorrect ----
 EXTENDS FlashWithMutex_NakcProgressCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM NakcProgressCorrect == FairSpec => NakcProgress

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_ReqProgressCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_ReqProgressCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_ReqProgressCorrect ----
 EXTENDS FlashWithMutex_ReqProgressCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM ReqProgressCorrect == FairSpec => ReqProgress

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_RpProgressCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_RpProgressCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_RpProgressCorrect ----
 EXTENDS FlashWithMutex_RpProgressCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM RpProgressCorrect == FairSpec => RpProgress

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_ShWbProgressCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_ShWbProgressCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_ShWbProgressCorrect ----
 EXTENDS FlashWithMutex_ShWbProgressCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM ShWbProgressCorrect == FairSpec => ShWbProgress

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_TypeCorrect ----
 EXTENDS FlashWithMutex_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_UniProgressCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_UniProgressCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_UniProgressCorrect ----
 EXTENDS FlashWithMutex_UniProgressCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM UniProgressCorrect == FairSpec => UniProgress

--- a/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_WbProgressCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_FlashProtocol/FlashWithMutex_WbProgressCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FlashWithMutex_WbProgressCorrect ----
 EXTENDS FlashWithMutex_WbProgressCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM WbProgressCorrect == FairSpec => WbProgress

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanControlBenchmarks_Coherence.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanControlBenchmarks_Coherence.tla
@@ -1,5 +1,11 @@
 ---- MODULE GermanControlBenchmarks_Coherence ----
 EXTENDS GermanControlBenchmarks_CoherenceDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Coherence

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_DataProp.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_DataProp.tla
@@ -1,5 +1,11 @@
 ---- MODULE GermanData_DataProp ----
 EXTENDS GermanData_DataPropDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []DataProp

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_DirectoryAccurate.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_DirectoryAccurate.tla
@@ -1,5 +1,11 @@
 ---- MODULE GermanData_DirectoryAccurate ----
 EXTENDS GermanData_DirectoryAccurateDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []DirectoryAccurate

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_ExclusiveIsolation.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_ExclusiveIsolation.tla
@@ -1,5 +1,11 @@
 ---- MODULE GermanData_ExclusiveIsolation ----
 EXTENDS GermanData_ExclusiveIsolationDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []ExclusiveIsolation

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_Refinement.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_Refinement.tla
@@ -1,5 +1,11 @@
 ---- MODULE GermanData_Refinement ----
 EXTENDS GermanData_RefinementDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => Refinement

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_TransactionConsistency.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_TransactionConsistency.tla
@@ -1,5 +1,11 @@
 ---- MODULE GermanData_TransactionConsistency ----
 EXTENDS GermanData_TransactionConsistencyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []TransactionConsistency

--- a/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_WritebackCarriesLatest.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_GermanProtocol/GermanData_WritebackCarriesLatest.tla
@@ -1,5 +1,11 @@
 ---- MODULE GermanData_WritebackCarriesLatest ----
 EXTENDS GermanData_WritebackCarriesLatestDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []WritebackCarriesLatest

--- a/benchmark/proof-from-scratch/tlaplus_examples_KeyValueStore/KeyValueStore_proof_TypeAndLifecycle.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_KeyValueStore/KeyValueStore_proof_TypeAndLifecycle.tla
@@ -1,5 +1,11 @@
 ---- MODULE KeyValueStore_proof_TypeAndLifecycle ----
 EXTENDS KeyValueStore_proof_TypeAndLifecycleDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeAndLifecycle == Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/AddTwo_Even.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/AddTwo_Even.tla
@@ -1,5 +1,11 @@
 ---- MODULE AddTwo_Even ----
 EXTENDS AddTwo_EvenDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Even

--- a/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/AddTwo_TypeInvariant.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/AddTwo_TypeInvariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE AddTwo_TypeInvariant ----
 EXTENDS AddTwo_TypeInvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeInvariant == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/FindHighest_DoneIndexValueThm.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/FindHighest_DoneIndexValueThm.tla
@@ -1,5 +1,11 @@
 ---- MODULE FindHighest_DoneIndexValueThm ----
 EXTENDS FindHighest_DoneIndexValueThmDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM DoneIndexValueThm == Spec => []DoneIndexValue

--- a/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/FindHighest_InductiveInvariantHolds.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/FindHighest_InductiveInvariantHolds.tla
@@ -1,5 +1,11 @@
 ---- MODULE FindHighest_InductiveInvariantHolds ----
 EXTENDS FindHighest_InductiveInvariantHoldsDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM InductiveInvariantHolds == Spec => []InductiveInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/FindHighest_IsCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/FindHighest_IsCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE FindHighest_IsCorrect ----
 EXTENDS FindHighest_IsCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM IsCorrect == Spec => []Correctness

--- a/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/FindHighest_TypeInvariantHolds.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_LearnProofs/FindHighest_TypeInvariantHolds.tla
@@ -1,5 +1,11 @@
 ---- MODULE FindHighest_TypeInvariantHolds ----
 EXTENDS FindHighest_TypeInvariantHoldsDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeInvariantHolds == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_LoopInvariance/BinarySearch_resultCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_LoopInvariance/BinarySearch_resultCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE BinarySearch_resultCorrect ----
 EXTENDS BinarySearch_resultCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []resultCorrect

--- a/benchmark/proof-from-scratch/tlaplus_examples_LoopInvariance/Quicksort_PCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_LoopInvariance/Quicksort_PCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE Quicksort_PCorrect ----
 EXTENDS Quicksort_PCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []PCorrect

--- a/benchmark/proof-from-scratch/tlaplus_examples_LoopInvariance/SumSequence_PCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_LoopInvariance/SumSequence_PCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE SumSequence_PCorrect ----
 EXTENDS SumSequence_PCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []PCorrect

--- a/benchmark/proof-from-scratch/tlaplus_examples_MisraReachability/ParReachProofs_line18.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_MisraReachability/ParReachProofs_line18.tla
@@ -1,5 +1,11 @@
 ---- MODULE ParReachProofs_line18 ----
 EXTENDS ParReachProofs_line18Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => R!Init /\ [][R!Next]_R!vars

--- a/benchmark/proof-from-scratch/tlaplus_examples_MisraReachability/ReachableProofs_line197.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_MisraReachability/ReachableProofs_line197.tla
@@ -1,5 +1,11 @@
 ---- MODULE ReachableProofs_line197 ----
 EXTENDS ReachableProofs_line197Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []((pc = "Done") => (marked = Reachable))

--- a/benchmark/proof-from-scratch/tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_MissionariesAndCannibals/MissionariesAndCannibals_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE MissionariesAndCannibals_proof_TypeCorrect ----
 EXTENDS MissionariesAndCannibals_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_MultiCarElevator/Elevator_proof_SafetyCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_MultiCarElevator/Elevator_proof_SafetyCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE Elevator_proof_SafetyCorrect ----
 EXTENDS Elevator_proof_SafetyCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM SafetyCorrect == Spec => []SafetyInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_MultiCarElevator/Elevator_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_MultiCarElevator/Elevator_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE Elevator_proof_TypeCorrect ----
 EXTENDS Elevator_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_Paxos/Consensus_Invariance.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_Paxos/Consensus_Invariance.tla
@@ -1,5 +1,11 @@
 ---- MODULE Consensus_Invariance ----
 EXTENDS Consensus_InvarianceDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Invariance == Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_Paxos/Consensus_LivenessTheorem.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_Paxos/Consensus_LivenessTheorem.tla
@@ -1,5 +1,11 @@
 ---- MODULE Consensus_LivenessTheorem ----
 EXTENDS Consensus_LivenessTheoremDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM LivenessTheorem == LiveSpec =>  Success

--- a/benchmark/proof-from-scratch/tlaplus_examples_Paxos/Voting_C_Spec.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_Paxos/Voting_C_Spec.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_C_Spec ----
 EXTENDS Voting_C_SpecDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => C!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_Paxos/Voting_QuorumNonEmpty.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_Paxos/Voting_QuorumNonEmpty.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_QuorumNonEmpty ----
 EXTENDS Voting_QuorumNonEmptyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM QuorumNonEmpty == \A Q \in Quorum : Q # {}

--- a/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Consensus_Invariance.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Consensus_Invariance.tla
@@ -1,5 +1,11 @@
 ---- MODULE Consensus_Invariance ----
 EXTENDS Consensus_InvarianceDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Invariance  ==  Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Voting_Implementation.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Voting_Implementation.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_Implementation ----
 EXTENDS Voting_ImplementationDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM  Implementation  ==  Spec  => C!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Voting_Invariance.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Voting_Invariance.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_Invariance ----
 EXTENDS Voting_InvarianceDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM  Invariance  ==  Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_AllSafeAtZero_T.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_AllSafeAtZero_T.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_proof_AllSafeAtZero_T ----
 EXTENDS Voting_proof_AllSafeAtZero_TDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM AllSafeAtZero_T == \A v \in Value : SafeAt(0, v)

--- a/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ChoosableThm_T.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ChoosableThm_T.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_proof_ChoosableThm_T ----
 EXTENDS Voting_proof_ChoosableThm_TDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM ChoosableThm_T ==

--- a/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ShowsSafety_T.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_PaxosHowToWinATuringAward/Voting_proof_ShowsSafety_T.tla
@@ -1,5 +1,11 @@
 ---- MODULE Voting_proof_ShowsSafety_T ----
 EXTENDS Voting_proof_ShowsSafety_TDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM ShowsSafety_T ==

--- a/benchmark/proof-from-scratch/tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ReadersWriters/ReadersWriters_proof_SafetyCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE ReadersWriters_proof_SafetyCorrect ----
 EXTENDS ReadersWriters_proof_SafetyCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM SafetyCorrect == Spec => []Safety

--- a/benchmark/proof-from-scratch/tlaplus_examples_ReadersWriters/ReadersWriters_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ReadersWriters/ReadersWriters_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE ReadersWriters_proof_TypeCorrect ----
 EXTENDS ReadersWriters_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_SpanningTree/SpanTree_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_SpanningTree/SpanTree_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE SpanTree_proof_TypeCorrect ----
 EXTENDS SpanTree_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_AsynchronousInterface/AsynchInterface_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE AsynchInterface_proof_TypeCorrect ----
 EXTENDS AsynchInterface_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_AsynchronousInterface/Channel_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE Channel_proof_TypeCorrect ----
 EXTENDS Channel_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_CachingMemory/InternalMemory_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE InternalMemory_proof_TypeCorrect ----
 EXTENDS InternalMemory_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == ISpec => []TypeInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_Composing/HourClock_proof_HCini_Invariant.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_Composing/HourClock_proof_HCini_Invariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE HourClock_proof_HCini_Invariant ----
 EXTENDS HourClock_proof_HCini_InvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM HCini_Invariant == HC => []HCini

--- a/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_FIFO/InnerFIFO_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE InnerFIFO_proof_TypeCorrect ----
 EXTENDS InnerFIFO_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_SpecifyingSystems_TLC/AlternatingBit_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE AlternatingBit_proof_TypeCorrect ----
 EXTENDS AlternatingBit_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == ABSpec => []ABTypeInv

--- a/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness.tla
@@ -1,5 +1,11 @@
 ---- MODULE SimpleRegular_Correctness ----
 EXTENDS SimpleRegular_CorrectnessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Correctness == Spec => []PCorrect

--- a/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness2.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/SimpleRegular_Correctness2.tla
@@ -1,5 +1,11 @@
 ---- MODULE SimpleRegular_Correctness2 ----
 EXTENDS SimpleRegular_Correctness2Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Correctness2 == Spec => []PCorrect

--- a/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_InvInvariant.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_InvInvariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE SimpleRegular_proof_InvInvariant ----
 EXTENDS SimpleRegular_proof_InvInvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM InvInvariant == Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/SimpleRegular_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE SimpleRegular_proof_TypeCorrect ----
 EXTENDS SimpleRegular_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/Simple_Correctness.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/Simple_Correctness.tla
@@ -1,5 +1,11 @@
 ---- MODULE Simple_Correctness ----
 EXTENDS Simple_CorrectnessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Correctness == Spec => []PCorrect

--- a/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/Simple_Correctness2.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/Simple_Correctness2.tla
@@ -1,5 +1,11 @@
 ---- MODULE Simple_Correctness2 ----
 EXTENDS Simple_Correctness2Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Correctness2 == Spec => []PCorrect

--- a/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/Simple_proof_InvInvariant.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/Simple_proof_InvInvariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE Simple_proof_InvInvariant ----
 EXTENDS Simple_proof_InvInvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM InvInvariant == Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/Simple_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TeachingConcurrency/Simple_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE Simple_proof_TypeCorrect ----
 EXTENDS Simple_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_TencentPaxos/TPaxosWithProof_Consistent.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TencentPaxos/TPaxosWithProof_Consistent.tla
@@ -1,5 +1,11 @@
 ---- MODULE TPaxosWithProof_Consistent ----
 EXTENDS TPaxosWithProof_ConsistentDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Consistent == Spec => []Consistency

--- a/benchmark/proof-from-scratch/tlaplus_examples_TencentPaxos/TPaxosWithProof_Invariant.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TencentPaxos/TPaxosWithProof_Invariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE TPaxosWithProof_Invariant ----
 EXTENDS TPaxosWithProof_InvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Invariant == Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_Termination/Termination_proof_Safety.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_Termination/Termination_proof_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE Termination_proof_Safety ----
 EXTENDS Termination_proof_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => []Safety

--- a/benchmark/proof-from-scratch/tlaplus_examples_TwoPhase/TwoPhase_Implementation.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TwoPhase/TwoPhase_Implementation.tla
@@ -1,5 +1,11 @@
 ---- MODULE TwoPhase_Implementation ----
 EXTENDS TwoPhase_ImplementationDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Implementation == Spec => A!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_TwoPhase/TwoPhase_proof_line17.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_TwoPhase/TwoPhase_proof_line17.tla
@@ -1,5 +1,11 @@
 ---- MODULE TwoPhase_proof_line17 ----
 EXTENDS TwoPhase_proof_line17Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => A!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_allocator/AllocatorImplementation_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_allocator/AllocatorImplementation_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE AllocatorImplementation_proof_TypeCorrect ----
 EXTENDS AllocatorImplementation_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Specification => []TypeInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_allocator/SchedulingAllocator_proof_Mutex.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_allocator/SchedulingAllocator_proof_Mutex.tla
@@ -1,5 +1,11 @@
 ---- MODULE SchedulingAllocator_proof_Mutex ----
 EXTENDS SchedulingAllocator_proof_MutexDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Mutex == Allocator => []ResourceMutex

--- a/benchmark/proof-from-scratch/tlaplus_examples_allocator/SchedulingAllocator_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_allocator/SchedulingAllocator_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE SchedulingAllocator_proof_TypeCorrect ----
 EXTENDS SchedulingAllocator_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Allocator => []TypeInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_allocator/SimpleAllocator_proof_Mutex.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_allocator/SimpleAllocator_proof_Mutex.tla
@@ -1,5 +1,11 @@
 ---- MODULE SimpleAllocator_proof_Mutex ----
 EXTENDS SimpleAllocator_proof_MutexDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Mutex == SimpleAllocator => []ResourceMutex

--- a/benchmark/proof-from-scratch/tlaplus_examples_allocator/SimpleAllocator_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_allocator/SimpleAllocator_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE SimpleAllocator_proof_TypeCorrect ----
 EXTENDS SimpleAllocator_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == SimpleAllocator => []TypeInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_barriers/Barriers_B_Spec.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_barriers/Barriers_B_Spec.tla
@@ -1,5 +1,11 @@
 ---- MODULE Barriers_B_Spec ----
 EXTENDS Barriers_B_SpecDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => B!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_barriers/Barriers_BarrierExclusion.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_barriers/Barriers_BarrierExclusion.tla
@@ -1,5 +1,11 @@
 ---- MODULE Barriers_BarrierExclusion ----
 EXTENDS Barriers_BarrierExclusionDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM BarrierExclusion ==

--- a/benchmark/proof-from-scratch/tlaplus_examples_barriers/Barriers_BarrierExclusion2.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_barriers/Barriers_BarrierExclusion2.tla
@@ -1,5 +1,11 @@
 ---- MODULE Barriers_BarrierExclusion2 ----
 EXTENDS Barriers_BarrierExclusion2Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM BarrierExclusion2 ==

--- a/benchmark/proof-from-scratch/tlaplus_examples_barriers/Barriers_FlushInvariant.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_barriers/Barriers_FlushInvariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE Barriers_FlushInvariant ----
 EXTENDS Barriers_FlushInvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM FlushInvariant == Spec => []FlushInv

--- a/benchmark/proof-from-scratch/tlaplus_examples_barriers/Barriers_Invariant.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_barriers/Barriers_Invariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE Barriers_Invariant ----
 EXTENDS Barriers_InvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Invariant == Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast.tla
@@ -1,5 +1,11 @@
 ---- MODULE bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast ----
 EXTENDS bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcastDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM FCConstraints_TypeOK_IndInv_Unforg_NoBcast ==  

--- a/benchmark/proof-from-scratch/tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast_TLC.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast_TLC.tla
@@ -1,5 +1,11 @@
 ---- MODULE bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast_TLC ----
 EXTENDS bcastByz_FCConstraints_TypeOK_IndInv_Unforg_NoBcast_TLCDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM FCConstraints_TypeOK_IndInv_Unforg_NoBcast_TLC ==  

--- a/benchmark/proof-from-scratch/tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_Init.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_Init.tla
@@ -1,5 +1,11 @@
 ---- MODULE bcastByz_FCConstraints_TypeOK_Init ----
 EXTENDS bcastByz_FCConstraints_TypeOK_InitDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM FCConstraints_TypeOK_Init == 

--- a/benchmark/proof-from-scratch/tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_SpecNoBcast.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_bcastByz/bcastByz_FCConstraints_TypeOK_SpecNoBcast.tla
@@ -1,5 +1,11 @@
 ---- MODULE bcastByz_FCConstraints_TypeOK_SpecNoBcast ----
 EXTENDS bcastByz_FCConstraints_TypeOK_SpecNoBcastDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM FCConstraints_TypeOK_SpecNoBcast == SpecNoBcast => [](FCConstraints /\ TypeOK)

--- a/benchmark/proof-from-scratch/tlaplus_examples_bcastByz/bcastByz_Unforg_Step4.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_bcastByz/bcastByz_Unforg_Step4.tla
@@ -1,5 +1,11 @@
 ---- MODULE bcastByz_Unforg_Step4 ----
 EXTENDS bcastByz_Unforg_Step4Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Unforg_Step4 == SpecNoBcast => []Unforg

--- a/benchmark/proof-from-scratch/tlaplus_examples_byihive/VoucherLifeCycle_proof_Spec_TypeOK_Consistent.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byihive/VoucherLifeCycle_proof_Spec_TypeOK_Consistent.tla
@@ -1,5 +1,11 @@
 ---- MODULE VoucherLifeCycle_proof_Spec_TypeOK_Consistent ----
 EXTENDS VoucherLifeCycle_proof_Spec_TypeOK_ConsistentDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec_TypeOK_Consistent == VSpec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/BPConProof_Invariance.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/BPConProof_Invariance.tla
@@ -1,5 +1,11 @@
 ---- MODULE BPConProof_Invariance ----
 EXTENDS BPConProof_InvarianceDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Invariance == Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/BPConProof_P_Spec.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/BPConProof_P_Spec.tla
@@ -1,5 +1,11 @@
 ---- MODULE BPConProof_P_Spec ----
 EXTENDS BPConProof_P_SpecDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => P!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/BPConProof_line2170.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/BPConProof_line2170.tla
@@ -1,5 +1,11 @@
 ---- MODULE BPConProof_line2170 ----
 EXTENDS BPConProof_line2170Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM chosen \subseteq P!chosen

--- a/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/Consensus_Invariance.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/Consensus_Invariance.tla
@@ -1,5 +1,11 @@
 ---- MODULE Consensus_Invariance ----
 EXTENDS Consensus_InvarianceDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Invariance == Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/Consensus_LiveSpecEquals.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/Consensus_LiveSpecEquals.tla
@@ -1,5 +1,11 @@
 ---- MODULE Consensus_LiveSpecEquals ----
 EXTENDS Consensus_LiveSpecEqualsDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM LiveSpecEquals ==

--- a/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/Consensus_Liveness.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/Consensus_Liveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE Consensus_Liveness ----
 EXTENDS Consensus_LivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Liveness == LiveSpec => Success

--- a/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/PConProof_NextDef.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/PConProof_NextDef.tla
@@ -1,5 +1,11 @@
 ---- MODULE PConProof_NextDef ----
 EXTENDS PConProof_NextDefDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM NextDef == (Next <=> TLANext)

--- a/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/VoteProof_Liveness.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/VoteProof_Liveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE VoteProof_Liveness ----
 EXTENDS VoteProof_LivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Liveness == LiveSpec => C!LiveSpec

--- a/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/VoteProof_VInv1.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/VoteProof_VInv1.tla
@@ -1,5 +1,11 @@
 ---- MODULE VoteProof_VInv1 ----
 EXTENDS VoteProof_VInv1Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM VInv3 => VInv1

--- a/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/VoteProof_VT2.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/VoteProof_VT2.tla
@@ -1,5 +1,11 @@
 ---- MODULE VoteProof_VT2 ----
 EXTENDS VoteProof_VT2Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM VT2 == Spec => []VInv

--- a/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/VoteProof_VT3.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_byzpaxos/VoteProof_VT3.tla
@@ -1,5 +1,11 @@
 ---- MODULE VoteProof_VT3 ----
 EXTENDS VoteProof_VT3Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM VT3 == Spec => C!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd687a/EWD687a_proof_Safety.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd687a/EWD687a_proof_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE EWD687a_proof_Safety ----
 EXTENDS EWD687a_proof_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Safety == Spec => []DT1Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd687a/EWD687a_proof_Thm_CountersConsistent.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd687a/EWD687a_proof_Thm_CountersConsistent.tla
@@ -1,5 +1,11 @@
 ---- MODULE EWD687a_proof_Thm_CountersConsistent ----
 EXTENDS EWD687a_proof_Thm_CountersConsistentDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Thm_CountersConsistent == Spec => CountersConsistent

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd687a/EWD687a_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd687a/EWD687a_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE EWD687a_proof_TypeCorrect ----
 EXTENDS EWD687a_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd840/EWD840_proof_Safety.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd840/EWD840_proof_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE EWD840_proof_Safety ----
 EXTENDS EWD840_proof_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Safety == Spec => []TerminationDetection

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd840/EWD840_proof_TD_Spec.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd840/EWD840_proof_TD_Spec.tla
@@ -1,5 +1,11 @@
 ---- MODULE EWD840_proof_TD_Spec ----
 EXTENDS EWD840_proof_TD_SpecDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Spec => TD!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd840/SyncTerminationDetection_proof_CorrectDetection.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd840/SyncTerminationDetection_proof_CorrectDetection.tla
@@ -1,5 +1,11 @@
 ---- MODULE SyncTerminationDetection_proof_CorrectDetection ----
 EXTENDS SyncTerminationDetection_proof_CorrectDetectionDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM CorrectDetection == Spec => TDCorrect

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd840/SyncTerminationDetection_proof_Live.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd840/SyncTerminationDetection_proof_Live.tla
@@ -1,5 +1,11 @@
 ---- MODULE SyncTerminationDetection_proof_Live ----
 EXTENDS SyncTerminationDetection_proof_LiveDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Live == Spec => Liveness

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd840/SyncTerminationDetection_proof_Quiescent.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd840/SyncTerminationDetection_proof_Quiescent.tla
@@ -1,5 +1,11 @@
 ---- MODULE SyncTerminationDetection_proof_Quiescent ----
 EXTENDS SyncTerminationDetection_proof_QuiescentDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Quiescent == Spec => Quiescence

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Liveness.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Liveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE AsyncTerminationDetection_proof_Liveness ----
 EXTENDS AsyncTerminationDetection_proof_LivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Liveness == Spec => Live

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Safety.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE AsyncTerminationDetection_proof_Safety ----
 EXTENDS AsyncTerminationDetection_proof_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Safety == Init /\ [][Next]_vars => []Safe

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Stability.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd998/AsyncTerminationDetection_proof_Stability.tla
@@ -1,5 +1,11 @@
 ---- MODULE AsyncTerminationDetection_proof_Stability ----
 EXTENDS AsyncTerminationDetection_proof_StabilityDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Stability == Init /\ [][Next]_vars => Quiescence

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd998/EWD998PCal_proof_InitRefinement.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd998/EWD998PCal_proof_InitRefinement.tla
@@ -1,5 +1,11 @@
 ---- MODULE EWD998PCal_proof_InitRefinement ----
 EXTENDS EWD998PCal_proof_InitRefinementDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM InitRefinement == Init => EWD998!Init

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd998/EWD998PCal_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd998/EWD998PCal_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE EWD998PCal_proof_TypeCorrect ----
 EXTENDS EWD998PCal_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []PCalTypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd998/EWD998_proof_Refinement.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd998/EWD998_proof_Refinement.tla
@@ -1,5 +1,11 @@
 ---- MODULE EWD998_proof_Refinement ----
 EXTENDS EWD998_proof_RefinementDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Refinement == Spec => TD!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_ewd998/EWD998_proof_TerminationDetectionInv.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_ewd998/EWD998_proof_TerminationDetectionInv.tla
@@ -1,5 +1,11 @@
 ---- MODULE EWD998_proof_TerminationDetectionInv ----
 EXTENDS EWD998_proof_TerminationDetectionInvDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TerminationDetectionInv == Spec => []TerminationDetection

--- a/benchmark/proof-from-scratch/tlaplus_examples_glowingRaccoon/clean_proof_Preservation.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_glowingRaccoon/clean_proof_Preservation.tla
@@ -1,5 +1,11 @@
 ---- MODULE clean_proof_Preservation ----
 EXTENDS clean_proof_PreservationDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Preservation == Spec => []preservationInvariant

--- a/benchmark/proof-from-scratch/tlaplus_examples_glowingRaccoon/clean_proof_PrimerPositive.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_glowingRaccoon/clean_proof_PrimerPositive.tla
@@ -1,5 +1,11 @@
 ---- MODULE clean_proof_PrimerPositive ----
 EXTENDS clean_proof_PrimerPositiveDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM PrimerPositive == Spec => []primerPositive

--- a/benchmark/proof-from-scratch/tlaplus_examples_glowingRaccoon/stages_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_glowingRaccoon/stages_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE stages_proof_TypeCorrect ----
 EXTENDS stages_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedNetworkInv.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_lamport_mutex/LamportMutex_proofs_BoundedNetworkInv.tla
@@ -1,5 +1,11 @@
 ---- MODULE LamportMutex_proofs_BoundedNetworkInv ----
 EXTENDS LamportMutex_proofs_BoundedNetworkInvDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM BoundedNetworkInv == Spec => []BoundedNetwork

--- a/benchmark/proof-from-scratch/tlaplus_examples_lamport_mutex/LamportMutex_proofs_Safety.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_lamport_mutex/LamportMutex_proofs_Safety.tla
@@ -1,5 +1,11 @@
 ---- MODULE LamportMutex_proofs_Safety ----
 EXTENDS LamportMutex_proofs_SafetyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Safety == Spec => []Mutex

--- a/benchmark/proof-from-scratch/tlaplus_examples_locks_auxiliary_vars/LockHS_P_Spec.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_locks_auxiliary_vars/LockHS_P_Spec.tla
@@ -1,5 +1,11 @@
 ---- MODULE LockHS_P_Spec ----
 EXTENDS LockHS_P_SpecDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM SpecHS => P!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_locks_auxiliary_vars/LockHS_line31.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_locks_auxiliary_vars/LockHS_line31.tla
@@ -1,5 +1,11 @@
 ---- MODULE LockHS_line31 ----
 EXTENDS LockHS_line31Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM StutterConstantCondition(1..2, 1, LAMBDA j : j-1)

--- a/benchmark/proof-from-scratch/tlaplus_examples_locks_auxiliary_vars/Lock_MutualExclusion.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_locks_auxiliary_vars/Lock_MutualExclusion.tla
@@ -1,5 +1,11 @@
 ---- MODULE Lock_MutualExclusion ----
 EXTENDS Lock_MutualExclusionDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM MutualExclusion == Spec => []LockInv

--- a/benchmark/proof-from-scratch/tlaplus_examples_locks_auxiliary_vars/Peterson_IndInvariant.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_locks_auxiliary_vars/Peterson_IndInvariant.tla
@@ -1,5 +1,11 @@
 ---- MODULE Peterson_IndInvariant ----
 EXTENDS Peterson_IndInvariantDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM IndInvariant == Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_locks_auxiliary_vars/Peterson_Refinement.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_locks_auxiliary_vars/Peterson_Refinement.tla
@@ -1,5 +1,11 @@
 ---- MODULE Peterson_Refinement ----
 EXTENDS Peterson_RefinementDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Refinement == Spec => L!Spec

--- a/benchmark/proof-from-scratch/tlaplus_examples_spanning/spanning_proof_SntMsgInv.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_spanning/spanning_proof_SntMsgInv.tla
@@ -1,5 +1,11 @@
 ---- MODULE spanning_proof_SntMsgInv ----
 EXTENDS spanning_proof_SntMsgInvDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM SntMsgInv == Spec => []SntMsg

--- a/benchmark/proof-from-scratch/tlaplus_examples_sums_even/sums_even_T1.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_sums_even/sums_even_T1.tla
@@ -1,5 +1,11 @@
 ---- MODULE sums_even_T1 ----
 EXTENDS sums_even_T1Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM T1 == \A x \in Nat: Even(x+x)

--- a/benchmark/proof-from-scratch/tlaplus_examples_sums_even/sums_even_line10.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_sums_even/sums_even_line10.tla
@@ -1,5 +1,11 @@
 ---- MODULE sums_even_line10 ----
 EXTENDS sums_even_line10Defs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM \A x \in Nat : Even(x+x)

--- a/benchmark/proof-from-scratch/tlaplus_examples_tcp/tcp_proof_InvInit.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_tcp/tcp_proof_InvInit.tla
@@ -1,5 +1,11 @@
 ---- MODULE tcp_proof_InvInit ----
 EXTENDS tcp_proof_InvInitDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM InvInit == Init => Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_tcp/tcp_proof_SpecImpliesInv.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_tcp/tcp_proof_SpecImpliesInv.tla
@@ -1,5 +1,11 @@
 ---- MODULE tcp_proof_SpecImpliesInv ----
 EXTENDS tcp_proof_SpecImpliesInvDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM SpecImpliesInv == Spec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_tcp/tcp_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_tcp/tcp_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE tcp_proof_TypeCorrect ----
 EXTENDS tcp_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == Spec => []TypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_Init.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_transaction_commit/PaxosCommit_proof_TypeOK_Init.tla
@@ -1,5 +1,11 @@
 ---- MODULE PaxosCommit_proof_TypeOK_Init ----
 EXTENDS PaxosCommit_proof_TypeOK_InitDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeOK_Init == PCSpec => PCTypeOK

--- a/benchmark/proof-from-scratch/tlaplus_examples_transaction_commit/TCommit_proof_TCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_transaction_commit/TCommit_proof_TCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE TCommit_proof_TCorrect ----
 EXTENDS TCommit_proof_TCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TCorrect == TCSpec => []Inv

--- a/benchmark/proof-from-scratch/tlaplus_examples_transaction_commit/TwoPhase_proof_Consistency.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_transaction_commit/TwoPhase_proof_Consistency.tla
@@ -1,5 +1,11 @@
 ---- MODULE TwoPhase_proof_Consistency ----
 EXTENDS TwoPhase_proof_ConsistencyDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Consistency == TPSpec => []TC!TCConsistent

--- a/benchmark/proof-from-scratch/tlaplus_examples_transaction_commit/TwoPhase_proof_TypeCorrect.tla
+++ b/benchmark/proof-from-scratch/tlaplus_examples_transaction_commit/TwoPhase_proof_TypeCorrect.tla
@@ -1,5 +1,11 @@
 ---- MODULE TwoPhase_proof_TypeCorrect ----
 EXTENDS TwoPhase_proof_TypeCorrectDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM TypeCorrect == TPSpec => []TPTypeOK

--- a/benchmark/proof-from-scratch/two_thread_mutex/two_thread_mutex_Liveness.tla
+++ b/benchmark/proof-from-scratch/two_thread_mutex/two_thread_mutex_Liveness.tla
@@ -1,5 +1,11 @@
 ---- MODULE two_thread_mutex_Liveness ----
 EXTENDS two_thread_mutex_LivenessDefs
+
+LOCAL INSTANCE TLAPS
+LOCAL NatInductionLib == INSTANCE NaturalsInduction
+LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems
+LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction
+
 \* BEGIN AGENT HELPERS
 \* END AGENT HELPERS
 THEOREM Liveness == Spec => Termination

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -231,8 +231,6 @@ Proof-completion targets contain one `AGENT PROOF` marker pair. Only its interio
 
 Proof-from-scratch targets contain separate `AGENT HELPERS` and `AGENT PROOF` marker pairs. The helper region accepts fresh operator definitions, module-level `USE DEF` / `HIDE DEF`, and fully proved named lemmas or theorems. Constants, variables, assumptions, instances, nested modules, shadowed names, and module-level declarations in the proof region are rejected.
 
-The fixed task scaffold exposes a common trusted proof interface to every proof-from-scratch task: `NatInductionLib!NatInduction`, `FiniteSetTheoremsLib!FS_Induction`, and `WellFoundedInductionLib!WFInduction`, plus unqualified TLAPS backend pragmas. These declarations sit outside the editable regions, so agents can use the libraries without changing imports or weakening the canonical task boundary.
-
 For both marked layouts, all fixed bytes must match the canonical target. Extra newlines at EOF are ignored; other newline-only differences fail but are not labeled cheating. Proof completion temporarily retains compatibility with the checked-in legacy unmarked dataset: when its manifest is absent and no task contains proof markers, the evaluator emits one warning and uses the previous heuristic discovery and preamble check. A malformed manifest or any marked proof-completion task without a manifest fails closed. Proof from scratch has no fallback.
 
 The runner captures canonical inputs before starting the agent and grades from a separate copy. Docker makes context read-only; native `--no-container` uses advisory `0444` permissions and is not a host-security boundary. Canonical validation failures are infrastructure errors.
@@ -346,7 +344,7 @@ Regenerate benchmark files from annotated source specs.
 
 ```bash
 uv run tlaps-bench generate
-uv run tlaps-bench generate --mode proof-from-scratch --layered
+uv run tlaps-bench generate --mode proof-from-scratch
 ```
 
 Proof-completion generation emits the layered suite described in [Layered-task trust boundary](#layered-task-trust-boundary): one read-only `<base>Model.tla` per source, one read-only `<task>Scaffold.tla` per target, an editable `<task>.tla` holding the fixed theorem statement and the marked proof region, and a `manifest.json` naming every task's source specification and exact context. Use `--legacy` only for the old generators.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -231,6 +231,8 @@ Proof-completion targets contain one `AGENT PROOF` marker pair. Only its interio
 
 Proof-from-scratch targets contain separate `AGENT HELPERS` and `AGENT PROOF` marker pairs. The helper region accepts fresh operator definitions, module-level `USE DEF` / `HIDE DEF`, and fully proved named lemmas or theorems. Constants, variables, assumptions, instances, nested modules, shadowed names, and module-level declarations in the proof region are rejected.
 
+The fixed task scaffold exposes a common trusted proof interface to every proof-from-scratch task: `NatInductionLib!NatInduction`, `FiniteSetTheoremsLib!FS_Induction`, and `WellFoundedInductionLib!WFInduction`, plus unqualified TLAPS backend pragmas. These declarations sit outside the editable regions, so agents can use the libraries without changing imports or weakening the canonical task boundary.
+
 For both marked layouts, all fixed bytes must match the canonical target. Extra newlines at EOF are ignored; other newline-only differences fail but are not labeled cheating. Proof completion temporarily retains compatibility with the checked-in legacy unmarked dataset: when its manifest is absent and no task contains proof markers, the evaluator emits one warning and uses the previous heuristic discovery and preamble check. A malformed manifest or any marked proof-completion task without a manifest fails closed. Proof from scratch has no fallback.
 
 The runner captures canonical inputs before starting the agent and grades from a separate copy. Docker makes context read-only; native `--no-container` uses advisory `0444` permissions and is not a host-security boundary. Canonical validation failures are infrastructure errors.
@@ -344,7 +346,7 @@ Regenerate benchmark files from annotated source specs.
 
 ```bash
 uv run tlaps-bench generate
-uv run tlaps-bench generate --mode proof-from-scratch
+uv run tlaps-bench generate --mode proof-from-scratch --layered
 ```
 
 Proof-completion generation emits the layered suite described in [Layered-task trust boundary](#layered-task-trust-boundary): one read-only `<base>Model.tla` per source, one read-only `<task>Scaffold.tla` per target, an editable `<task>.tla` holding the fixed theorem statement and the marked proof region, and a `manifest.json` naming every task's source specification and exact context. Use `--legacy` only for the old generators.

--- a/src/dataset/proof_from_scratch/design.md
+++ b/src/dataset/proof_from_scratch/design.md
@@ -55,6 +55,12 @@ For each **top-level theorem** `T` in source file `X.tla`, generate one benchmar
 | All comments (`\*` line, `(* … *)` block) — in the benchmark and in copied deps | Delete |
 | Dependency modules referenced by EXTENDS, or by a *kept* INSTANCE (e.g. `Consensus.tla`) | Copy alongside, all proofs stripped to `PROOF OMITTED`, all comments stripped |
 
+Layered task modules additionally receive one immutable, generator-owned proof
+context before the editable regions. It exposes TLAPS backend pragmas and named
+instances of `NaturalsInduction`, `FiniteSetTheorems`, and
+`WellFoundedInduction`. This proof support is identical for every task and does
+not change the source-derived Model or Defs layers.
+
 ## Top-level theorem identification
 
 Candidates first — then the OR rule.

--- a/src/dataset/proof_from_scratch/generate.py
+++ b/src/dataset/proof_from_scratch/generate.py
@@ -95,6 +95,10 @@ the two must stay byte-compatible.
 
 Only spec-goal targets extend the shared model; a pure lemma target keeps a
 self-contained Defs layer with just the declarations it uses.
+
+Every task module also carries a fixed proof-library context before its
+editable regions.  This gives all agents the same trusted TLAPS interfaces
+without allowing submissions to change the task's import surface.
 """
 
 import argparse
@@ -891,6 +895,13 @@ END_AGENT_HELPERS = r"\* END AGENT HELPERS"
 BEGIN_AGENT_PROOF = r"\* BEGIN AGENT PROOF"
 END_AGENT_PROOF = r"\* END AGENT PROOF"
 
+PROOF_LIBRARY_CONTEXT = (
+    "LOCAL INSTANCE TLAPS\n"
+    "LOCAL NatInductionLib == INSTANCE NaturalsInduction\n"
+    "LOCAL FiniteSetTheoremsLib == INSTANCE FiniteSetTheorems\n"
+    "LOCAL WellFoundedInductionLib == INSTANCE WellFoundedInduction"
+)
+
 # `USE`/`HIDE` are prover hints from the original proof, not given semantics, so
 # they never belong in a read-only layer. Every occurrence in source/ is one line.
 _MODULE_DIRECTIVE = re.compile(r"(?m)^[ \t]*(USE|HIDE)\b[^\n]*\n?")
@@ -1045,14 +1056,18 @@ def build_defs(source_lines, dump, defs_set, defs_module_name, model_module, kee
 
 
 def build_task_module(task_module_name, defs_module, statement_text):
-    """The editable task file: EXTENDS the Defs layer, then the four marker
-    lines around an empty helper region and a `PROOF OBVIOUS` proof region, with
-    the canonical theorem statement fixed in between. Built from scratch (not by
-    editing source) so the marker structure the evaluator parses is exact."""
+    """Build a task with fixed proof libraries and two editable regions.
+
+    The task extends its Defs layer, exposes a small trusted proof interface,
+    then places the four marker lines around an empty helper region and a
+    ``PROOF OBVIOUS`` proof region.  The theorem statement remains fixed between
+    them.  Building from scratch keeps the evaluator's marker contract exact.
+    """
     stmt = statement_text.rstrip("\n")
     return (
         f"---- MODULE {task_module_name} ----\n"
-        f"EXTENDS {defs_module}\n"
+        f"EXTENDS {defs_module}\n\n"
+        f"{PROOF_LIBRARY_CONTEXT}\n\n"
         f"{BEGIN_AGENT_HELPERS}\n"
         f"{END_AGENT_HELPERS}\n"
         f"{stmt}\n"

--- a/src/evaluator/prompts/proof-from-scratch-one-shot.txt
+++ b/src/evaluator/prompts/proof-from-scratch-one-shot.txt
@@ -16,6 +16,10 @@ Only change text inside the target's two marked regions:
 
 Put fresh same-module operator definitions, module-level `USE DEF` / `HIDE DEF` directives, and fully proved named helper lemmas in the helper region. Put the target theorem's complete proof in the proof region.
 
+# Available proof libraries
+
+The fixed task scaffold provides `NatInductionLib!NatInduction`, `FiniteSetTheoremsLib!FS_Induction`, and `WellFoundedInductionLib!WFInduction`. TLAPS backend pragmas such as `SMTT`, `PTL`, and `ExpandENABLED` are available unqualified.
+
 # Response format
 
 Return the complete target module from its module header through `====`. Return only that module, optionally inside one `tla` Markdown code fence. Do not return a patch, proof fragment, explanation, or dependency module.

--- a/src/evaluator/prompts/proof-from-scratch.txt
+++ b/src/evaluator/prompts/proof-from-scratch.txt
@@ -18,7 +18,15 @@ Put fresh same-module operator definitions, module-level `USE DEF` / `HIDE DEF` 
 
 # Proving and iterating
 
-The TLAPS standard library is at `{tlapm_lib}`, and the Community Modules library is at `$COMMUNITY_LIB`. You may read and reference either library, but do not modify them. You may run:
+The TLAPS standard library is at `{tlapm_lib}`, and the Community Modules library is at `$COMMUNITY_LIB`. You may inspect both libraries, but cite only declarations already brought into scope by the task and its read-only context. Do not modify either library.
+
+Every task's fixed scaffold provides these standard proof interfaces:
+
+- `NatInductionLib!NatInduction`
+- `FiniteSetTheoremsLib!FS_Induction`
+- `WellFoundedInductionLib!WFInduction`
+
+TLAPS backend pragmas such as `SMTT`, `PTL`, and `ExpandENABLED` are available unqualified. You may run:
 
 ```sh
 {tlapm_path}/bin/tlapm -I {tlapm_lib} -I "$COMMUNITY_LIB" {benchmark_basename}

--- a/tests/dataset/test_etcd_raft.py
+++ b/tests/dataset/test_etcd_raft.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from tlacore.tlapm.locate import find_tlapm, find_tlapm_lib
+
 REPO = Path(__file__).resolve().parents[2]
 TASK_DIR = REPO / "benchmark" / "proof-from-scratch" / "etcd_raft"
 SOURCE = REPO / "source" / "etcd_raft" / "etcd_raft.tla"
@@ -49,13 +51,15 @@ def _run_tlc(
     invariant: str = "QuorumLogInv",
     module: str = "etcd_raft_QuorumLog",
 ) -> str:
-    if shutil.which("java") is None or not TLA2TOOLS.is_file() or not COMMUNITY.is_dir():
+    tlapm = find_tlapm()
+    tlapm_lib = find_tlapm_lib(tlapm) if tlapm else None
+    if shutil.which("java") is None or not TLA2TOOLS.is_file() or not COMMUNITY.is_dir() or not tlapm_lib:
         pytest.skip("TLC dependencies are not installed; run make setup")
 
     tmp_path.mkdir()
     config = tmp_path / "QuorumLog.cfg"
     config.write_text(CONFIG.format(init_server=init_server, server=server, nil=nil, invariant=invariant))
-    classpath = os.pathsep.join((str(TLA2TOOLS), str(COMMUNITY), str(TASK_DIR)))
+    classpath = os.pathsep.join((str(TLA2TOOLS), str(COMMUNITY), str(TASK_DIR), tlapm_lib))
     result = subprocess.run(
         [
             "java",

--- a/tests/dataset/test_layered_generator.py
+++ b/tests/dataset/test_layered_generator.py
@@ -23,6 +23,7 @@ from dataset.proof_from_scratch.generate import (
     BEGIN_AGENT_PROOF,
     END_AGENT_HELPERS,
     END_AGENT_PROOF,
+    PROOF_LIBRARY_CONTEXT,
     _defined_names,
     _plan_layered_targets,
     _strip_module_directives,
@@ -60,10 +61,12 @@ def test_task_module_ships_an_empty_helper_region_and_placeholder_proof():
     assert proof.strip() == "PROOF OBVIOUS"
 
 
-def test_task_module_imports_only_its_defs_layer():
+def test_task_module_adds_fixed_proof_library_context_before_editable_regions():
     text = build_task_module("Foo_Thm", "Foo_ThmDefs", "THEOREM TRUE")
-    assert "EXTENDS Foo_ThmDefs" in text
-    assert text.startswith("---- MODULE Foo_Thm ----")
+    assert text.startswith("---- MODULE Foo_Thm ----\nEXTENDS Foo_ThmDefs\n")
+    assert text.count("EXTENDS ") == 1
+    assert text.count(PROOF_LIBRARY_CONTEXT) == 1
+    assert text.index(PROOF_LIBRARY_CONTEXT) < text.index(BEGIN_AGENT_HELPERS)
     # The theorem is fixed scaffold, never inside an editable region.
     assert text.index("THEOREM TRUE") > text.index(END_AGENT_HELPERS)
     assert text.index("THEOREM TRUE") < text.index(BEGIN_AGENT_PROOF)
@@ -455,6 +458,16 @@ def test_shipped_layered_output_passes_read_only_integrity():
     generate.validate_layered_output(str(suite), manifest, audit)
 
     assert audit.getvalue() == ""
+
+
+def test_shipped_tasks_include_fixed_proof_library_context():
+    suite = Path(generate.BENCHMARK_DIR)
+    manifest = json.loads((suite / "manifest.json").read_text())
+
+    for task_key in manifest:
+        text = (suite / task_key).read_text()
+        assert text.count(PROOF_LIBRARY_CONTEXT) == 1, task_key
+        assert text.index(PROOF_LIBRARY_CONTEXT) < text.index(BEGIN_AGENT_HELPERS), task_key
 
 
 def test_multi_line_declaration_statement_is_deleted_as_one_unit():

--- a/tests/evaluator/test_oneshot_prompt.py
+++ b/tests/evaluator/test_oneshot_prompt.py
@@ -105,6 +105,9 @@ def test_proof_from_scratch_one_shot_prompt_enforces_marked_regions(tmp_path):
     assert "fully proved named helper lemmas" in prompt
     assert "Every helper `LEMMA` or `THEOREM` must be named and fully proved" in prompt
     assert "Do not add or change dependency modules, imports" in prompt
+    assert "NatInductionLib!NatInduction" in prompt
+    assert "FiniteSetTheoremsLib!FS_Induction" in prompt
+    assert "WellFoundedInductionLib!WFInduction" in prompt
     assert "Do not return a patch" in prompt
     assert "Keep editing" not in prompt
     assert "check_proof_bin" not in prompt
@@ -120,4 +123,7 @@ def test_proof_from_scratch_agentic_prompt_enforces_same_boundary(tmp_path):
     assert r"\* BEGIN AGENT PROOF" in prompt
     assert "Do not change the module header, imports, marker lines" in prompt
     assert "Every helper `LEMMA` or `THEOREM` must be named and fully proved" in prompt
+    assert "NatInductionLib!NatInduction" in prompt
+    assert "FiniteSetTheoremsLib!FS_Induction" in prompt
+    assert "WellFoundedInductionLib!WFInduction" in prompt
     assert "check_proof_bin Target_Goal.tla --mode proof-from-scratch" in prompt

--- a/tests/integration/test_proof_from_scratch_boundary.py
+++ b/tests/integration/test_proof_from_scratch_boundary.py
@@ -15,6 +15,7 @@ from common.proof_from_scratch_contract import (
     END_AGENT_HELPERS,
     END_AGENT_PROOF,
 )
+from dataset.proof_from_scratch.generate import PROOF_LIBRARY_CONTEXT
 
 REPO = Path(__file__).resolve().parents[2]
 CHECKER = REPO / "src" / "common" / "check_proof.py"
@@ -33,6 +34,9 @@ def _task(*, helper: str = "", proof: str = "PROOF OBVIOUS") -> str:
         (
             "---- MODULE Task ----",
             "EXTENDS Model",
+            "",
+            PROOF_LIBRARY_CONTEXT,
+            "",
             BEGIN_AGENT_HELPERS,
             helper,
             END_AGENT_HELPERS,
@@ -105,3 +109,22 @@ def test_real_checker_accepts_helpers_and_rejects_forbidden_declaration(tmp_path
     assert invalid.returncode == 1, invalid.stdout + invalid.stderr
     assert "HELPER_REGION_VIOLATION" in invalid.stdout
     assert "CHEAT-DETECTED: editable_regions_valid" in invalid.stdout
+
+
+def test_real_checker_resolves_fixed_proof_library_theorems(tmp_path):
+    result = _run_checker(
+        tmp_path,
+        _task(
+            helper=(
+                "LEMMA ProofLibrariesAvailable == TRUE\n"
+                "<1>1. USE NatInductionLib!NatInduction\n"
+                "<1>2. USE FiniteSetTheoremsLib!FS_Induction\n"
+                "<1>3. USE WellFoundedInductionLib!WFInduction\n"
+                "<1>4. QED OBVIOUS"
+            ),
+            proof="PROOF OBVIOUS",
+        ),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASS — target goal genuinely proved" in result.stdout


### PR DESCRIPTION
## What changed

In proof-from-scratch tasks, agents could not use standard induction theorems when the source spec did not import their libraries. Task imports are read-only, so agents could not add the missing libraries themselves.

- Add TLAPS and the natural-number, finite-set, and well-founded induction libraries to every generated task.
- Put the library declarations in the read-only part of the task, so agents can use them without changing imports.
- Regenerate all 245 tasks and update the prompts and tests with the available theorem names.

## Testing

- Regenerated and checked all 245 proof-from-scratch tasks.
- An end-to-end test confirms that agents can use `NatInduction`, `FS_Induction`, and `WFInduction`, while agent-added imports remain rejected.

Closes #126.
