### PR TITLE
Implement module-level proof-from-scratch evaluation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ CHECKER_SOURCES := \
 	src/common/__init__.py \
 	src/common/check_proof.py \
 	src/common/cheating_detection.py \
+	src/common/proof_from_scratch_grading.py \
+	src/common/proof_from_scratch_module.py \
 	src/common/proof_libraries.py \
 	src/common/task_contract.py \
 	src/common/tla_modules.py \

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -421,7 +421,7 @@ uv run tlaps-bench run --backend codex --model gpt-5.5 --output-dir results/proo
 
 The runner skips benchmarks already recorded as `SKIP` or as a genuine `PASS` in that directory (first-attempt or via a continuation round), and reruns the rest.
 
-When resuming a task-list run, pass the same `--task-list` again. The runner rejects a different list, a different mode, or an output directory whose prior results were not recorded with a task list. Proof-from-scratch runs also record `run-manifest.json` and reject resume when the canonical corpus, execution sources, pinned official proof-library digest, or content-locked verification toolchain changed.
+When resuming a task-list run, pass the same `--task-list` again. The runner rejects a different list, a different mode, or an output directory whose prior results were not recorded with a task list. Proof-from-scratch runs also record `run-manifest.json` and reject resume when the canonical corpus, execution sources, pinned official proof-library digest, content-locked verification toolchain, execution limits, or persistent-session policy changed. If the original run used `--session-dir` or the implicit session directory from `--keep-container`, resume with the same resolved session path.
 
 Inline infra retries are intentionally short: the default `--infra-retries 3` gives the original attempt plus three retries with brief backoff. If a longer provider or network outage leaves `INFRA_ERROR` / `QUOTA_EXHAUSTED` results, rerun later with the same `--output-dir --resume`; those non-genuine results are not skipped.
 
@@ -501,14 +501,14 @@ With `--keep-container` this happens automatically under `~/.tlaps-bench/session
 uv run tlaps-bench run --backend copilot --session-dir ./sessions --filter my_benchmark
 ```
 
-Each run writes its state to `<session-dir>/<backend>/<benchmark>/` (or `<...>/<container-name>/` under `--keep-container`, one dir per retained container). For `codex`/`codex_single_turn`/`claude_code`/`pi` the credential files are stored there too, so a single mount holds both auth and session. Because it is a real host path — not `/tmp` and not tied to the container's lifetime — the state survives container removal *and* reboot, and can be moved to another machine. A `.gitignore` (`*`) is written at the session root so this credential-bearing data can't be accidentally committed. `--session-dir` is ignored with `--no-container`.
+Each physical module writes its state to `<session-dir>/<backend>/<module-key>/`. The key includes the complete mode-relative module path, so modules with the same filename never share state. Retries, continuation rounds, `--keep-container`, and `--resume` all reuse that module's directory. For `codex`/`codex_single_turn`/`claude_code`/`pi` the credential files are stored there too, so a single mount holds both auth and session. Because it is a real host path — not `/tmp` and not tied to the container's lifetime — the state survives container removal and reboot. A `.gitignore` (`*`) is written at the session root so this credential-bearing data can't be accidentally committed. `--session-dir` is ignored with `--no-container`.
 
 ### Restoring a session into a container
 
 To resume or inspect a persisted session, mount it back into a fresh container:
 
 ```bash
-scripts/restore-session.sh --backend copilot ~/.tlaps-bench/sessions/copilot/<container-name>
+scripts/restore-session.sh --backend copilot ~/.tlaps-bench/sessions/copilot/<module-key>
 ```
 
 This starts an interactive `tlaps-bench-base` shell with the session mounted at the backend's session path (e.g. `/root/.copilot`), so you can read the transcript or run the agent CLI's own resume command (e.g. `copilot --resume`). The container is removed on exit; the host session directory is not. (Network egress is not firewalled in this debug shell, and no benchmark files are mounted — it is for inspecting/continuing the agent session, not for grading.)

--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -55,6 +55,8 @@ import argparse
 import bisect
 import contextlib
 import glob
+import json
+import math
 import os
 import re
 import shutil
@@ -62,6 +64,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import time
 from concurrent.futures import ThreadPoolExecutor
 
 from common.cheating_detection import (
@@ -76,6 +79,12 @@ from common.cheating_detection import (
     strip_comments,
 )
 from common.container import ContainerConfig, ContainerRunner, DockerUnavailableError, ensure_image
+from common.proof_from_scratch_grading import (
+    ModuleSubmissionError,
+    analyze_module_submission,
+    proof_unit_ids_from_markers,
+)
+from common.proof_from_scratch_module import compute_trusted_units
 from common.proof_libraries import (
     ProofLibraryError,
     load_frozen_catalog,
@@ -90,6 +99,7 @@ from common.task_contract import (
     parse_editable_regions,
     parse_proof_region,
 )
+from tlacore.model import Module
 from tlacore.sany.dump import SanyRun, SanyStatus, run_normalized
 
 try:
@@ -1074,6 +1084,354 @@ def parse_strict_status(tlapm_exit, tlapm_output):
     return complete, n_missing, obligation_failed
 
 
+MODULE_RESULT_PREFIX = "MODULE-RESULT: "
+
+
+def authoritative_module_unit_ids(filepath: str, benchmark_dir: str | None) -> tuple[str, ...] | None:
+    """Return identified proof units when the canonical target is a module task."""
+
+    authoritative = os.path.join(benchmark_dir, os.path.basename(filepath)) if benchmark_dir is not None else filepath
+    try:
+        with open(authoritative, encoding="utf-8", newline="") as stream:
+            source = stream.read()
+    except (OSError, UnicodeError):
+        return () if benchmark_dir is not None else None
+    if "\\* BEGIN AGENT PROOF " not in source:
+        return None
+    try:
+        return proof_unit_ids_from_markers(source)
+    except ModuleSubmissionError:
+        return ()
+
+
+def _module_context_issues(filepath: str, benchmark_dir: str) -> list[tuple[str, str]]:
+    """Compare every workspace TLA+ dependency with the frozen canonical copy."""
+
+    target_name = os.path.basename(filepath)
+    workspace = os.path.dirname(filepath)
+    canonical_paths = {
+        os.path.basename(path): path for path in glob.glob(os.path.join(benchmark_dir, "*.tla")) if os.path.isfile(path)
+    }
+    workspace_paths = {
+        os.path.basename(path): path
+        for path in glob.glob(os.path.join(workspace, "*.tla"))
+        if os.path.isfile(path) or os.path.islink(path)
+    }
+    issues: list[tuple[str, str]] = []
+    expected_context = set(canonical_paths) - {target_name}
+    actual_context = set(workspace_paths) - {target_name}
+    for missing in sorted(expected_context - actual_context):
+        issues.append(("CONTEXT_MISSING", f"canonical context file {missing!r} is missing from the submission"))
+    for extra in sorted(actual_context - expected_context):
+        issues.append(("CONTEXT_ADDED", f"undeclared TLA+ file {extra!r} was added to the submission"))
+    for name in sorted(expected_context & actual_context):
+        submitted = workspace_paths[name]
+        if os.path.islink(submitted):
+            issues.append(("CONTEXT_MODIFIED", f"context file {name!r} was replaced by a symlink"))
+            continue
+        try:
+            if os.path.samefile(submitted, canonical_paths[name]):
+                issues.append(("CONTEXT_MODIFIED", f"context file {name!r} aliases the canonical input"))
+                continue
+        except OSError as exc:
+            issues.append(("CONTEXT_MODIFIED", f"cannot compare context file {name!r}: {exc}"))
+            continue
+        try:
+            with open(canonical_paths[name], "rb") as expected_stream:
+                expected = expected_stream.read()
+            with open(submitted, "rb") as submitted_stream:
+                actual = submitted_stream.read()
+        except OSError as exc:
+            issues.append(("CONTEXT_MODIFIED", f"cannot compare context file {name!r}: {exc}"))
+            continue
+        if actual != expected:
+            issues.append(("CONTEXT_MODIFIED", f"context file {name!r} differs from the canonical input"))
+    return issues
+
+
+def _module_unit_result(
+    *,
+    unit,
+    tlapm_path: str,
+    tlapm_lib: str,
+    community_lib: str | None,
+    staged_file: str,
+    tmp_dir: str,
+    deadline: float | None,
+    index: int,
+) -> tuple[dict[str, object], str]:
+    base = {
+        "unit_id": unit.unit_id,
+        "kind": unit.kind,
+        "theorem_name": unit.theorem_name,
+        "line_start": unit.line_start,
+        "line_end": unit.line_end,
+        "dependencies": list(unit.dependencies),
+    }
+    if unit.admitted:
+        return (
+            {
+                **base,
+                "raw_verdict": "UNRESOLVED",
+                "tlapm_exit": None,
+                "missing_proofs": 1,
+                "obligation_failed": False,
+            },
+            "proof is omitted or missing",
+        )
+    if unit.line_start <= 0 or unit.line_end < unit.line_start:
+        return (
+            {
+                **base,
+                "raw_verdict": "ERROR",
+                "tlapm_exit": None,
+                "missing_proofs": None,
+                "obligation_failed": None,
+            },
+            "SANY did not provide a valid theorem location",
+        )
+
+    remaining = None if deadline is None else deadline - time.monotonic()
+    if remaining is not None and remaining <= 0:
+        return (
+            {
+                **base,
+                "raw_verdict": "TIMEOUT",
+                "tlapm_exit": None,
+                "missing_proofs": None,
+                "obligation_failed": None,
+            },
+            "module checker timeout exhausted before this proof unit",
+        )
+
+    command = [
+        tlapm_path,
+        "--strict",
+        "--toolbox",
+        str(unit.line_start),
+        str(unit.line_end),
+        "--threads",
+        "1",
+        "-I",
+        tlapm_lib,
+    ]
+    if community_lib:
+        command += ["-I", community_lib]
+    cache_dir = os.path.join(tmp_dir, "unit-cache", str(index))
+    os.makedirs(cache_dir, exist_ok=True)
+    command += ["--cache-dir", cache_dir, "--safefp", staged_file]
+    try:
+        stdout, stderr, returncode = run_killgroup(command, remaining, tmp_dir)
+    except subprocess.TimeoutExpired:
+        return (
+            {
+                **base,
+                "raw_verdict": "TIMEOUT",
+                "tlapm_exit": None,
+                "missing_proofs": None,
+                "obligation_failed": None,
+            },
+            "TLAPM timed out",
+        )
+    except Exception as exc:
+        return (
+            {
+                **base,
+                "raw_verdict": "ERROR",
+                "tlapm_exit": None,
+                "missing_proofs": None,
+                "obligation_failed": None,
+            },
+            f"TLAPM could not run: {exc}",
+        )
+
+    output = stdout + stderr
+    complete, missing, obligation_failed = parse_strict_status(returncode, output)
+    # This TLAPM invocation is scoped to exactly one submitted target/helper.
+    # Exit 11 therefore means that unit still contains an omitted or missing
+    # proof; admitted siblings outside the toolbox range do not affect it.
+    complete = complete and returncode == 0
+    return (
+        {
+            **base,
+            "raw_verdict": "PASS" if complete else "FAIL",
+            "tlapm_exit": returncode,
+            "missing_proofs": missing,
+            "obligation_failed": obligation_failed,
+        },
+        output,
+    )
+
+
+def run_module_task_check(
+    *,
+    filepath: str,
+    benchmark_dir: str,
+    expected_unit_ids: tuple[str, ...],
+    tlapm_path: str,
+    tlapm_lib: str,
+    timeout: int,
+    output_path: str,
+    import_violations: list,
+    emit,
+) -> int:
+    """Grade one complete submitted module and emit per-unit trust evidence."""
+
+    deadline = None if timeout <= 0 else time.monotonic() + timeout
+    canonical_path = os.path.join(benchmark_dir, os.path.basename(filepath))
+    try:
+        with open(canonical_path, encoding="utf-8", newline="") as stream:
+            canonical_source = stream.read()
+        with open(filepath, encoding="utf-8", newline="") as stream:
+            submitted_source = stream.read()
+    except (OSError, UnicodeError) as exc:
+        emit("SANY-STATUS: unavailable")
+        emit(f"ERROR: cannot read module task inputs: {exc}")
+        return 3
+
+    integrity_issues = _module_context_issues(filepath, benchmark_dir)
+    integrity_issues.extend((violation.code, violation.message) for violation in import_violations)
+    tmp_dir = tempfile.mkdtemp(prefix="tlaps_module_check_")
+    try:
+        try:
+            staged_file = stage_verification_files(
+                filepath,
+                tmp_dir,
+                benchmark_dir=benchmark_dir,
+                require_canonical=True,
+            )
+        except (OSError, ValueError) as exc:
+            emit("SANY-STATUS: unavailable")
+            emit(f"ERROR: cannot stage module task inputs: {exc}")
+            return 3
+
+        remaining = None if deadline is None else deadline - time.monotonic()
+        if remaining is not None and remaining <= 0:
+            emit("SANY-STATUS: unavailable")
+            emit("ERROR: module checker timeout exhausted before SANY validation")
+            return 3
+        sany_timeout = 180 if remaining is None else max(1, min(180, math.ceil(remaining)))
+        sany_run = run_normalized(staged_file, dep_dir=tmp_dir, timeout=sany_timeout)
+        try:
+            write_sany_log(sany_run, output_path)
+        except OSError as exc:
+            emit("SANY-STATUS: unavailable")
+            emit(f"ERROR: cannot write SANY log: {exc}")
+            return 3
+        emit(f"SANY-STATUS: {sany_run.status.value}")
+        if sany_run.status is SanyStatus.UNAVAILABLE:
+            emit(f"ERROR: SANY validation unavailable: {sany_run.detail[:300]}")
+            return 3
+        if sany_run.status is SanyStatus.INVALID:
+            report = {
+                "schema_version": 1,
+                "sany_status": "invalid",
+                "proof_unit_ids": list(expected_unit_ids),
+                "units": [],
+                "trusted_unit_ids": [],
+                "trusted_proof_unit_ids": [],
+                "complete": False,
+            }
+            emit(MODULE_RESULT_PREFIX + json.dumps(report, sort_keys=True, separators=(",", ":")))
+            emit(f"FAIL {SANY_INVALID_MARKER} — {sany_run.detail[:300]}")
+            return 1
+
+        assert sany_run.raw is not None
+        remaining = None if deadline is None else deadline - time.monotonic()
+        if remaining is not None and remaining <= 0:
+            emit("ERROR: module checker timeout exhausted before canonical SANY validation")
+            return 3
+        canonical_sany_timeout = 180 if remaining is None else max(1, min(180, math.ceil(remaining)))
+        canonical_sany_run = run_normalized(
+            canonical_path,
+            dep_dir=benchmark_dir,
+            timeout=canonical_sany_timeout,
+        )
+        if canonical_sany_run.status is not SanyStatus.VALID or canonical_sany_run.raw is None:
+            emit(f"ERROR: canonical module SANY validation unavailable: {canonical_sany_run.detail[:300]}")
+            return 3
+        canonical_module = Module.parse(canonical_sany_run.raw)
+        try:
+            analysis = analyze_module_submission(
+                canonical_source=canonical_source,
+                submitted_source=submitted_source,
+                expected_unit_ids=expected_unit_ids,
+                module=Module.parse(sany_run.raw),
+                expected_extends=canonical_module.extends,
+            )
+        except ModuleSubmissionError as exc:
+            integrity_issues.append((exc.code, str(exc)))
+
+        if integrity_issues:
+            report = {
+                "schema_version": 1,
+                "sany_status": "valid",
+                "proof_unit_ids": list(expected_unit_ids),
+                "units": [],
+                "trusted_unit_ids": [],
+                "trusted_proof_unit_ids": [],
+                "complete": False,
+                "integrity_issues": [{"code": code, "message": message} for code, message in integrity_issues],
+            }
+            emit(MODULE_RESULT_PREFIX + json.dumps(report, sort_keys=True, separators=(",", ":")))
+            for code, message in integrity_issues:
+                emit(f"FAIL {code}: {message}")
+            emit("GATES-FAILED: module_integrity")
+            emit("CHEAT-DETECTED: " + ",".join(sorted({code for code, _message in integrity_issues})))
+            return 1
+
+        unit_results: list[dict[str, object]] = []
+        community_lib = find_community_lib(filepath)
+        for index, unit in enumerate(analysis.checked_units):
+            unit_result, raw_output = _module_unit_result(
+                unit=unit,
+                tlapm_path=tlapm_path,
+                tlapm_lib=tlapm_lib,
+                community_lib=community_lib,
+                staged_file=staged_file,
+                tmp_dir=tmp_dir,
+                deadline=deadline,
+                index=index,
+            )
+            unit_results.append(unit_result)
+            emit("-" * 60)
+            emit(f"PROOF UNIT {unit.unit_id}: {unit_result['raw_verdict']}")
+            for line in raw_output.splitlines():
+                emit(line)
+
+        raw_pass = {result["unit_id"] for result in unit_results if result["raw_verdict"] == "PASS"}
+        trusted = compute_trusted_units(raw_pass, analysis.local_dependencies)
+        trusted_targets = [unit.unit_id for unit in analysis.target_units if unit.unit_id in trusted]
+        for result in unit_results:
+            result["trusted"] = result["unit_id"] in trusted
+        complete = len(trusted_targets) == len(expected_unit_ids)
+        report = {
+            "schema_version": 1,
+            "sany_status": "valid",
+            "proof_unit_ids": list(expected_unit_ids),
+            "units": unit_results,
+            "trusted_unit_ids": sorted(trusted),
+            "trusted_proof_unit_ids": trusted_targets,
+            "unused_helper_names": list(analysis.unused_helper_names),
+            "complete": complete,
+        }
+        emit(MODULE_RESULT_PREFIX + json.dumps(report, sort_keys=True, separators=(",", ":")))
+
+        unavailable = any(result["raw_verdict"] in {"ERROR", "TIMEOUT"} for result in unit_results)
+        if unavailable:
+            emit("ERROR: one or more proof-unit checks were unavailable")
+            return 3
+        if complete:
+            emit(
+                f"PASS — {len(trusted_targets)}/{len(expected_unit_ids)} proof units are dependency-closed and trusted"
+            )
+            return 0
+        emit(f"FAIL — {len(trusted_targets)}/{len(expected_unit_ids)} proof units are dependency-closed and trusted")
+        return 1
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
 def _run_in_container(filepath, args):
     """Run check_proof_bin inside Docker container."""
     require_canonical = getattr(args, "canonical_replay_required", False) and not args.sany_only
@@ -1275,6 +1633,7 @@ def main(*, require_canonical_for_proof_from_scratch: bool = False):
 
     target_name = os.path.splitext(os.path.basename(filepath))[0]
     benchmark_dir = resolve_benchmark_dir(args.benchmark_dir, filepath, target_name)
+    module_unit_ids = authoritative_module_unit_ids(filepath, benchmark_dir)
     marked_task = task_has_proof_region_markers(filepath, benchmark_dir)
     marked_proof_completion = args.mode == "proof-completion" and marked_task
     strict_contract = marked_task or (args.mode == "proof-from-scratch" and args.canonical_replay_required)
@@ -1388,6 +1747,24 @@ def main(*, require_canonical_for_proof_from_scratch: bool = False):
     if git_track_warning:
         emit(f"WARNING: {git_track_warning}")
     emit()
+
+    if args.mode == "proof-from-scratch" and module_unit_ids is not None:
+        if not module_unit_ids:
+            emit("SANY-STATUS: unavailable")
+            emit("ERROR: canonical module task has malformed or missing identified proof markers")
+            write_result_and_exit(3)
+        exit_code = run_module_task_check(
+            filepath=filepath,
+            benchmark_dir=benchmark_dir,
+            expected_unit_ids=module_unit_ids,
+            tlapm_path=tlapm_path,
+            tlapm_lib=tlapm_lib,
+            timeout=args.timeout,
+            output_path=output_path,
+            import_violations=import_violations,
+            emit=emit,
+        )
+        write_result_and_exit(exit_code)
 
     # --- Step 1: Run tlapm ---
     emit("=" * 60)

--- a/src/common/proof_from_scratch_grading.py
+++ b/src/common/proof_from_scratch_grading.py
@@ -1,0 +1,385 @@
+"""Pure semantic analysis for one submitted proof-from-scratch module."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, replace
+
+from common.proof_from_scratch_module import (
+    ModuleTaskContractError,
+    ModuleTaskRegions,
+    parse_module_task_regions,
+)
+from common.tla_modules import mask_comments_and_strings
+from tlacore.model import Module, Theorem
+
+HELPER_UNIT_PREFIX = "helper:"
+_OMITTED_KEYWORD = re.compile(r"\bOMITTED\b")
+_SMT_KEYWORD = re.compile(r"(?<![A-Za-z0-9_])SMT(?![A-Za-z0-9_])")
+_SMTT_KEYWORD = re.compile(r"(?<![A-Za-z0-9_])SMTT(?![A-Za-z0-9_])")
+_SMTT_FORM = re.compile(r'SMTT\s*\(\s*"r(?P<round>[0-9]+)"\s*\)(?![A-Za-z0-9_])')
+
+
+class ModuleSubmissionError(ValueError):
+    """A submitted module cannot be graded under the module-task contract."""
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class LocalProofUnit:
+    """One original proof unit or reachable submitted helper theorem."""
+
+    unit_id: str
+    kind: str
+    theorem_name: str | None
+    line_start: int
+    line_end: int
+    dependencies: tuple[str, ...]
+    admitted: bool
+
+
+@dataclass(frozen=True)
+class ModuleSubmissionAnalysis:
+    """Validated local theorem graph extracted only from the submission."""
+
+    target_units: tuple[LocalProofUnit, ...]
+    helper_units: tuple[LocalProofUnit, ...]
+    unused_helper_names: tuple[str, ...]
+
+    @property
+    def checked_units(self) -> tuple[LocalProofUnit, ...]:
+        return (*self.target_units, *self.helper_units)
+
+    @property
+    def local_dependencies(self) -> dict[str, tuple[str, ...]]:
+        return {unit.unit_id: unit.dependencies for unit in self.checked_units}
+
+
+def proof_unit_ids_from_markers(source: str) -> tuple[str, ...]:
+    """Read ordered proof-unit IDs from module marker lines."""
+
+    prefix = "\\* BEGIN AGENT PROOF "
+    unit_ids = tuple(line.removeprefix(prefix) for line in source.splitlines() if line.startswith(prefix))
+    if not unit_ids:
+        raise ModuleSubmissionError("MODULE_MARKERS_INVALID", "module task contains no identified proof regions")
+    return unit_ids
+
+
+def _parse_regions(source: str, expected_unit_ids: Iterable[str], *, label: str) -> ModuleTaskRegions:
+    try:
+        return parse_module_task_regions(source, expected_unit_ids)
+    except ModuleTaskContractError as exc:
+        raise ModuleSubmissionError(
+            "MODULE_MARKERS_INVALID", f"{label} module task has invalid editable regions: {exc}"
+        ) from exc
+
+
+def _theorem_in_range(theorems: tuple[Theorem, ...], start: int, end: int, *, unit_id: str) -> Theorem:
+    matches = [theorem for theorem in theorems if theorem.loc is not None and start <= theorem.loc.line_start <= end]
+    if len(matches) != 1:
+        raise ModuleSubmissionError(
+            "PROOF_UNIT_MAPPING_INVALID",
+            f"proof unit {unit_id!r} must map to exactly one top-level theorem, found {len(matches)}",
+        )
+    return matches[0]
+
+
+def _target_theorems(
+    module: Module,
+    regions: ModuleTaskRegions,
+) -> tuple[tuple[str, Theorem], ...]:
+    theorems = tuple(module.theorems)
+    result: list[tuple[str, Theorem]] = []
+    previous_closing_marker = regions.helper_line_bounds[1] + 1
+    for proof in regions.proofs:
+        opening_marker = proof.line_bounds[0] - 1
+        theorem = _theorem_in_range(
+            theorems,
+            previous_closing_marker + 1,
+            opening_marker - 1,
+            unit_id=proof.task_id,
+        )
+        statement_end = opening_marker - 1
+        if theorem.statement_loc is None or not (
+            previous_closing_marker + 1 <= theorem.statement_loc.line_start
+            and theorem.statement_loc.line_end <= statement_end
+        ):
+            raise ModuleSubmissionError(
+                "TARGET_STATEMENT_MODIFIED",
+                f"statement for proof unit {proof.task_id!r} extends into an editable region",
+            )
+        if theorem.proof_loc is not None and not (
+            proof.line_bounds[0] <= theorem.proof_loc.line_start <= proof.line_bounds[1]
+        ):
+            raise ModuleSubmissionError(
+                "PROOF_OUTSIDE_REGION",
+                f"proof for unit {proof.task_id!r} is outside its editable proof region",
+            )
+        result.append((proof.task_id, theorem))
+        previous_closing_marker = proof.line_bounds[1] + 1
+    return tuple(result)
+
+
+def _helper_theorems(module: Module, regions: ModuleTaskRegions) -> tuple[Theorem, ...]:
+    start, end = regions.helper_line_bounds
+    helpers = tuple(
+        theorem for theorem in module.theorems if theorem.loc is not None and start <= theorem.loc.line_start <= end
+    )
+    for theorem in helpers:
+        if not theorem.name:
+            raise ModuleSubmissionError("HELPER_NAME_REQUIRED", "every submitted helper theorem must be named")
+        if theorem.proof_loc is not None and not (start <= theorem.proof_loc.line_start <= end):
+            raise ModuleSubmissionError(
+                "HELPER_PROOF_OUTSIDE_REGION",
+                f"proof for helper theorem {theorem.name!r} is outside the helper region",
+            )
+    return helpers
+
+
+def _reject_added_omitted_proofs(
+    canonical_regions: ModuleTaskRegions,
+    submitted_regions: ModuleTaskRegions,
+) -> None:
+    """Reject admissions added inside editable regions.
+
+    An unchanged canonical ``PROOF OMITTED`` remains an unresolved target so a
+    partially solved module can still earn credit. Any newly introduced
+    ``OMITTED`` token, including one buried in a hierarchical proof, admits an
+    obligation and must fail before TLAPM can mistake exit 11 for a raw pass.
+    """
+
+    if _OMITTED_KEYWORD.search(mask_comments_and_strings(submitted_regions.helpers)):
+        raise ModuleSubmissionError(
+            "PROOF_OMITTED_ADDED",
+            "helper region contains an admitted proof",
+        )
+
+    for canonical, submitted in zip(canonical_regions.proofs, submitted_regions.proofs, strict=True):
+        if submitted.text == canonical.text:
+            continue
+        if _OMITTED_KEYWORD.search(mask_comments_and_strings(submitted.text)):
+            raise ModuleSubmissionError(
+                "PROOF_OMITTED_ADDED",
+                f"proof region {submitted.task_id!r} contains an admitted proof",
+            )
+
+
+def _reject_invalid_smt_budgets(regions: ModuleTaskRegions) -> None:
+    """Require deterministic, bounded SMT calls in editable proof text."""
+
+    editable_regions = [("helper region", regions.helpers)]
+    editable_regions.extend((f"proof region {proof.task_id!r}", proof.text) for proof in regions.proofs)
+    for label, source in editable_regions:
+        code = mask_comments_and_strings(source)
+        if _SMT_KEYWORD.search(code) is not None:
+            raise ModuleSubmissionError(
+                "SMT_BUDGET_INVALID",
+                f'{label} uses standalone SMT; use SMTT("rN") with 1 <= N <= 30',
+            )
+        for match in _SMTT_KEYWORD.finditer(code):
+            form = _SMTT_FORM.match(source, match.start())
+            if form is None:
+                raise ModuleSubmissionError(
+                    "SMT_BUDGET_INVALID",
+                    f'{label} uses invalid SMTT form; use SMTT("rN") with 1 <= N <= 30',
+                )
+            digits = form.group("round").lstrip("0")
+            if not digits or len(digits) > 2 or int(digits) > 30:
+                raise ModuleSubmissionError(
+                    "SMT_BUDGET_INVALID",
+                    f'{label} uses invalid SMTT form; use SMTT("rN") with 1 <= N <= 30',
+                )
+
+
+def _reject_forbidden_editable_declarations(module: Module, regions: ModuleTaskRegions) -> None:
+    helper_start, helper_end = regions.helper_line_bounds
+
+    def in_helpers(loc) -> bool:
+        return loc is not None and helper_start <= loc.line_start <= helper_end
+
+    def proof_unit_at(loc) -> str | None:
+        if loc is None:
+            return None
+        for proof in regions.proofs:
+            start, end = proof.line_bounds
+            if start <= loc.line_start <= end:
+                return proof.task_id
+        return None
+
+    forbidden: list[str] = []
+    forbidden.extend(f"CONSTANT {symbol.name}" for symbol in module.constants if in_helpers(symbol.loc))
+    forbidden.extend(f"VARIABLE {symbol.name}" for symbol in module.variables if in_helpers(symbol.loc))
+    forbidden.extend(
+        f"{'AXIOM' if assumption.is_axiom else 'ASSUME'} {assumption.name or '<unnamed>'}"
+        for assumption in module.assumes
+        if in_helpers(assumption.loc)
+    )
+    forbidden.extend(
+        f"nested MODULE {module_symbol.name}" for module_symbol in module.inner_modules if in_helpers(module_symbol.loc)
+    )
+    forbidden.extend(f"top-level {node.kind}" for node in module.other_top_levels if in_helpers(node.loc))
+    if forbidden:
+        raise ModuleSubmissionError(
+            "FORBIDDEN_HELPER_DECLARATION",
+            "helper region contains forbidden declarations: " + ", ".join(forbidden),
+        )
+
+    bad_directives = [
+        directive.kind
+        for directive in module.directives
+        if in_helpers(directive.loc) and not directive.definitions_only
+    ]
+    if bad_directives:
+        raise ModuleSubmissionError(
+            "FORBIDDEN_HELPER_DIRECTIVE",
+            "helper region contains a non-definition USE/HIDE directive",
+        )
+
+    proof_region_nodes: list[tuple[str, object]] = []
+    proof_region_nodes.extend((f"CONSTANT {value.name}", value.loc) for value in module.constants)
+    proof_region_nodes.extend((f"VARIABLE {value.name}", value.loc) for value in module.variables)
+    proof_region_nodes.extend(
+        (f"{'AXIOM' if value.is_axiom else 'ASSUME'} {value.name or '<unnamed>'}", value.loc)
+        for value in module.assumes
+    )
+    proof_region_nodes.extend(
+        (f"INSTANCE {value.name or value.module or '<unnamed>'}", value.loc) for value in module.instances
+    )
+    proof_region_nodes.extend((f"operator {value.name}", value.loc) for value in module.operators)
+    proof_region_nodes.extend((f"nested MODULE {value.name}", value.loc) for value in module.inner_modules)
+    proof_region_nodes.extend((f"module directive {value.kind}", value.loc) for value in module.directives)
+    proof_region_nodes.extend((f"top-level {value.kind}", value.loc) for value in module.other_top_levels)
+    proof_region_nodes.extend((f"theorem {value.name or '<unnamed>'}", value.loc) for value in module.theorems)
+    unexpected = [
+        (description, unit_id) for description, loc in proof_region_nodes if (unit_id := proof_unit_at(loc)) is not None
+    ]
+    if unexpected:
+        description, unit_id = unexpected[0]
+        raise ModuleSubmissionError(
+            "TOP_LEVEL_DECLARATION_IN_PROOF",
+            f"proof region {unit_id!r} contains an extra {description}; target regions may contain only proofs",
+        )
+
+
+def _reachable_helpers(
+    target_units: tuple[LocalProofUnit, ...],
+    helpers_by_id: dict[str, LocalProofUnit],
+) -> set[str]:
+    reachable: set[str] = set()
+    pending = [dependency for unit in target_units for dependency in unit.dependencies if dependency in helpers_by_id]
+    while pending:
+        unit_id = pending.pop()
+        if unit_id in reachable:
+            continue
+        reachable.add(unit_id)
+        pending.extend(
+            dependency
+            for dependency in helpers_by_id[unit_id].dependencies
+            if dependency in helpers_by_id and dependency not in reachable
+        )
+    return reachable
+
+
+def analyze_module_submission(
+    *,
+    canonical_source: str,
+    submitted_source: str,
+    expected_unit_ids: Iterable[str],
+    module: Module,
+    expected_extends: Iterable[str] | None = None,
+) -> ModuleSubmissionAnalysis:
+    """Validate immutable regions and derive the submitted local dependency graph."""
+
+    expected = tuple(expected_unit_ids)
+    canonical_regions = _parse_regions(canonical_source, expected, label="canonical")
+    submitted_regions = _parse_regions(submitted_source, expected, label="submitted")
+    if submitted_regions.fixed_segments != canonical_regions.fixed_segments:
+        raise ModuleSubmissionError(
+            "SCAFFOLD_MODIFIED",
+            "fixed module task scaffold outside editable regions was modified",
+        )
+
+    if expected_extends is not None and tuple(module.extends) != tuple(expected_extends):
+        raise ModuleSubmissionError(
+            "MODULE_EXTENDS_MODIFIED",
+            "submitted module changes the canonical EXTENDS imports through an editable region",
+        )
+
+    _reject_invalid_smt_budgets(submitted_regions)
+    _reject_forbidden_editable_declarations(module, submitted_regions)
+    _reject_added_omitted_proofs(canonical_regions, submitted_regions)
+    target_theorems = _target_theorems(module, submitted_regions)
+    helper_theorems = _helper_theorems(module, submitted_regions)
+
+    named: dict[str, str] = {}
+    for unit_id, theorem in target_theorems:
+        if theorem.name:
+            if theorem.name in named:
+                raise ModuleSubmissionError("LOCAL_NAME_COLLISION", f"local theorem name {theorem.name!r} is repeated")
+            named[theorem.name] = unit_id
+    for theorem in helper_theorems:
+        assert theorem.name is not None
+        if theorem.name in named:
+            raise ModuleSubmissionError("LOCAL_NAME_COLLISION", f"local theorem name {theorem.name!r} is repeated")
+        named[theorem.name] = HELPER_UNIT_PREFIX + theorem.name
+
+    def local_dependencies(theorem: Theorem) -> tuple[str, ...]:
+        return tuple(sorted({named[reference] for reference in theorem.references if reference in named}))
+
+    target_units = tuple(
+        LocalProofUnit(
+            unit_id=unit_id,
+            kind="target",
+            theorem_name=theorem.name,
+            line_start=theorem.loc.line_start if theorem.loc else 0,
+            line_end=theorem.loc.line_end if theorem.loc else 0,
+            dependencies=local_dependencies(theorem),
+            admitted=theorem.is_admitted,
+        )
+        for unit_id, theorem in target_theorems
+    )
+    all_helpers = tuple(
+        LocalProofUnit(
+            unit_id=HELPER_UNIT_PREFIX + (theorem.name or ""),
+            kind="helper",
+            theorem_name=theorem.name,
+            line_start=theorem.loc.line_start if theorem.loc else 0,
+            line_end=theorem.loc.line_end if theorem.loc else 0,
+            dependencies=local_dependencies(theorem),
+            admitted=theorem.is_admitted,
+        )
+        for theorem in helper_theorems
+    )
+    helpers_by_id = {unit.unit_id: unit for unit in all_helpers}
+    reachable = _reachable_helpers(target_units, helpers_by_id)
+    helper_units = tuple(unit for unit in all_helpers if unit.unit_id in reachable)
+
+    checked = {unit.unit_id for unit in (*target_units, *helper_units)}
+    target_units = tuple(
+        replace(unit, dependencies=tuple(dependency for dependency in unit.dependencies if dependency in checked))
+        for unit in target_units
+    )
+    helper_units = tuple(
+        replace(unit, dependencies=tuple(dependency for dependency in unit.dependencies if dependency in checked))
+        for unit in helper_units
+    )
+    unused_helper_names = tuple(unit.theorem_name or "" for unit in all_helpers if unit.unit_id not in reachable)
+    return ModuleSubmissionAnalysis(
+        target_units=target_units,
+        helper_units=helper_units,
+        unused_helper_names=unused_helper_names,
+    )
+
+
+__all__ = [
+    "HELPER_UNIT_PREFIX",
+    "LocalProofUnit",
+    "ModuleSubmissionAnalysis",
+    "ModuleSubmissionError",
+    "analyze_module_submission",
+    "proof_unit_ids_from_markers",
+]

--- a/src/common/proof_from_scratch_manifest.py
+++ b/src/common/proof_from_scratch_manifest.py
@@ -1,0 +1,384 @@
+"""Strict loader for the generated proof-from-scratch module corpus.
+
+The generator owns how module tasks are produced. The evaluator consumes only
+the versioned manifest and the exact files named by it; it never reconstructs a
+second grouping from the legacy theorem-level corpus.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from common.proof_from_scratch_module import (
+    MODULE_TASK_FORMAT_VERSION,
+    ModuleTaskContractError,
+    ModuleTaskRegions,
+    ModuleTaskSpec,
+    parse_module_task_regions,
+    statement_sha256,
+    validate_module_task_spec_data,
+)
+from common.task_contract import TaskContractError, load_manifest_specification_ids
+from tlacore.source import strip_comments
+
+MANIFEST_FILENAME = "manifest.json"
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_THEOREM_SCAN = re.compile(r"^[ \t]*(THEOREM|LEMMA|COROLLARY|PROPOSITION)\b", re.MULTILINE)
+_PROOF_ARTIFACT_SCAN = re.compile(
+    r"^[ \t]*(?:(?:LOCAL[ \t]+)?(?:THEOREM|LEMMA|COROLLARY|PROPOSITION)\b"
+    r"|(?:PROOF|OMITTED|OBVIOUS|BY|QED)\b|<\d+>)",
+    re.MULTILINE,
+)
+_TASK_PROOF_ARTIFACT_SCAN = re.compile(
+    r"^[ \t]*(?:(?:PROOF|OMITTED|OBVIOUS|BY|QED|USE|HIDE|DEFINE|SUFFICES|WITNESS|PICK|TAKE)\b|<\d+>)",
+    re.MULTILINE,
+)
+
+
+class ModuleTaskManifestError(ValueError):
+    """The module corpus manifest or one of its declared files is invalid."""
+
+
+@dataclass(frozen=True)
+class ModuleTaskEntry:
+    """One generated module task and its exact read-only context."""
+
+    spec: ModuleTaskSpec
+    context: tuple[str, ...]
+    renamed_bindings: tuple[tuple[str, tuple[tuple[str, str], ...]], ...]
+
+
+@dataclass(frozen=True)
+class ModuleTaskManifest:
+    """Validated, complete module-task corpus metadata."""
+
+    format_version: int
+    corpus_sha256: str
+    entries: tuple[ModuleTaskEntry, ...]
+
+    @property
+    def proof_unit_ids(self) -> tuple[str, ...]:
+        return tuple(unit.task_id for entry in self.entries for unit in entry.spec.proof_units)
+
+
+def _reject_json_constant(value: str) -> Any:
+    raise ModuleTaskManifestError(f"manifest contains non-standard JSON constant {value}")
+
+
+def _object_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ModuleTaskManifestError(f"manifest contains duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _exact_object(value: object, keys: set[str], *, label: str) -> dict[str, Any]:
+    if type(value) is not dict or set(value) != keys:
+        expected = ", ".join(sorted(keys))
+        raise ModuleTaskManifestError(f"{label} must contain exactly: {expected}")
+    return value
+
+
+def _sha256(value: object, *, label: str) -> str:
+    if type(value) is not str or not _SHA256_RE.fullmatch(value):
+        raise ModuleTaskManifestError(f"{label} must be a lowercase SHA-256 hex digest")
+    return value
+
+
+def _canonical_tla_path(value: object, *, label: str) -> str:
+    if type(value) is not str or not value or "\\" in value:
+        raise ModuleTaskManifestError(f"{label} must be a non-empty canonical relative .tla path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or path.as_posix() != value or any(part in {".", ".."} for part in path.parts):
+        raise ModuleTaskManifestError(f"{label} must be a canonical relative path: {value!r}")
+    if path.suffix != ".tla":
+        raise ModuleTaskManifestError(f"{label} must name a .tla file: {value!r}")
+    return value
+
+
+def _validate_renamed_bindings(
+    value: object,
+    spec: ModuleTaskSpec,
+) -> tuple[tuple[str, tuple[tuple[str, str], ...]], ...]:
+    if type(value) is not dict:
+        raise ModuleTaskManifestError(f"renamed_bindings for {spec.task_id!r} must be an object")
+    unknown = set(value) - set(spec.proof_unit_ids)
+    if unknown:
+        raise ModuleTaskManifestError(
+            f"renamed_bindings for {spec.task_id!r} contains unknown proof units: {sorted(unknown)}"
+        )
+
+    result: list[tuple[str, tuple[tuple[str, str], ...]]] = []
+    for unit_id, raw_renames in value.items():
+        if type(raw_renames) is not dict or not raw_renames:
+            raise ModuleTaskManifestError(f"renamed_bindings for proof unit {unit_id!r} must be a non-empty object")
+        renames: dict[str, str] = {}
+        for original, replacement in raw_renames.items():
+            if type(original) is not str or not original or type(replacement) is not str or not replacement:
+                raise ModuleTaskManifestError(
+                    f"renamed binding names for proof unit {unit_id!r} must be non-empty strings"
+                )
+            if original == replacement:
+                raise ModuleTaskManifestError(
+                    f"renamed binding {original!r} for proof unit {unit_id!r} does not change the name"
+                )
+            renames[original] = replacement
+        result.append((unit_id, tuple(sorted(renames.items()))))
+    return tuple(sorted(result))
+
+
+def module_task_statements(source: str, regions: ModuleTaskRegions) -> tuple[tuple[str, str], ...]:
+    """Return the exact target statements carried by a generated module task."""
+
+    lines = source.splitlines(keepends=True)
+    statements: list[tuple[str, str]] = []
+    cursor = regions.helper_line_bounds[1] + 1
+    for proof in regions.proofs:
+        marker_index = proof.line_bounds[0] - 2
+        statement = "".join(lines[cursor:marker_index]).strip()
+        if not statement:
+            raise ModuleTaskManifestError(f"proof unit {proof.task_id!r} has an empty target statement")
+        statements.append((proof.task_id, statement))
+        cursor = proof.line_bounds[1] + 1
+    return tuple(statements)
+
+
+def _resolve_declared_file(root: Path, relative: str, *, label: str) -> Path:
+    path = root.joinpath(*PurePosixPath(relative).parts)
+    try:
+        resolved = path.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ModuleTaskManifestError(
+            f"{label} does not resolve to a file inside the declared root: {relative!r}"
+        ) from exc
+    if not resolved.is_file() or path.is_symlink():
+        raise ModuleTaskManifestError(f"{label} must be a regular non-symlink file: {relative!r}")
+    return resolved
+
+
+def _validate_source_file(source_root: Path, entry: ModuleTaskEntry) -> None:
+    """Bind a generated task to the exact source specification it represents."""
+
+    source_path = _resolve_declared_file(source_root, entry.spec.task_id, label="source specification")
+    try:
+        source_sha256 = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise ModuleTaskManifestError(f"cannot read source specification {entry.spec.task_id!r}: {exc}") from exc
+    if source_sha256 != entry.spec.source_sha256:
+        raise ModuleTaskManifestError(
+            f"source specification {entry.spec.task_id!r} source_sha256 does not match the shipped source"
+        )
+
+
+def _validate_task_file(root: Path, entry: ModuleTaskEntry) -> None:
+    task_path = _resolve_declared_file(root, entry.spec.task_id, label="module task")
+    try:
+        source = task_path.read_text(encoding="utf-8")
+        regions = parse_module_task_regions(source, entry.spec.proof_unit_ids)
+    except (OSError, UnicodeError, ModuleTaskContractError) as exc:
+        raise ModuleTaskManifestError(f"invalid module task {entry.spec.task_id!r}: {exc}") from exc
+
+    statements = dict(module_task_statements(source, regions))
+    if regions.render() != source:
+        raise ModuleTaskManifestError(f"module task {entry.spec.task_id!r} does not round-trip through its regions")
+    if regions.helpers.strip():
+        raise ModuleTaskManifestError(f"canonical module task {entry.spec.task_id!r} has a non-empty helper region")
+    for unit in entry.spec.proof_units:
+        if statement_sha256(statements[unit.task_id]) != unit.statement_sha256:
+            raise ModuleTaskManifestError(
+                f"module task {entry.spec.task_id!r} statement digest does not match proof unit {unit.task_id!r}"
+            )
+    for proof in regions.proofs:
+        if proof.text.strip() != "PROOF OMITTED":
+            raise ModuleTaskManifestError(
+                f"canonical module task {entry.spec.task_id!r} proof region {proof.task_id!r} is not PROOF OMITTED"
+            )
+
+    fixed_source = strip_comments("".join(regions.fixed_segments))
+    artifact = _TASK_PROOF_ARTIFACT_SCAN.search(fixed_source)
+    if artifact is not None:
+        raise ModuleTaskManifestError(
+            f"canonical module task {entry.spec.task_id!r} contains proof artifact "
+            f"{artifact.group(0).strip()!r} outside an editable region"
+        )
+    theorem_keywords = _THEOREM_SCAN.findall(fixed_source)
+    if len(theorem_keywords) != len(entry.spec.proof_units):
+        raise ModuleTaskManifestError(
+            f"canonical module task {entry.spec.task_id!r} contains {len(theorem_keywords)} target statements; "
+            f"expected {len(entry.spec.proof_units)}"
+        )
+
+    for context in entry.context:
+        context_path = _resolve_declared_file(root, context, label=f"context for {entry.spec.task_id!r}")
+        try:
+            context_source = context_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise ModuleTaskManifestError(f"cannot read context {context!r}: {exc}") from exc
+        artifact = _PROOF_ARTIFACT_SCAN.search(strip_comments(context_source))
+        if artifact is not None:
+            raise ModuleTaskManifestError(f"context {context!r} contains proof artifact {artifact.group(0).strip()!r}")
+
+
+def load_module_task_manifest(
+    root: Path,
+    *,
+    corpus_manifest_path: Path | None = None,
+    source_root: Path | None = None,
+) -> ModuleTaskManifest:
+    """Load and fully validate the generated module-task corpus manifest.
+
+    corpus_manifest_path binds the generated suite to the exact legacy theorem
+    corpus from which the generator produced it. The evaluator passes this path
+    explicitly instead of inferring any task grouping from that corpus.
+
+    source_root identifies the shipped source-specification tree used to verify
+    each entry's ``source_sha256``. When omitted, it is inferred as the
+    repository's ``source`` sibling for the conventional ``benchmark`` layout.
+    """
+
+    try:
+        resolved_root = root.resolve(strict=True)
+        text = (resolved_root / MANIFEST_FILENAME).read_text(encoding="utf-8")
+    except (OSError, UnicodeError, RuntimeError) as exc:
+        raise ModuleTaskManifestError(f"cannot read module-task manifest under {root}: {exc}") from exc
+    try:
+        raw = json.loads(
+            text,
+            object_pairs_hook=_object_without_duplicates,
+            parse_constant=_reject_json_constant,
+        )
+    except ModuleTaskManifestError:
+        raise
+    except json.JSONDecodeError as exc:
+        raise ModuleTaskManifestError(
+            f"invalid JSON in module-task manifest at line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        ) from exc
+
+    document = _exact_object(
+        raw,
+        {"format_version", "corpus_sha256", "complete", "module_tasks"},
+        label="module-task manifest",
+    )
+    if type(document["format_version"]) is not int or document["format_version"] != MODULE_TASK_FORMAT_VERSION:
+        raise ModuleTaskManifestError(
+            f"unsupported module-task manifest format_version {document['format_version']!r}; "
+            f"expected {MODULE_TASK_FORMAT_VERSION}"
+        )
+    if document["complete"] is not True:
+        raise ModuleTaskManifestError("module-task manifest must describe a complete corpus")
+    corpus_sha256 = _sha256(document["corpus_sha256"], label="manifest corpus_sha256")
+    if corpus_manifest_path is not None:
+        try:
+            current_corpus_sha256 = hashlib.sha256(corpus_manifest_path.read_bytes()).hexdigest()
+        except OSError as exc:
+            raise ModuleTaskManifestError(f"cannot read source corpus manifest {corpus_manifest_path}: {exc}") from exc
+        if current_corpus_sha256 != corpus_sha256:
+            raise ModuleTaskManifestError(
+                "module-task manifest was generated from a different proof-from-scratch corpus"
+            )
+
+    raw_entries = document["module_tasks"]
+    if type(raw_entries) is not list or not raw_entries:
+        raise ModuleTaskManifestError("module-task manifest module_tasks must be a non-empty list")
+
+    if source_root is None:
+        source_root = resolved_root.parent.parent / "source"
+    try:
+        resolved_source_root = source_root.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ModuleTaskManifestError(f"cannot read shipped source tree under {source_root}: {exc}") from exc
+
+    entries: list[ModuleTaskEntry] = []
+    seen_tasks: set[str] = set()
+    seen_units: set[str] = set()
+    for index, value in enumerate(raw_entries):
+        raw_entry = _exact_object(value, {"spec", "context", "renamed_bindings"}, label=f"module task {index}")
+        try:
+            spec = validate_module_task_spec_data(raw_entry["spec"])
+        except ModuleTaskContractError as exc:
+            raise ModuleTaskManifestError(f"invalid module task {index}: {exc}") from exc
+        if spec.task_id in seen_tasks:
+            raise ModuleTaskManifestError(f"module-task manifest repeats task ID {spec.task_id!r}")
+        seen_tasks.add(spec.task_id)
+        repeated_units = seen_units.intersection(spec.proof_unit_ids)
+        if repeated_units:
+            raise ModuleTaskManifestError(f"proof units appear in more than one module task: {sorted(repeated_units)}")
+        seen_units.update(spec.proof_unit_ids)
+
+        raw_context = raw_entry["context"]
+        if type(raw_context) is not list:
+            raise ModuleTaskManifestError(f"context for {spec.task_id!r} must be a list")
+        context = tuple(
+            _canonical_tla_path(path, label=f"context path {context_index} for {spec.task_id!r}")
+            for context_index, path in enumerate(raw_context)
+        )
+        if len(context) != len(set(context)):
+            raise ModuleTaskManifestError(f"context for {spec.task_id!r} repeats a path")
+        if spec.task_id in context:
+            raise ModuleTaskManifestError(f"module task {spec.task_id!r} also appears in its context")
+        workspace_names = [PurePosixPath(spec.task_id).name, *(PurePosixPath(path).name for path in context)]
+        if len(workspace_names) != len(set(workspace_names)):
+            raise ModuleTaskManifestError(f"module task {spec.task_id!r} has colliding workspace filenames")
+
+        entry = ModuleTaskEntry(
+            spec=spec,
+            context=context,
+            renamed_bindings=_validate_renamed_bindings(raw_entry["renamed_bindings"], spec),
+        )
+        _validate_source_file(resolved_source_root, entry)
+        _validate_task_file(resolved_root, entry)
+        entries.append(entry)
+
+    ordered_ids = [entry.spec.task_id for entry in entries]
+    if ordered_ids != sorted(ordered_ids):
+        raise ModuleTaskManifestError("module-task manifest entries must be sorted by task ID")
+    if corpus_manifest_path is not None:
+        try:
+            corpus_specification_ids = load_manifest_specification_ids(
+                corpus_manifest_path.parent,
+                suite_name="proof-from-scratch",
+            )
+        except TaskContractError as exc:
+            raise ModuleTaskManifestError(f"invalid source proof-from-scratch manifest: {exc}") from exc
+        expected_by_spec: dict[str, set[str]] = {}
+        for unit_id, spec_id in corpus_specification_ids.items():
+            expected_by_spec.setdefault(spec_id, set()).add(unit_id)
+        actual_by_spec = {entry.spec.task_id: set(entry.spec.proof_unit_ids) for entry in entries}
+        if set(actual_by_spec) != set(expected_by_spec):
+            missing = sorted(set(expected_by_spec) - set(actual_by_spec))
+            extra = sorted(set(actual_by_spec) - set(expected_by_spec))
+            raise ModuleTaskManifestError(
+                f"module-task manifest specification coverage differs from the source corpus; "
+                f"missing={missing}, extra={extra}"
+            )
+        mismatched = [
+            spec_id for spec_id in sorted(expected_by_spec) if actual_by_spec[spec_id] != expected_by_spec[spec_id]
+        ]
+        if mismatched:
+            raise ModuleTaskManifestError(
+                f"module-task manifest proof-unit coverage differs from the source corpus for {mismatched}"
+            )
+    return ModuleTaskManifest(
+        format_version=MODULE_TASK_FORMAT_VERSION,
+        corpus_sha256=corpus_sha256,
+        entries=tuple(entries),
+    )
+
+
+__all__ = [
+    "MANIFEST_FILENAME",
+    "ModuleTaskEntry",
+    "ModuleTaskManifest",
+    "ModuleTaskManifestError",
+    "load_module_task_manifest",
+    "module_task_statements",
+]

--- a/src/common/proof_from_scratch_module.py
+++ b/src/common/proof_from_scratch_module.py
@@ -1,10 +1,9 @@
-"""Shared contract for future module-level proof-from-scratch tasks.
+"""Shared contract for module-level proof-from-scratch tasks.
 
-The current corpus remains one physical task per target theorem.  A future
-corpus revision will group those same target IDs into one editable proof module
-per source specification.  This module fixes only the small boundary shared by
-the generator and evaluator: strict metadata, identified proof regions, fixed
-scaffold extraction, and dependency-closed trust.  It deliberately performs no
+The generated corpus groups existing theorem target IDs into one editable proof
+module per source specification. This module fixes the boundary shared by the
+generator and evaluator: strict metadata, identified proof regions, fixed
+scaffold extraction, and dependency-closed trust. It deliberately performs no
 SANY or TLAPM work.
 """
 
@@ -34,7 +33,7 @@ class ModuleTaskContractError(ValueError):
 
 @dataclass(frozen=True)
 class ModuleProofUnit:
-    """One existing theorem target scored inside a future module task."""
+    """One existing theorem target scored inside a module task."""
 
     task_id: str
     statement_sha256: str

--- a/src/common/proof_libraries.py
+++ b/src/common/proof_libraries.py
@@ -286,7 +286,13 @@ def validate_official_imports(source: str, allowed_modules: frozenset[str]) -> l
     try:
         regions = parse_editable_regions(source)
     except EditableRegionError:
-        return []
+        try:
+            from common.proof_from_scratch_grading import proof_unit_ids_from_markers
+            from common.proof_from_scratch_module import parse_module_task_regions
+
+            regions = parse_module_task_regions(source, proof_unit_ids_from_markers(source))
+        except (ValueError, EditableRegionError):
+            return []
     code = mask_comments_and_strings(regions.helpers)
     violations: list[ImportViolation] = []
     first_line = regions.helper_line_bounds[0]

--- a/src/dataset/sany-dump/DumpSemantics.java
+++ b/src/dataset/sany-dump/DumpSemantics.java
@@ -428,10 +428,15 @@ public class DumpSemantics {
   // ----- theorem-use graph (BY/USE/DEFS, for top-level selection) ----------
 
   static void collectRefs(ProofNode p, Set<String> refs, Set<String> moduleTheoremNames) {
+    Set<Integer> visited = new HashSet<Integer>();
     if (p instanceof LeafProofNode) {
       LeafProofNode lp = (LeafProofNode) p;
-      for (LevelNode f : lp.getFacts()) addRefFromFact(f, refs, moduleTheoremNames);
-      for (SymbolNode d : lp.getDefs()) addRefFromSymbol(d, refs, moduleTheoremNames);
+      for (LevelNode f : lp.getFacts()) {
+        collectTheoremRefsFromFact(f, refs, moduleTheoremNames, visited);
+      }
+      for (SymbolNode d : lp.getDefs()) {
+        collectTheoremRefsFromSymbol(d, refs, moduleTheoremNames, visited);
+      }
     } else if (p instanceof NonLeafProofNode) {
       for (LevelNode step : ((NonLeafProofNode) p).getSteps()) {
         if (step instanceof TheoremNode) {
@@ -439,23 +444,79 @@ public class DumpSemantics {
           if (sub != null) collectRefs(sub, refs, moduleTheoremNames);
         } else if (step instanceof UseOrHideNode) {
           UseOrHideNode u = (UseOrHideNode) step;
-          if (u.facts != null) for (LevelNode f : u.facts) addRefFromFact(f, refs, moduleTheoremNames);
-          if (u.defs != null) for (SymbolNode d : u.defs) addRefFromSymbol(d, refs, moduleTheoremNames);
+          // HIDE removes facts/definitions from the usable context.  It must
+          // not create a proof dependency merely because it names an earlier
+          // theorem.  USE is the directive that makes those facts available.
+          if (u.getKind() != ASTConstants.UseKind) continue;
+          if (u.facts != null) {
+            for (LevelNode f : u.facts) {
+              collectTheoremRefsFromFact(f, refs, moduleTheoremNames, visited);
+            }
+          }
+          if (u.defs != null) {
+            for (SymbolNode d : u.defs) {
+              collectTheoremRefsFromSymbol(d, refs, moduleTheoremNames, visited);
+            }
+          }
         } else if (step instanceof DefStepNode) {
-          // DefStepNode introduces new definitions inside a proof; no refs to extract here.
+          // References inside proof-local DEFINE bodies are collected by the
+          // semantic walk below. They matter for dependency-closed scoring:
+          // `DEFINE Alias == EarlierTheorem` must not hide that dependency.
         }
         // InstanceNode steps and others: no refs.
       }
     }
   }
 
-  static void addRefFromFact(LevelNode fact, Set<String> refs, Set<String> moduleTheoremNames) {
-    if (fact instanceof OpApplNode) {
-      OpApplNode app = (OpApplNode) fact;
-      String name = symbolName(app.getOperator());
-      if (name != null && moduleTheoremNames.contains(name)) refs.add(name);
+  static void collectTheoremRefs(
+      SemanticNode node,
+      Set<String> refs,
+      Set<String> moduleTheoremNames,
+      Set<Integer> visited) {
+    if (node == null || !visited.add(node.getUid())) return;
+    if (node instanceof OpApplNode) {
+      collectTheoremRefsFromSymbol(
+          ((OpApplNode) node).getOperator(), refs, moduleTheoremNames, visited);
+    }
+    SemanticNode[] children;
+    try {
+      children = node.getChildren();
+    } catch (Throwable t) {
+      children = null;
+    }
+    if (children != null) {
+      for (SemanticNode child : children) {
+        collectTheoremRefs(child, refs, moduleTheoremNames, visited);
+      }
     }
   }
+
+  static void collectTheoremRefsFromSymbol(
+      SymbolNode symbol,
+      Set<String> refs,
+      Set<String> moduleTheoremNames,
+      Set<Integer> visited) {
+    addRefFromSymbol(symbol, refs, moduleTheoremNames);
+    if (symbol instanceof OpDefNode) {
+      // An admitted theorem can otherwise be hidden behind a proof-local or
+      // helper-region operator and cited only through `BY ... DEF Alias`.
+      collectTheoremRefs(((OpDefNode) symbol).getBody(), refs, moduleTheoremNames, visited);
+    }
+  }
+
+  static void collectTheoremRefsFromFact(
+      LevelNode fact,
+      Set<String> refs,
+      Set<String> moduleTheoremNames,
+      Set<Integer> visited) {
+    // A BY/USE fact can hide a theorem arbitrarily deeply through user
+    // operators, LET/IN, CASE, or other semantic wrappers. Conservatively walk
+    // the complete fact subtree. This can retain a dependency when a theorem
+    // name occurs in a tautological composite fact, but it cannot award trust
+    // to a proof whose usable fact was derived from an admitted theorem.
+    collectTheoremRefs(fact, refs, moduleTheoremNames, visited);
+  }
+
   static void addRefFromSymbol(SymbolNode sym, Set<String> refs, Set<String> moduleTheoremNames) {
     if (sym == null) return;
     String name = symbolName(sym);

--- a/src/evaluator/backends/base.py
+++ b/src/evaluator/backends/base.py
@@ -363,6 +363,8 @@ class Backend(ABC):
         early-verdict policy in their sibling backend base class.
         """
 
+        if not allow_materialization:
+            return SubmissionPlan(copy_solution=False)
         return SubmissionPlan()
 
     def resolve_infra_retries(self, configured: int | None) -> int:

--- a/src/evaluator/backends/copilot.py
+++ b/src/evaluator/backends/copilot.py
@@ -330,6 +330,46 @@ _COPILOT_ACTIVITY_EVENTS = frozenset(
 )
 
 
+def _stream_proves_model_activity(jsonl_path: str) -> bool:
+    """Detect native response/tool activity when Copilot OTel is incomplete."""
+
+    try:
+        with open(jsonl_path, encoding="utf-8") as stream:
+            for raw in stream:
+                try:
+                    event = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                event_type = event.get("type")
+                if event_type in {
+                    "tool.execution_start",
+                    "tool.execution_complete",
+                    "tool.execution_partial_result",
+                }:
+                    return True
+                if event_type != "assistant.message":
+                    continue
+                data = event.get("data")
+                if not isinstance(data, dict):
+                    continue
+                content = data.get("content")
+                if isinstance(content, str) and content:
+                    return True
+                if isinstance(content, list) and content:
+                    return True
+                requests = data.get("toolRequests")
+                if isinstance(requests, list) and requests:
+                    return True
+                output_tokens = nonnegative_int(data.get("outputTokens"))
+                if output_tokens:
+                    return True
+    except (OSError, UnicodeError):
+        return False
+    return False
+
+
 def _copilot_data(event: dict[str, Any]) -> dict[str, Any]:
     data = event.get("data")
     return data if isinstance(data, dict) else {}
@@ -663,6 +703,12 @@ class CopilotBackend(AgenticBackend):
 
     def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
         return {"tool_calls": _tool_call_summary(jsonl_path).to_dict()}
+
+    def retry_may_duplicate_model_work(self, jsonl_path: str) -> bool:
+        # Copilot may lose its terminal OTel/token totals when the native event
+        # stream is cut off after a response or edit. Those events still prove
+        # that replaying the launch could duplicate real model work.
+        return _stream_proves_model_activity(jsonl_path)
 
     def parse_output(self, jsonl_path: str) -> tuple[str, int, int]:
         lines: list[str] = []

--- a/src/evaluator/backends/cursor.py
+++ b/src/evaluator/backends/cursor.py
@@ -172,6 +172,36 @@ def _tool_call_summary(jsonl_path: str) -> toolcalls.ToolCallSummary:
     )
 
 
+def _stream_proves_model_activity(jsonl_path: str) -> bool:
+    """Detect native response/tool activity when Cursor omits terminal usage."""
+
+    try:
+        with open(jsonl_path, encoding="utf-8") as stream:
+            for raw in stream:
+                try:
+                    event = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                if event.get("type") == "tool_call" and _cursor_call(event) is not None:
+                    return True
+                if event.get("type") != "assistant":
+                    continue
+                message = event.get("message")
+                content = message.get("content") if isinstance(message, dict) else None
+                if isinstance(content, str) and content:
+                    return True
+                if isinstance(content, list) and any(
+                    isinstance(block, dict) and isinstance(block.get("text"), str) and bool(block["text"])
+                    for block in content
+                ):
+                    return True
+    except (OSError, UnicodeError):
+        return False
+    return False
+
+
 class CursorBackend(AgenticBackend):
     name = "cursor"
     requires_public_pricing = True
@@ -384,6 +414,12 @@ class CursorBackend(AgenticBackend):
 
     def parse_run_metadata(self, jsonl_path: str) -> dict[str, object]:
         return {"tool_calls": _tool_call_summary(jsonl_path).to_dict()}
+
+    def retry_may_duplicate_model_work(self, jsonl_path: str) -> bool:
+        # Cursor reports token usage only in its terminal result. A truncated
+        # stream can still contain assistant text and completed edits, which
+        # must be preserved instead of replayed as a zero-work launch.
+        return _stream_proves_model_activity(jsonl_path)
 
     @staticmethod
     def _summarize_args(kind: str, args: dict) -> str:

--- a/src/evaluator/modes/proof_from_scratch.py
+++ b/src/evaluator/modes/proof_from_scratch.py
@@ -1,77 +1,87 @@
-"""proof-from-scratch — proof from scratch.
+"""Manifest-driven module-level proof-from-scratch evaluation."""
 
-The benchmark file keeps the model (definitions, constants, variables,
-assumptions) and only the target theorem's statement, with `PROOF OBVIOUS`
-in place of its body. All other theorems and lemmas are stripped. The agent
-must invent the proof structure — including any helper lemmas — from scratch.
-
-Because the agent is allowed to add new lemmas above the target theorem,
-the strict proof-completion preamble-integrity check does not apply here.
-"""
-
+import os
 from functools import cached_property
 from pathlib import Path
 
-from common.proof_from_scratch_contract import TaskBoundary, load_proof_from_scratch_manifest
+from common.proof_from_scratch_manifest import ModuleTaskEntry, ModuleTaskManifest, load_module_task_manifest
+from common.proof_from_scratch_module import ModuleTaskSpec
 
 from .base import Mode
+
+MODULE_SUITE = "proof-from-scratch-module"
 
 
 class ProofFromScratch(Mode):
     name = "proof-from-scratch"
-    description = "Proof from scratch — agent invents the proof structure"
+    description = "Proof from scratch — one agent session proves every selected theorem in a module"
     read_only_dependencies = True
     canonical_replay_required = True
     requires_workspace_tools = True
 
-    @cached_property
-    def _boundaries(self) -> tuple[TaskBoundary, ...]:
-        # Keep a pickleable tuple on the mode: WorkItem sends this object to
-        # worker processes when the evaluator runs with --jobs > 1.
-        return tuple(load_proof_from_scratch_manifest(Path(self.benchmark_dir())).values())
+    def benchmark_dir(self) -> str:
+        return os.path.join(self._benchmark_root, MODULE_SUITE)
 
     @cached_property
-    def _boundaries_by_path(self) -> dict[Path, TaskBoundary]:
-        return {boundary.task_path: boundary for boundary in self._boundaries}
+    def _manifest(self) -> ModuleTaskManifest:
+        return load_module_task_manifest(
+            Path(self.benchmark_dir()),
+            corpus_manifest_path=Path(self._benchmark_root) / "proof-from-scratch" / "manifest.json",
+            source_root=Path(self._benchmark_root).parent / "source",
+        )
+
+    @cached_property
+    def _entries_by_path(self) -> dict[Path, ModuleTaskEntry]:
+        root = Path(self.benchmark_dir())
+        return {(root / entry.spec.task_id).resolve(): entry for entry in self._manifest.entries}
+
+    def _entry_for_path(self, benchmark_path: str) -> ModuleTaskEntry:
+        try:
+            resolved = Path(benchmark_path).resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
+            raise ValueError(f"proof-from-scratch module task does not exist: {benchmark_path}") from exc
+        entry = self._entries_by_path.get(resolved)
+        if entry is None:
+            raise ValueError(
+                f"proof-from-scratch module task is not declared in {self.benchmark_dir()}/manifest.json: "
+                f"{benchmark_path}"
+            )
+        return entry
 
     def is_benchmark_file(self, path: str) -> bool:
-        """Return whether ``path`` is a task declared by the manifest."""
+        """Return whether path is a complete module task declared by the manifest."""
 
         try:
             resolved = Path(path).resolve(strict=True)
         except (OSError, RuntimeError):
             return False
-        return resolved in self._boundaries_by_path
+        return resolved in self._entries_by_path
 
     def get_benchmark_files(self, filter_pattern: str | None = None) -> list[str]:
-        """Discover tasks exclusively from sorted manifest entries."""
+        """Discover complete module tasks exclusively from the shipped manifest."""
 
-        boundaries = self._boundaries
+        entries = self._manifest.entries
         if filter_pattern:
             patterns = [pattern.strip() for pattern in filter_pattern.split(",") if pattern.strip()]
-            boundaries = tuple(
-                boundary for boundary in boundaries if any(pattern in str(boundary.task_path) for pattern in patterns)
-            )
-        return [str(boundary.task_path) for boundary in boundaries]
+            entries = tuple(entry for entry in entries if any(pattern in entry.spec.task_id for pattern in patterns))
+        root = Path(self.benchmark_dir())
+        return [str((root / entry.spec.task_id).resolve()) for entry in entries]
 
     def specification_ids(self) -> dict[str, str]:
-        return {boundary.task_key: boundary.spec_id for boundary in self._boundaries}
+        return {entry.spec.task_id: entry.spec.task_id for entry in self._manifest.entries}
 
     def get_dependencies(self, benchmark_path: str) -> list[str]:
         """Return only the exact context declared for a manifest task."""
 
-        try:
-            resolved = Path(benchmark_path).resolve(strict=True)
-        except (OSError, RuntimeError) as exc:
-            raise ValueError(f"proof-from-scratch benchmark does not exist: {benchmark_path}") from exc
+        entry = self._entry_for_path(benchmark_path)
+        root = Path(self.benchmark_dir())
+        return [str((root / relative).resolve()) for relative in entry.context]
 
-        boundary = self._boundaries_by_path.get(resolved)
-        if boundary is None:
-            raise ValueError(
-                f"proof-from-scratch benchmark is not declared in {self.benchmark_dir()}/manifest.json: "
-                f"{benchmark_path}"
-            )
-        return [str(path) for path in boundary.context_paths]
+    def module_task_spec(self, benchmark_path: str) -> ModuleTaskSpec:
+        return self._entry_for_path(benchmark_path).spec
+
+    def module_task_entry(self, benchmark_path: str) -> ModuleTaskEntry:
+        return self._entry_for_path(benchmark_path)
 
     def build_one_shot_prompt(self, benchmark_path: str, dependencies: list[str]) -> str:
         del benchmark_path, dependencies

--- a/src/evaluator/prompts/proof-from-scratch.txt
+++ b/src/evaluator/prompts/proof-from-scratch.txt
@@ -1,52 +1,44 @@
 # Task
 
-Prove the target theorem in `{benchmark_basename}`. This is the only editable file. Every other TLA+ file in the workspace is read-only context supplied for this task.
+Prove every target theorem in {benchmark_basename}. This is the only editable file and represents one complete module task. Every other TLA+ file in the workspace is read-only context supplied for this module.
 
-Only edit inside these two marked regions:
+Only edit inside the `\* BEGIN AGENT HELPERS` ... `\* END AGENT HELPERS` region and each identified AGENT PROOF region (`\* BEGIN AGENT PROOF <proof-unit-id>` ... `\* END AGENT PROOF <proof-unit-id>`). Do not change the proof-unit IDs on the marker lines. You may choose the proof strategy and reuse any earlier sibling theorem once it is proved.
 
-```tla
-\* BEGIN AGENT HELPERS
-...
-\* END AGENT HELPERS
-
-\* BEGIN AGENT PROOF
-...
-\* END AGENT PROOF
-```
-
-Put fresh same-module operator definitions, module-level `USE DEF` / `HIDE DEF` directives, and fully proved named helper lemmas in the helper region. Put the target theorem's complete proof in the proof region.
+Put fresh same-module operator definitions, module-level USE DEF or HIDE DEF directives, and fully proved named helper lemmas in AGENT HELPERS. Put each target theorem's proof only in its matching identified proof region.
 
 # Proving and iterating
 
-Audited official proof libraries are available at `{tlapm_lib}` and `$COMMUNITY_LIB` (allowed modules are listed in `$TLAPS_PROOF_LIBRARY_CATALOG`); inside `AGENT HELPERS` you may add `LOCAL <alias> == INSTANCE <module>` from that catalog, but you must not modify library files or use `WITH`.
+Audited official proof libraries are available at {tlapm_lib} and $COMMUNITY_LIB. Allowed modules are listed in $TLAPS_PROOF_LIBRARY_CATALOG. Inside AGENT HELPERS you may add LOCAL <alias> == INSTANCE <module> from that catalog, but you must not modify library files or use `WITH`.
 
 You may run:
 
-```sh
+~~~sh
 {tlapm_path}/bin/tlapm -I {tlapm_lib} -I "$COMMUNITY_LIB" {benchmark_basename}
-```
+~~~
 
-Keep refining the proof until this authoritative check reports PASS:
+Keep refining the module until this authoritative check reports PASS:
 
-```sh
+~~~sh
 check_proof_bin {benchmark_basename} --mode proof-from-scratch
-```
+~~~
+
+The checker reports a raw result for every target and every helper theorem used by a target. A raw PASS counts only when all local theorem dependencies are also trusted, so a proof cannot rely on an omitted or circular sibling.
 
 For a quick syntax check, run:
 
-```sh
+~~~sh
 check_proof_bin {benchmark_basename} --mode proof-from-scratch --sany-only
-```
+~~~
 
-If you must stop early, leave your best partial proof in the target file.
+If you must stop early, leave your best partial proofs in the module. Independently trusted proof units still receive credit.
 
 # Constraints
 
-- Do not change the module header, imports, marker lines, target theorem statement, or any text outside the two editable regions.
+- Do not change the module header, imports, marker lines, theorem statements, theorem order, or any text outside the editable regions.
 - Do not modify, replace, or add dependency modules.
-- Do not add `EXTENDS`, nested modules, `CONSTANT`, `VARIABLE`, `ASSUME`, `ASSUMPTION`, or `AXIOM` declarations; `INSTANCE` is allowed only in the official-library form described above.
+- Do not add EXTENDS, nested modules, CONSTANT, VARIABLE, ASSUME, ASSUMPTION, or AXIOM declarations. INSTANCE is allowed only in the official-library form described above.
 - Every helper `LEMMA` or `THEOREM` must be named and fully proved.
-- Never use `PROOF OMITTED` or bare `OMITTED`, and never restate the target as an unproved or circular helper.
-- Bound the SMT/Z3 backend with a deterministic budget `SMTT("rN")` (for example `SMTT("r5")`), capped at `SMTT("r30")`; do not use the wall-clock forms `SMT` or `SMTT(n)`, and if a step needs more than the cap, decompose it rather than raising the budget.
-- New operator and lemma names must be fresh; do not shadow names from the task or its context.
+- Never use PROOF OMITTED or bare OMITTED, and never create a circular helper.
+- Bound the SMT/Z3 backend with a deterministic budget SMTT("rN"), capped at SMTT("r30"). Do not use the wall-clock forms SMT or SMTT(n).
+- New operator and lemma names must be fresh. Do not shadow names from the task or its context.
 - Do not browse or fetch external material. Work only from the files in this workspace and your knowledge of TLA+/TLAPS.

--- a/src/evaluator/proof_module_artifact.py
+++ b/src/evaluator/proof_module_artifact.py
@@ -1,0 +1,140 @@
+"""Content-addressed snapshots of complete submitted proof modules."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+
+MODULE_ARTIFACT_DIRECTORY = "module-artifacts"
+MODULE_ARTIFACT_SCHEMA_VERSION = 1
+
+
+class ModuleArtifactError(ValueError):
+    """A module artifact receipt cannot be tied to immutable bytes."""
+
+
+def _relative_path(digest: str) -> str:
+    return (PurePosixPath(MODULE_ARTIFACT_DIRECTORY) / digest[:2] / f"{digest}.tla").as_posix()
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _ensure_directory(root: Path, relative_parent: PurePosixPath) -> Path:
+    current = root
+    for part in relative_parent.parts:
+        current = current / part
+        created = False
+        try:
+            current.mkdir()
+            created = True
+        except FileExistsError:
+            pass
+        if current.is_symlink() or not current.is_dir():
+            raise ModuleArtifactError(f"module artifact directory component is unsafe: {current}")
+        if created:
+            _fsync_directory(current.parent)
+    return current
+
+
+def publish_module_artifact(output_dir: str | Path, content: bytes) -> dict[str, object]:
+    """Publish exact submission bytes once and return their strict receipt."""
+
+    if type(content) is not bytes or not content:
+        raise ModuleArtifactError("module artifact content must be non-empty bytes")
+    root = Path(output_dir).resolve()
+    digest = hashlib.sha256(content).hexdigest()
+    relative = PurePosixPath(_relative_path(digest))
+    parent = _ensure_directory(root, relative.parent)
+    path = parent / relative.name
+    if path.exists():
+        if path.is_symlink() or not path.is_file():
+            raise ModuleArtifactError(f"module artifact path is unsafe: {path}")
+        if path.read_bytes() != content:
+            raise ModuleArtifactError(f"module artifact path already contains different bytes: {path}")
+    else:
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{digest}.", suffix=".tmp", dir=parent)
+        try:
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
+            try:
+                os.link(temporary_name, path)
+            except FileExistsError:
+                if path.is_symlink() or path.read_bytes() != content:
+                    raise ModuleArtifactError(f"module artifact path raced with different bytes: {path}") from None
+            _fsync_directory(parent)
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(temporary_name)
+    return {
+        "schema_version": MODULE_ARTIFACT_SCHEMA_VERSION,
+        "sha256": digest,
+        "path": relative.as_posix(),
+        "byte_count": len(content),
+    }
+
+
+def read_module_artifact(output_dir: str | Path, receipt: object) -> bytes:
+    """Validate a receipt, path, and digest before returning reusable bytes."""
+
+    if type(receipt) is not dict or set(receipt) != {"schema_version", "sha256", "path", "byte_count"}:
+        raise ModuleArtifactError("module artifact receipt has an invalid shape")
+    if type(receipt["schema_version"]) is not int or receipt["schema_version"] != MODULE_ARTIFACT_SCHEMA_VERSION:
+        raise ModuleArtifactError(f"unsupported module artifact schema_version {receipt['schema_version']!r}")
+    digest = receipt["sha256"]
+    if type(digest) is not str or len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise ModuleArtifactError("module artifact receipt has an invalid SHA-256 digest")
+    expected_relative = _relative_path(digest)
+    if receipt["path"] != expected_relative:
+        raise ModuleArtifactError("module artifact receipt does not use its digest-owned path")
+    if type(receipt["byte_count"]) is not int or receipt["byte_count"] <= 0:
+        raise ModuleArtifactError("module artifact receipt has an invalid byte count")
+
+    root = Path(output_dir).resolve()
+    relative = PurePosixPath(expected_relative)
+    current = root
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink():
+            raise ModuleArtifactError(f"module artifact path cannot contain a symlink: {current}")
+    if not current.is_file():
+        raise ModuleArtifactError(f"module artifact is missing: {current}")
+    try:
+        content = current.read_bytes()
+    except OSError as exc:
+        raise ModuleArtifactError(f"cannot read module artifact {current}: {exc}") from exc
+    if len(content) != receipt["byte_count"] or hashlib.sha256(content).hexdigest() != digest:
+        raise ModuleArtifactError(f"module artifact no longer matches its receipt: {current}")
+    return content
+
+
+def result_module_artifact(result: Mapping[str, object]) -> object | None:
+    """Return the latest submission receipt, including continuation progress."""
+
+    continuations = result.get("continuations")
+    if isinstance(continuations, list):
+        for round_result in reversed(continuations):
+            if isinstance(round_result, Mapping) and round_result.get("module_artifact") is not None:
+                return round_result["module_artifact"]
+    return result.get("module_artifact")
+
+
+__all__ = [
+    "MODULE_ARTIFACT_DIRECTORY",
+    "MODULE_ARTIFACT_SCHEMA_VERSION",
+    "ModuleArtifactError",
+    "publish_module_artifact",
+    "read_module_artifact",
+    "result_module_artifact",
+]

--- a/src/evaluator/proof_module_checkpoint.py
+++ b/src/evaluator/proof_module_checkpoint.py
@@ -1,0 +1,396 @@
+"""Atomic per-module checkpoints for proof-from-scratch evaluation."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import re
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from evaluator.proof_module_artifact import ModuleArtifactError, read_module_artifact
+from evaluator.proof_module_result import ModuleResultError, validate_module_result
+
+MODULE_CHECKPOINT_DIRECTORY = "module-checkpoints"
+MODULE_CHECKPOINT_FORMAT_VERSION = 1
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ModuleCheckpointError(ValueError):
+    """Persisted module progress does not match the frozen run."""
+
+
+@dataclass(frozen=True)
+class ModuleCheckpointIdentity:
+    task_id: str
+    proof_unit_ids: tuple[str, ...]
+    canonical_input_sha256: str
+    run_identity_sha256: str
+
+    def __post_init__(self) -> None:
+        if type(self.task_id) is not str or not self.task_id.endswith(".tla"):
+            raise ModuleCheckpointError("module checkpoint task_id must be a non-empty .tla path")
+        if any(type(unit_id) is not str or not unit_id for unit_id in self.proof_unit_ids):
+            raise ModuleCheckpointError("module checkpoint proof_unit_ids must be non-empty strings")
+        if not self.proof_unit_ids or len(self.proof_unit_ids) != len(set(self.proof_unit_ids)):
+            raise ModuleCheckpointError("module checkpoint proof_unit_ids must be non-empty and unique")
+        for label, value in (
+            ("canonical_input_sha256", self.canonical_input_sha256),
+            ("run_identity_sha256", self.run_identity_sha256),
+        ):
+            if type(value) is not str or not _SHA256_RE.fullmatch(value):
+                raise ModuleCheckpointError(f"module checkpoint {label} must be a lowercase SHA-256 digest")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "task_id": self.task_id,
+            "proof_unit_ids": list(self.proof_unit_ids),
+            "canonical_input_sha256": self.canonical_input_sha256,
+            "run_identity_sha256": self.run_identity_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class ModuleCheckpoint:
+    identity: ModuleCheckpointIdentity
+    sequence: int
+    result: dict[str, object]
+
+
+def run_identity_sha256(run_identity: Mapping[str, object]) -> str:
+    """Hash semantic run inputs while leaving the informational Git revision out."""
+
+    comparable = {key: value for key, value in run_identity.items() if key != "benchmark_revision"}
+    try:
+        encoded = json.dumps(
+            comparable,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode()
+    except (TypeError, ValueError) as exc:
+        raise ModuleCheckpointError(f"run identity is not canonical JSON: {exc}") from exc
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def checkpoint_filename(task_id: str) -> str:
+    return f"module-{hashlib.sha256(task_id.encode()).hexdigest()}.json"
+
+
+def checkpoint_path(output_dir: str | Path, task_id: str) -> Path:
+    return Path(output_dir) / MODULE_CHECKPOINT_DIRECTORY / checkpoint_filename(task_id)
+
+
+def _reject_constant(value: str) -> Any:
+    raise ModuleCheckpointError(f"module checkpoint contains non-standard JSON constant {value}")
+
+
+def _without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ModuleCheckpointError(f"module checkpoint contains duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _parse_identity(raw: object) -> ModuleCheckpointIdentity:
+    keys = {"task_id", "proof_unit_ids", "canonical_input_sha256", "run_identity_sha256"}
+    if type(raw) is not dict or set(raw) != keys or type(raw["proof_unit_ids"]) is not list:
+        raise ModuleCheckpointError("module checkpoint identity has an invalid shape")
+    return ModuleCheckpointIdentity(
+        task_id=raw["task_id"],
+        proof_unit_ids=tuple(raw["proof_unit_ids"]),
+        canonical_input_sha256=raw["canonical_input_sha256"],
+        run_identity_sha256=raw["run_identity_sha256"],
+    )
+
+
+def _validate_result(
+    output_dir: str | Path,
+    identity: ModuleCheckpointIdentity,
+    result: object,
+) -> dict[str, object]:
+    if type(result) is not dict:
+        raise ModuleCheckpointError("module checkpoint result must be an object")
+    if result.get("benchmark") != identity.task_id:
+        raise ModuleCheckpointError("module checkpoint result names the wrong task")
+    if result.get("proof_unit_ids") != list(identity.proof_unit_ids):
+        raise ModuleCheckpointError("module checkpoint result proof-unit IDs differ from the task identity")
+    if type(result.get("proof_unit_count")) is not int or result["proof_unit_count"] != len(identity.proof_unit_ids):
+        raise ModuleCheckpointError("module checkpoint result has the wrong proof-unit count")
+
+    def validate_attempt(attempt: dict[str, object], *, label: str) -> None:
+        verdict = attempt.get("check_verdict")
+        if type(verdict) is not str or verdict not in {"PASS", "FAIL", "TIMEOUT", "ERROR", "CHEATING"}:
+            raise ModuleCheckpointError(f"module checkpoint {label} has an invalid checker verdict")
+        module_result = attempt.get("module_result")
+        invalid_after_interruption = attempt.get("invalid_submission_after_interruption")
+        if invalid_after_interruption is not None:
+            if invalid_after_interruption is not True:
+                raise ModuleCheckpointError(f"module checkpoint {label} has an invalid interrupted-submission marker")
+            if (
+                attempt.get("termination_reason") not in {"INFRA_ERROR", "QUOTA_EXHAUSTED"}
+                or verdict != "FAIL"
+                or module_result is not None
+                or attempt.get("module_artifact") is not None
+                or attempt.get("graded_after_interruption") is not None
+            ):
+                raise ModuleCheckpointError(
+                    f"module checkpoint {label} has an inconsistent interrupted-submission failure"
+                )
+        if module_result is None:
+            if verdict == "PASS":
+                raise ModuleCheckpointError(
+                    f"module checkpoint {label} records PASS without a complete module checker result"
+                )
+            return
+        if attempt.get("module_artifact") is None:
+            raise ModuleCheckpointError(f"module checkpoint {label} has a checker result without an artifact")
+        try:
+            validated = validate_module_result(module_result, identity.proof_unit_ids)
+        except ModuleResultError as exc:
+            raise ModuleCheckpointError(f"module checkpoint contains an invalid {label} checker result: {exc}") from exc
+        trusted_targets = validated["trusted_proof_unit_ids"]
+        if type(attempt.get("proof_unit_count")) is not int or attempt["proof_unit_count"] != len(
+            identity.proof_unit_ids
+        ):
+            raise ModuleCheckpointError(f"module checkpoint {label} has the wrong proof-unit count")
+        if type(attempt.get("trusted_proof_unit_count")) is not int or attempt["trusted_proof_unit_count"] != len(
+            trusted_targets
+        ):
+            raise ModuleCheckpointError(f"module checkpoint {label} has the wrong trusted proof-unit count")
+        if attempt.get("trusted_proof_unit_ids") != trusted_targets:
+            raise ModuleCheckpointError(f"module checkpoint {label} has inconsistent trusted proof-unit IDs")
+        if verdict == "PASS" and not validated["complete"]:
+            raise ModuleCheckpointError(f"module checkpoint {label} records PASS for an incomplete module")
+        if validated["complete"] and verdict != "PASS":
+            raise ModuleCheckpointError(f"module checkpoint {label} does not record PASS for a complete module")
+
+    validate_attempt(result, label="first attempt")
+    continuations = result.get("continuations")
+    max_continuations = result.get("max_continuations", 0)
+    if type(max_continuations) is not int or max_continuations < 0:
+        raise ModuleCheckpointError("module checkpoint max_continuations must be a non-negative integer")
+    if continuations is not None:
+        if type(continuations) is not list or any(type(round_result) is not dict for round_result in continuations):
+            raise ModuleCheckpointError("module checkpoint continuations must be a list of objects")
+        if len(continuations) > max_continuations:
+            raise ModuleCheckpointError("module checkpoint exceeds its configured continuation budget")
+        if result.get("check_verdict") == "PASS" and continuations:
+            raise ModuleCheckpointError("module checkpoint cannot continue after a first-attempt PASS")
+        passed_round = False
+        for index, round_result in enumerate(continuations, start=1):
+            if passed_round:
+                raise ModuleCheckpointError("module checkpoint cannot continue after a passing continuation")
+            if round_result.get("round") != index:
+                raise ModuleCheckpointError("module checkpoint continuation rounds must be consecutive and one-based")
+            validate_attempt(round_result, label=f"continuation {index}")
+            passed_round = round_result.get("check_verdict") == "PASS"
+
+    interrupted_continuations = result.get("interrupted_continuations")
+    if interrupted_continuations is not None:
+        if type(interrupted_continuations) is not list or any(
+            type(round_result) is not dict for round_result in interrupted_continuations
+        ):
+            raise ModuleCheckpointError("module checkpoint interrupted continuations must be a list of objects")
+        for index, round_result in enumerate(interrupted_continuations, start=1):
+            round_number = round_result.get("round")
+            if type(round_number) is not int or not 1 <= round_number <= max_continuations:
+                raise ModuleCheckpointError("module checkpoint interrupted continuation has an invalid round")
+            if round_result.get("termination_reason") not in {"INFRA_ERROR", "QUOTA_EXHAUSTED"}:
+                raise ModuleCheckpointError(
+                    "module checkpoint interrupted continuation must record an infra or quota interruption"
+                )
+            validate_attempt(round_result, label=f"interrupted continuation {index}")
+
+    pending_grading = result.get("module_grading_pending")
+    if pending_grading is not None:
+        if type(pending_grading) is not int or pending_grading < 0:
+            raise ModuleCheckpointError("module checkpoint pending grading round must be a non-negative integer")
+        if pending_grading == 0:
+            pending_attempt = result
+        elif not isinstance(continuations, list) or pending_grading != len(continuations):
+            raise ModuleCheckpointError("module checkpoint pending grading must identify the latest continuation")
+        else:
+            pending_attempt = continuations[-1]
+        if pending_attempt.get("module_result") is not None:
+            raise ModuleCheckpointError("module checkpoint cannot mark an already graded attempt as pending")
+        if pending_attempt.get("module_artifact") is None:
+            raise ModuleCheckpointError("module checkpoint pending grading requires a preserved module artifact")
+
+    artifact_attempts = [result]
+    if isinstance(continuations, list):
+        artifact_attempts.extend(continuations)
+    if isinstance(interrupted_continuations, list):
+        artifact_attempts.extend(interrupted_continuations)
+    for attempt in artifact_attempts:
+        receipt = attempt.get("module_artifact")
+        if receipt is not None:
+            try:
+                read_module_artifact(output_dir, receipt)
+            except ModuleArtifactError as exc:
+                raise ModuleCheckpointError(f"module checkpoint contains an invalid artifact: {exc}") from exc
+    return dict(result)
+
+
+def load_module_checkpoint(
+    output_dir: str | Path,
+    expected_identity: ModuleCheckpointIdentity,
+) -> ModuleCheckpoint:
+    path = checkpoint_path(output_dir, expected_identity.task_id)
+    if path.is_symlink() or not path.is_file():
+        raise ModuleCheckpointError(f"module checkpoint is not a regular file: {path}")
+    try:
+        raw = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_without_duplicates,
+            parse_constant=_reject_constant,
+        )
+    except ModuleCheckpointError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ModuleCheckpointError(f"cannot read module checkpoint {path}: {exc}") from exc
+    if type(raw) is not dict or set(raw) != {"format_version", "identity", "sequence", "result"}:
+        raise ModuleCheckpointError(f"module checkpoint {path} has an invalid shape")
+    if type(raw["format_version"]) is not int or raw["format_version"] != MODULE_CHECKPOINT_FORMAT_VERSION:
+        raise ModuleCheckpointError(f"unsupported module checkpoint format_version {raw['format_version']!r}")
+    identity = _parse_identity(raw["identity"])
+    if identity != expected_identity:
+        raise ModuleCheckpointError(f"module checkpoint identity differs from the current run for {identity.task_id!r}")
+    if type(raw["sequence"]) is not int or raw["sequence"] <= 0:
+        raise ModuleCheckpointError("module checkpoint sequence must be a positive integer")
+    result = _validate_result(output_dir, identity, raw["result"])
+    return ModuleCheckpoint(identity=identity, sequence=raw["sequence"], result=result)
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def write_module_checkpoint(
+    output_dir: str | Path,
+    identity: ModuleCheckpointIdentity,
+    result: Mapping[str, object],
+) -> ModuleCheckpoint:
+    root = Path(output_dir)
+    directory = root / MODULE_CHECKPOINT_DIRECTORY
+    directory.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path(root, identity.task_id)
+    if path.is_symlink():
+        raise ModuleCheckpointError(f"module checkpoint path is unsafe: {path}")
+    frozen_result = _validate_result(root, identity, dict(result))
+    previous = load_module_checkpoint(root, identity) if path.exists() else None
+    if previous is not None and previous.result == frozen_result:
+        return previous
+    sequence = 1 if previous is None else previous.sequence + 1
+    checkpoint = ModuleCheckpoint(identity=identity, sequence=sequence, result=frozen_result)
+    payload = {
+        "format_version": MODULE_CHECKPOINT_FORMAT_VERSION,
+        "identity": identity.as_dict(),
+        "sequence": sequence,
+        "result": frozen_result,
+    }
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=directory)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, indent=2, allow_nan=False)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_name, path)
+        _fsync_directory(directory)
+    except (OSError, TypeError, ValueError) as exc:
+        raise ModuleCheckpointError(f"cannot write module checkpoint {path}: {exc}") from exc
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary_name)
+    return checkpoint
+
+
+def prepare_module_checkpoints(
+    output_dir: str | Path,
+    identities: Mapping[str, ModuleCheckpointIdentity],
+    *,
+    resume: bool,
+) -> dict[str, ModuleCheckpoint]:
+    """Validate the checkpoint cohort and load all durable module progress."""
+
+    if not identities:
+        raise ModuleCheckpointError("module checkpoint cohort must not be empty")
+    root = Path(output_dir)
+    directory = root / MODULE_CHECKPOINT_DIRECTORY
+    if not resume:
+        existing_run_state = [
+            name
+            for name in ("results.json", "run-manifest.json", "task-list.json", "module-artifacts")
+            if (root / name).exists() or (root / name).is_symlink()
+        ]
+        if existing_run_state:
+            raise ModuleCheckpointError(
+                f"module output already contains run state {sorted(existing_run_state)}; use --resume or a new directory"
+            )
+    if not directory.exists():
+        if resume:
+            return {}
+        directory.mkdir(parents=True)
+        return {}
+    if directory.is_symlink() or not directory.is_dir():
+        raise ModuleCheckpointError(f"module checkpoint directory is unsafe: {directory}")
+    expected_names = {checkpoint_filename(task_id) for task_id in identities}
+    entries = tuple(directory.iterdir())
+
+    def owned_temporary(path: Path) -> bool:
+        return (
+            path.is_file()
+            and not path.is_symlink()
+            and path.name.endswith(".tmp")
+            and any(path.name.startswith(f".{checkpoint_name}.") for checkpoint_name in expected_names)
+        )
+
+    actual_names = {path.name for path in entries if not owned_temporary(path)}
+    unexpected = actual_names - expected_names
+    if unexpected:
+        raise ModuleCheckpointError(f"module checkpoint directory contains unexpected entries: {sorted(unexpected)}")
+    if actual_names and not resume:
+        raise ModuleCheckpointError("module checkpoints already exist; use --resume with the same run inputs")
+    if actual_names and resume:
+        missing_records = [
+            name
+            for name in ("task-list.json", "run-manifest.json")
+            if not (root / name).is_file() or (root / name).is_symlink()
+        ]
+        if missing_records:
+            raise ModuleCheckpointError(
+                f"module checkpoints cannot resume without recorded run inputs: {sorted(missing_records)}"
+            )
+    checkpoints: dict[str, ModuleCheckpoint] = {}
+    for task_id, identity in identities.items():
+        if checkpoint_filename(task_id) in actual_names:
+            checkpoints[task_id] = load_module_checkpoint(output_dir, identity)
+    return checkpoints
+
+
+__all__ = [
+    "MODULE_CHECKPOINT_DIRECTORY",
+    "MODULE_CHECKPOINT_FORMAT_VERSION",
+    "ModuleCheckpoint",
+    "ModuleCheckpointError",
+    "ModuleCheckpointIdentity",
+    "checkpoint_filename",
+    "checkpoint_path",
+    "load_module_checkpoint",
+    "prepare_module_checkpoints",
+    "run_identity_sha256",
+    "write_module_checkpoint",
+]

--- a/src/evaluator/proof_module_result.py
+++ b/src/evaluator/proof_module_result.py
@@ -1,0 +1,223 @@
+"""Validation for machine-readable module checker results."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from common.proof_from_scratch_module import ModuleTaskContractError, compute_trusted_units
+
+MODULE_RESULT_SCHEMA_VERSION = 1
+MODULE_RESULT_PREFIX = "MODULE-RESULT: "
+RAW_VERDICTS = frozenset({"PASS", "FAIL", "UNRESOLVED", "TIMEOUT", "ERROR"})
+
+
+class ModuleResultError(ValueError):
+    """A module checker result is missing or internally inconsistent."""
+
+
+def _reject_constant(value: str) -> Any:
+    raise ModuleResultError(f"module result contains non-standard JSON constant {value}")
+
+
+def _without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ModuleResultError(f"module result contains duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _string_list(value: object, *, label: str) -> list[str]:
+    if type(value) is not list or any(type(item) is not str or not item for item in value):
+        raise ModuleResultError(f"{label} must be a list of non-empty strings")
+    if len(value) != len(set(value)):
+        raise ModuleResultError(f"{label} must not contain duplicates")
+    return value
+
+
+def validate_module_result(raw: object, expected_unit_ids: Iterable[str]) -> dict[str, object]:
+    """Validate checker output and recompute dependency-closed trust."""
+
+    expected = tuple(expected_unit_ids)
+    if not expected or len(expected) != len(set(expected)):
+        raise ModuleResultError("expected proof-unit IDs must be non-empty and unique")
+    if type(raw) is not dict:
+        raise ModuleResultError("module result must be an object")
+    required = {
+        "schema_version",
+        "sany_status",
+        "proof_unit_ids",
+        "units",
+        "trusted_unit_ids",
+        "trusted_proof_unit_ids",
+        "complete",
+    }
+    allowed = required | {"unused_helper_names", "integrity_issues"}
+    if not required <= set(raw) or set(raw) - allowed:
+        raise ModuleResultError("module result has missing or unknown fields")
+    if type(raw["schema_version"]) is not int or raw["schema_version"] != MODULE_RESULT_SCHEMA_VERSION:
+        raise ModuleResultError(f"unsupported module result schema_version {raw['schema_version']!r}")
+    if type(raw["sany_status"]) is not str or raw["sany_status"] not in {"valid", "invalid"}:
+        raise ModuleResultError("module result sany_status must be valid or invalid")
+    if tuple(_string_list(raw["proof_unit_ids"], label="proof_unit_ids")) != expected:
+        raise ModuleResultError("module result proof-unit IDs differ from the selected module task")
+    if type(raw["complete"]) is not bool:
+        raise ModuleResultError("module result complete must be a boolean")
+    trusted_ids = _string_list(raw["trusted_unit_ids"], label="trusted_unit_ids")
+    trusted_targets = _string_list(raw["trusted_proof_unit_ids"], label="trusted_proof_unit_ids")
+    if tuple(unit_id for unit_id in expected if unit_id in trusted_targets) != tuple(trusted_targets):
+        raise ModuleResultError("trusted proof-unit IDs must preserve manifest order")
+    if not set(trusted_targets) <= set(expected):
+        raise ModuleResultError("trusted proof-unit IDs contain an unknown target")
+
+    units = raw["units"]
+    if type(units) is not list:
+        raise ModuleResultError("module result units must be a list")
+    normalized_units: list[dict[str, object]] = []
+    dependencies: dict[str, tuple[str, ...]] = {}
+    raw_pass: set[str] = set()
+    seen: set[str] = set()
+    unit_keys = {
+        "unit_id",
+        "kind",
+        "theorem_name",
+        "line_start",
+        "line_end",
+        "dependencies",
+        "raw_verdict",
+        "tlapm_exit",
+        "missing_proofs",
+        "obligation_failed",
+        "trusted",
+    }
+    for index, value in enumerate(units):
+        if type(value) is not dict or set(value) != unit_keys:
+            raise ModuleResultError(f"module result unit {index} has an invalid shape")
+        unit_id = value["unit_id"]
+        if type(unit_id) is not str or not unit_id or unit_id in seen:
+            raise ModuleResultError(f"module result unit {index} has an invalid or repeated unit_id")
+        seen.add(unit_id)
+        kind = value["kind"]
+        if type(kind) is not str or kind not in {"target", "helper"}:
+            raise ModuleResultError(f"module result unit {unit_id!r} has an invalid kind")
+        if kind == "target" and unit_id not in expected:
+            raise ModuleResultError(f"module result contains unknown target unit {unit_id!r}")
+        if kind == "helper" and not unit_id.startswith("helper:"):
+            raise ModuleResultError(f"module result helper {unit_id!r} has an invalid identity")
+        theorem_name = value["theorem_name"]
+        if theorem_name is not None and (type(theorem_name) is not str or not theorem_name):
+            raise ModuleResultError(f"module result unit {unit_id!r} has an invalid theorem_name")
+        if any(type(value[field]) is not int or value[field] <= 0 for field in ("line_start", "line_end")):
+            raise ModuleResultError(f"module result unit {unit_id!r} has invalid line bounds")
+        if value["line_end"] < value["line_start"]:
+            raise ModuleResultError(f"module result unit {unit_id!r} has reversed line bounds")
+        deps = tuple(_string_list(value["dependencies"], label=f"dependencies for {unit_id!r}"))
+        dependencies[unit_id] = deps
+        verdict = value["raw_verdict"]
+        if type(verdict) is not str or verdict not in RAW_VERDICTS:
+            raise ModuleResultError(f"module result unit {unit_id!r} has an invalid raw_verdict")
+        tlapm_exit = value["tlapm_exit"]
+        if tlapm_exit is not None and (type(tlapm_exit) is not int):
+            raise ModuleResultError(f"module result unit {unit_id!r} has an invalid tlapm_exit")
+        missing_proofs = value["missing_proofs"]
+        if missing_proofs is not None and (type(missing_proofs) is not int or missing_proofs < 0):
+            raise ModuleResultError(f"module result unit {unit_id!r} has invalid missing_proofs")
+        obligation_failed = value["obligation_failed"]
+        if obligation_failed is not None and type(obligation_failed) is not bool:
+            raise ModuleResultError(f"module result unit {unit_id!r} has invalid obligation_failed")
+        if verdict == "PASS" and (tlapm_exit != 0 or missing_proofs != 0 or obligation_failed is not False):
+            raise ModuleResultError(f"module result unit {unit_id!r} has inconsistent PASS evidence")
+        if verdict == "FAIL" and (tlapm_exit is None or missing_proofs is None or obligation_failed is None):
+            raise ModuleResultError(f"module result unit {unit_id!r} has incomplete FAIL evidence")
+        if verdict == "UNRESOLVED" and (
+            tlapm_exit is not None or missing_proofs is None or missing_proofs < 1 or obligation_failed is not False
+        ):
+            raise ModuleResultError(f"module result unit {unit_id!r} has inconsistent UNRESOLVED evidence")
+        if verdict in {"TIMEOUT", "ERROR"} and (
+            tlapm_exit is not None or missing_proofs is not None or obligation_failed is not None
+        ):
+            raise ModuleResultError(f"module result unit {unit_id!r} has inconsistent {verdict} evidence")
+        if verdict == "PASS":
+            raw_pass.add(unit_id)
+        if type(value["trusted"]) is not bool:
+            raise ModuleResultError(f"module result unit {unit_id!r} trusted must be a boolean")
+        normalized_units.append(dict(value))
+
+    integrity = raw.get("integrity_issues")
+    if integrity is not None:
+        if type(integrity) is not list or any(
+            type(issue) is not dict
+            or set(issue) != {"code", "message"}
+            or type(issue["code"]) is not str
+            or not issue["code"]
+            or type(issue["message"]) is not str
+            for issue in integrity
+        ):
+            raise ModuleResultError("module result integrity_issues has an invalid shape")
+    unused = raw.get("unused_helper_names", [])
+    _string_list(unused, label="unused_helper_names")
+
+    if raw["sany_status"] != "valid" or integrity:
+        if units or trusted_ids or trusted_targets or raw["complete"]:
+            raise ModuleResultError("an invalid or integrity-failing module result cannot contain trusted proof data")
+        return dict(raw)
+
+    target_order = [unit["unit_id"] for unit in normalized_units if unit["kind"] == "target"]
+    if target_order != list(expected):
+        raise ModuleResultError("module result must contain every target unit in manifest order")
+    unknown_dependencies = {dependency for values in dependencies.values() for dependency in values} - set(dependencies)
+    if unknown_dependencies:
+        raise ModuleResultError(f"module result contains unknown local dependencies: {sorted(unknown_dependencies)}")
+    try:
+        recomputed = compute_trusted_units(raw_pass, dependencies)
+    except ModuleTaskContractError as exc:
+        raise ModuleResultError(f"module result dependency graph is invalid: {exc}") from exc
+    if set(trusted_ids) != set(recomputed):
+        raise ModuleResultError("module result trusted-unit set does not match dependency-closed raw passes")
+    if any(value["trusted"] != (value["unit_id"] in recomputed) for value in normalized_units):
+        raise ModuleResultError("module result per-unit trust flags do not match the trusted-unit set")
+    recomputed_targets = [unit_id for unit_id in expected if unit_id in recomputed]
+    if trusted_targets != recomputed_targets:
+        raise ModuleResultError("module result trusted proof-unit list does not match the trusted-unit set")
+    if raw["complete"] != (len(recomputed_targets) == len(expected)):
+        raise ModuleResultError("module result complete flag does not match trusted proof-unit coverage")
+    return dict(raw)
+
+
+def parse_module_result_json(text: str, expected_unit_ids: Iterable[str]) -> dict[str, object]:
+    """Parse strict JSON and validate all checker-owned trust fields."""
+
+    if type(text) is not str or not text:
+        raise ModuleResultError("module result JSON must be a non-empty string")
+    try:
+        raw = json.loads(
+            text,
+            object_pairs_hook=_without_duplicates,
+            parse_constant=_reject_constant,
+        )
+    except ModuleResultError:
+        raise
+    except json.JSONDecodeError as exc:
+        raise ModuleResultError(
+            f"invalid module result JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        ) from exc
+    return validate_module_result(raw, expected_unit_ids)
+
+
+def module_result_from_result(result: Mapping[str, object]) -> dict[str, object] | None:
+    value = result.get("module_result")
+    return value if isinstance(value, dict) else None
+
+
+__all__ = [
+    "MODULE_RESULT_SCHEMA_VERSION",
+    "MODULE_RESULT_PREFIX",
+    "RAW_VERDICTS",
+    "ModuleResultError",
+    "module_result_from_result",
+    "parse_module_result_json",
+    "validate_module_result",
+]

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -16,10 +16,12 @@ Usage:
 
 import argparse
 import contextlib
+import copy
 import fcntl
 import glob
 import hashlib
 import json
+import math
 import os
 import random
 import re
@@ -67,6 +69,22 @@ from evaluator.backends.base import Backend, SubmissionDisposition
 from evaluator.cost import calculate_equivalent_cost_usd, public_price_error
 from evaluator.modes import get_mode, list_modes
 from evaluator.modes.base import Mode
+from evaluator.proof_module_artifact import (
+    ModuleArtifactError,
+    publish_module_artifact,
+    read_module_artifact,
+    result_module_artifact,
+)
+from evaluator.proof_module_checkpoint import (
+    ModuleCheckpointError,
+    ModuleCheckpointIdentity,
+    prepare_module_checkpoints,
+    write_module_checkpoint,
+)
+from evaluator.proof_module_checkpoint import (
+    run_identity_sha256 as module_run_identity_sha256,
+)
+from evaluator.proof_module_result import MODULE_RESULT_PREFIX, ModuleResultError, parse_module_result_json
 from evaluator.score import (
     SCORERS,
     applicable_manifest_results,
@@ -77,6 +95,7 @@ from evaluator.score import (
     is_skipped,
     n_non_genuine,
     n_skipped,
+    proof_unit_rate_line,
     scope_specification_ids,
     specification_score_lines,
     weighted_score,
@@ -91,6 +110,7 @@ SKILLS_DIR = os.path.join(REPO_ROOT, "skills")
 TASK_LIST_RECORD = "task-list.json"
 RUN_MANIFEST_RECORD = "run-manifest.json"
 NAMED_TASK_LISTS = {"core": "core.txt"}
+SESSION_KEY_SCHEME = "mode-relative-task-v1"
 
 VERDICT_ICONS = {"PASS": "✅", "FAIL": "❌", "CHEATING": "⚠️", "TIMEOUT": "⏱️", "ERROR": "💥"}
 
@@ -463,6 +483,34 @@ def wait_for_memory(min_free_gb: float, max_waits: int, log_prefix: str = "") ->
 _summary_lock = threading.Lock()
 
 
+MODULE_RESUME_RETRY_FIRST = "retry-first-attempt"
+MODULE_RESUME_GRADE_SAVED = "grade-saved-submission"
+MODULE_RESUME_CONTINUE = "run-next-continuation"
+MODULE_RESUME_COMPLETE = "complete"
+
+
+@dataclass(frozen=True)
+class ModuleResume:
+    """Validated durable state needed to resume one module task exactly."""
+
+    action: str
+    result: dict[str, object]
+    submission: bytes | None
+    artifact_receipt: dict[str, object] | None
+    checkpoint_sequence: int
+
+    def __post_init__(self) -> None:
+        if self.action not in {
+            MODULE_RESUME_RETRY_FIRST,
+            MODULE_RESUME_GRADE_SAVED,
+            MODULE_RESUME_CONTINUE,
+            MODULE_RESUME_COMPLETE,
+        }:
+            raise ValueError(f"unknown module resume action {self.action!r}")
+        if self.checkpoint_sequence <= 0:
+            raise ValueError("module resume checkpoint sequence must be positive")
+
+
 @dataclass
 class WorkItem:
     """A single (benchmark, backend, mode) task fed to the worker pool."""
@@ -501,7 +549,12 @@ class WorkItem:
     session_dir: str = ""
     # Replay-required modes capture every task before the worker pool starts.
     canonical_inputs: "CanonicalInputs | None" = None
+    # One process-wide byte snapshot is shared by every work item so parallel
+    # modules and a resume cannot observe different project skill inputs.
+    agent_skills_snapshot: "AgentSkillsSnapshot | None" = None
     run_identity: dict[str, object] | None = None
+    module_resume: ModuleResume | None = None
+    module_checkpoint_identity: ModuleCheckpointIdentity | None = None
 
 
 @dataclass(frozen=True)
@@ -535,6 +588,101 @@ class CanonicalInputs:
         if self.proof_library_catalog is not None:
             _write_bytes(os.path.join(destination, CATALOG_FILENAME), self.proof_library_catalog)
 
+    def digest(self) -> str:
+        digest = hashlib.sha256()
+
+        def update(value: bytes) -> None:
+            digest.update(len(value).to_bytes(8, byteorder="big"))
+            digest.update(value)
+
+        update(b"proof-module-canonical-input-v1")
+        update(self.target_name.encode())
+        update(self.target_bytes)
+        for name, content in self.dependencies:
+            update(name.encode())
+            update(content)
+        update(self.proof_library_catalog or b"")
+        return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class AgentSkillFile:
+    """One regular file in a frozen project Agent Skill catalog."""
+
+    relative_path: str
+    content: bytes
+    mode: int
+
+
+@dataclass(frozen=True)
+class AgentSkillsSnapshot:
+    """Portable, immutable bytes supplied to every agent in one run."""
+
+    names: tuple[str, ...]
+    directories: tuple[tuple[str, int], ...]
+    files: tuple[AgentSkillFile, ...]
+
+    @classmethod
+    def capture(cls, backend: Backend, root: str | Path) -> "AgentSkillsSnapshot":
+        if backend.project_skills_dir is None:
+            return cls((), (), ())
+
+        root = Path(root)
+        skills = discover_agent_skills(root)
+        directories: list[tuple[str, int]] = []
+        files: list[AgentSkillFile] = []
+        for skill in skills:
+            paths = [skill.source_dir, *skill.source_dir.rglob("*")]
+            for path in sorted(paths, key=lambda candidate: candidate.relative_to(root).as_posix()):
+                relative = path.relative_to(root).as_posix()
+                if path.is_symlink():
+                    raise ValueError(f"Agent Skill snapshots do not allow symlinks: {path}")
+                metadata = path.stat()
+                mode = stat.S_IMODE(metadata.st_mode)
+                if stat.S_ISDIR(metadata.st_mode):
+                    directories.append((relative, mode))
+                elif stat.S_ISREG(metadata.st_mode):
+                    files.append(AgentSkillFile(relative, path.read_bytes(), mode))
+                else:
+                    raise ValueError(f"Agent Skill snapshots require regular files and directories: {path}")
+        return cls(
+            tuple(skill.name for skill in skills),
+            tuple(directories),
+            tuple(files),
+        )
+
+    def digest(self) -> str:
+        digest = hashlib.sha256()
+        _update_identity_digest(digest, b"agent-skills-snapshot-v1")
+        for name in self.names:
+            _update_identity_digest(digest, b"name")
+            _update_identity_digest(digest, name.encode())
+        for relative, mode in self.directories:
+            _update_identity_digest(digest, b"directory")
+            _update_identity_digest(digest, relative.encode())
+            _update_identity_digest(digest, mode.to_bytes(4, byteorder="big"))
+        for skill_file in self.files:
+            _update_identity_digest(digest, b"file")
+            _update_identity_digest(digest, skill_file.relative_path.encode())
+            _update_identity_digest(digest, skill_file.mode.to_bytes(4, byteorder="big"))
+            _update_identity_digest(digest, skill_file.content)
+        return digest.hexdigest()
+
+    def materialize(self, destination: str | Path) -> None:
+        destination = Path(destination)
+        destination.mkdir(parents=True, exist_ok=True)
+        if any(destination.iterdir()):
+            raise ValueError(f"Agent Skill snapshot destination must be empty: {destination}")
+        for relative, mode in self.directories:
+            path = destination / relative
+            path.mkdir(parents=True, exist_ok=False)
+            path.chmod(mode)
+        for skill_file in self.files:
+            path = destination / skill_file.relative_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(skill_file.content)
+            path.chmod(skill_file.mode)
+
 
 def _read_bytes(path: str) -> bytes:
     with open(path, "rb") as stream:
@@ -546,17 +694,16 @@ def _write_bytes(path: str, content: bytes) -> None:
         stream.write(content)
 
 
-def _snapshot_agent_skills(backend: Backend, destination: str) -> list[str]:
+def _snapshot_agent_skills(
+    backend: Backend,
+    destination: str,
+    snapshot: AgentSkillsSnapshot | None = None,
+) -> list[str]:
     """Capture the catalog this backend can discover and return its skill names."""
 
-    os.makedirs(destination, exist_ok=True)
-    if backend.project_skills_dir is None:
-        return []
-
-    skills = discover_agent_skills(SKILLS_DIR)
-    for skill in skills:
-        shutil.copytree(skill.source_dir, os.path.join(destination, skill.name))
-    return [skill.name for skill in skills]
+    snapshot = snapshot or AgentSkillsSnapshot.capture(backend, SKILLS_DIR)
+    snapshot.materialize(destination)
+    return list(snapshot.names)
 
 
 def _copy_skills_to_workspace(skills_snapshot_dir: str, workspace: str, project_skills_dir: str) -> None:
@@ -610,6 +757,7 @@ def _make_workspace(
     skills_snapshot_dir: str | None = None,
     project_skills_dir: str | None = None,
     read_only_dependencies: bool = False,
+    initial_target_bytes: bytes | None = None,
 ) -> str:
     """Create a fresh Git workspace with canonical inputs and project skills.
 
@@ -618,6 +766,8 @@ def _make_workspace(
     workspace = tempfile.mkdtemp(prefix=f"{backend_name}_bench_{name_no_ext}_")
     try:
         canonical_inputs.materialize(workspace)
+        if initial_target_bytes is not None:
+            _write_bytes(os.path.join(workspace, canonical_inputs.target_name), initial_target_bytes)
         if project_skills_dir is not None:
             if skills_snapshot_dir is None:
                 raise ValueError("a skills snapshot is required when project skill discovery is enabled")
@@ -659,6 +809,7 @@ class ExecutionOutcome:
     quota_exhausted: bool
     quota_retry_suppressed: bool
     infra_retriable: bool  # still a no-model-work infra failure after all retries
+    model_work_observed: bool
     infra_reasons: list[str]
     usage: UsageSummary
 
@@ -730,6 +881,7 @@ def _run_backend_with_retries(
 
             canonical_dir = _make_canonical_dir(name_no_ext, canonical_inputs)
             if fixed_workspace is None:
+                resume_submission = item.module_resume.submission if item.module_resume is not None else None
                 workspace = _make_workspace(
                     backend.name,
                     name_no_ext,
@@ -737,6 +889,7 @@ def _run_backend_with_retries(
                     skills_snapshot_dir=skills_snapshot_dir,
                     project_skills_dir=backend.project_skills_dir,
                     read_only_dependencies=read_only_dependencies,
+                    initial_target_bytes=resume_submission,
                 )
 
             wait_for_memory(item.min_free_gb, 120, log_prefix=f"[{name_no_ext}] ")
@@ -936,9 +1089,15 @@ def _run_backend_with_retries(
     if infra_reasons:
         result["infra_retries"] = attempt  # retries performed (0-based final attempt index)
         result["infra_retry_reasons"] = infra_reasons
-    non_experiment_attempt = _supports_cost_time(backend) and (
-        quota_exhausted or result.get("termination_reason") == TerminationReason.INFRA_ERROR
+    model_work_observed = _retry_may_duplicate_model_work(
+        backend,
+        agent_jsonl,
+        attempt_usage,
+        attempt_usage.legacy_output_tokens,
     )
+    interrupted = quota_exhausted or result.get("termination_reason") == TerminationReason.INFRA_ERROR
+    graded_module_progress = item.module_checkpoint_identity is not None and model_work_observed
+    non_experiment_attempt = _supports_cost_time(backend) and interrupted and not graded_module_progress
     if non_experiment_attempt:
         category = "quota-attempts" if quota_exhausted else "attempts"
         _write_attempt_accounting(
@@ -965,6 +1124,7 @@ def _run_backend_with_retries(
         quota_exhausted,
         quota_retry_suppressed,
         infra_retriable,
+        model_work_observed,
         infra_reasons,
         outcome_usage,
     )
@@ -980,6 +1140,133 @@ def _record_result(results: list[dict], new_result: dict) -> None:
     benchmark = new_result["benchmark"]
     results[:] = [result for result in results if result.get("benchmark") != benchmark]
     results.append(new_result)
+
+
+def _load_resume_results(output_dir: str) -> list[dict]:
+    """Load a resumable result list without accepting ambiguous persisted data."""
+
+    path = os.path.join(output_dir, "results.json")
+    if not os.path.isfile(path):
+        return []
+    try:
+        with open(path, encoding="utf-8") as stream:
+            value = json.load(stream)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read prior results {path!r}: {exc}") from exc
+    if type(value) is not list or any(type(result) is not dict for result in value):
+        raise ValueError(f"prior results {path!r} must be a JSON list of objects")
+    benchmark_ids = [result.get("benchmark") for result in value]
+    if any(type(benchmark) is not str or not benchmark for benchmark in benchmark_ids):
+        raise ValueError(f"prior results {path!r} contain a missing or invalid benchmark ID")
+    if len(benchmark_ids) != len(set(benchmark_ids)):
+        raise ValueError(f"prior results {path!r} contain duplicate benchmark IDs")
+    return value
+
+
+def _validate_resume_result_accounting(results: list[dict], *, supports_cost_time: bool) -> None:
+    """Reject values that would make cumulative resume reporting ambiguous."""
+
+    totals: dict[str, list[float]] = {"time_secs": [], "equivalent_cost_usd": []}
+    for result in results:
+        benchmark = result["benchmark"]
+        verdict = result.get("check_verdict")
+        if type(verdict) is not str or not verdict:
+            raise ValueError(f"prior result {benchmark!r} has no non-empty check_verdict")
+        for field in ("input_tokens", "output_tokens"):
+            value = result.get(field, 0)
+            if type(value) is not int or value < 0:
+                raise ValueError(f"prior result {benchmark!r} has invalid {field}: expected a non-negative integer")
+        time_secs = result.get("time_secs")
+        if time_secs is None:
+            if not supports_cost_time:
+                raise ValueError(f"prior result {benchmark!r} has invalid time_secs: expected a non-negative number")
+        elif nonnegative_float(time_secs) is None or isinstance(time_secs, bool):
+            raise ValueError(f"prior result {benchmark!r} has invalid time_secs: expected a finite non-negative number")
+        else:
+            totals["time_secs"].append(float(time_secs))
+        equivalent_cost = result.get("equivalent_cost_usd")
+        if equivalent_cost is not None:
+            if nonnegative_float(equivalent_cost) is None or isinstance(equivalent_cost, bool):
+                raise ValueError(
+                    f"prior result {benchmark!r} has invalid equivalent_cost_usd: expected a finite non-negative number"
+                )
+            totals["equivalent_cost_usd"].append(float(equivalent_cost))
+    for field, values in totals.items():
+        if not math.isfinite(sum(values)):
+            raise ValueError(f"prior result {field} total is not finite")
+
+
+def _recover_module_resume(
+    output_dir: str,
+    previous_results: list[dict],
+    checkpoint_identities: dict[str, ModuleCheckpointIdentity],
+    checkpoints: dict,
+    *,
+    max_continuations: int,
+) -> tuple[list[dict], dict[str, ModuleResume], set[str]]:
+    """Recover exact module stages rather than starting a new pass@1 attempt."""
+
+    for result in previous_results:
+        benchmark = result["benchmark"]
+        if benchmark not in checkpoint_identities:
+            raise ValueError(f"prior result {benchmark!r} is outside the selected module-task cohort")
+        if benchmark not in checkpoints:
+            raise ValueError(
+                "cannot resume theorem-level or pre-checkpoint proof-from-scratch results; "
+                f"module task {benchmark!r} has no durable module checkpoint"
+            )
+
+    results: list[dict] = []
+    resumes: dict[str, ModuleResume] = {}
+    completed: set[str] = set()
+    for task_id, checkpoint in checkpoints.items():
+        result = copy.deepcopy(checkpoint.result)
+        receipt = result_module_artifact(result)
+        content = read_module_artifact(output_dir, receipt) if receipt is not None else None
+        action = _module_resume_action(result, max_continuations=max_continuations)
+        state = ModuleResume(
+            action=action,
+            result=result,
+            submission=content,
+            artifact_receipt=dict(receipt) if receipt is not None else None,
+            checkpoint_sequence=checkpoint.sequence,
+        )
+        _record_result(results, result)
+        if action == MODULE_RESUME_COMPLETE:
+            completed.add(task_id)
+        else:
+            resumes[task_id] = state
+    return results, resumes, completed
+
+
+def _module_resume_action(result: dict[str, object], *, max_continuations: int) -> str:
+    """Return the next exact action without discarding prior attempt evidence.
+
+    A pending-grading marker is written immediately after publishing an
+    artifact, so a restart grades those saved bytes before any model call. A
+    completed first attempt is never rewritten as pass@1: remaining work is a
+    continuation, and a fully spent chain is terminal even when it did not
+    pass.
+    """
+
+    if result.get("module_grading_pending") is not None:
+        return MODULE_RESUME_GRADE_SAVED
+    if _resume_should_skip(result):
+        return MODULE_RESUME_COMPLETE
+    if is_non_genuine(result):
+        return MODULE_RESUME_RETRY_FIRST
+
+    raw_rounds = result.get("continuations")
+    rounds = raw_rounds if isinstance(raw_rounds, list) else []
+    if rounds and isinstance(rounds[-1], dict) and is_non_genuine(rounds[-1]):
+        # This round did not count as an experiment. It remains visible until
+        # the retry starts, then _run_continuations archives it while reusing
+        # the same formal round number and continuation budget slot.
+        return MODULE_RESUME_CONTINUE
+
+    if len(rounds) < max_continuations:
+        return MODULE_RESUME_CONTINUE
+    return MODULE_RESUME_COMPLETE
 
 
 def _resume_done_benchmarks(results: list[dict]) -> set[str]:
@@ -1192,17 +1479,56 @@ def _proof_from_scratch_run_identity(
     mode: Mode,
     catalog: OfficialLibraryCatalog,
     toolchain: dict[str, object],
+    execution_policy: dict[str, object],
+    agent_skills_snapshot: AgentSkillsSnapshot,
 ) -> dict[str, object]:
     return {
-        "schema_version": 2,
+        "schema_version": 5,
         "mode": mode.name,
         "benchmark_revision": _benchmark_revision(),
         "execution_source_digest": _image_source_fingerprint(),
+        "agent_skills_digest": agent_skills_snapshot.digest(),
+        "agent_skills": list(agent_skills_snapshot.names),
         "corpus_digest": _corpus_digest(mode, catalog.digest),
         "proof_library_digest": catalog.digest,
         "proof_library_sources": {name: dict(source) for name, source in catalog.sources.items()},
         "verification_toolchain_digest": toolchain["digest"],
         "verification_toolchain": toolchain,
+        "execution_policy": execution_policy,
+    }
+
+
+def _execution_policy_identity(
+    backend: Backend,
+    *,
+    use_container: bool,
+    timeout: int,
+    check_timeout: int,
+    infra_retries: int,
+    max_continuations: int,
+    session_dir: str,
+) -> dict[str, object]:
+    """Freeze every option that can change an attempt or its reported score."""
+
+    return {
+        "backend": backend.name,
+        "approach": backend.approach,
+        "model": getattr(backend, "model", None),
+        "reasoning_effort": backend.reasoning_effort,
+        "max_output_tokens": backend.max_output_tokens,
+        "environment": "container" if use_container else "local",
+        "timeout": timeout,
+        "check_timeout": check_timeout,
+        "infra_retries": infra_retries,
+        "max_continuations": max_continuations,
+        # A resumed module must see the same backend state tree. Unlike the
+        # task artifact, this mutable CLI state is not copied into the output
+        # checkpoint; pre-existing contents remain an operator-controlled input.
+        "session": {
+            "persistence": bool(session_dir),
+            "root": session_dir or None,
+            "key_scheme": SESSION_KEY_SCHEME,
+        },
     }
 
 
@@ -1334,6 +1660,7 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
             lines.append(f"**Corpus digest**: `{next(iter(corpus_digests))}`")
         if len(library_digests) == 1:
             lines.append(f"**Official proof libraries**: `{next(iter(library_digests))}`")
+        diagnostic_score_lines: list[str] = []
         if specification_ids is None:
             # Generic/custom modes may not expose a specification identity map.
             pass_pct, n_pass, scored = weighted_score(results, SCORERS["equal"])
@@ -1344,7 +1671,7 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
                 pass_line += f" · {n_skip} skipped"
             if non_genuine:
                 pass_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
-            lines.append(pass_line)
+            diagnostic_score_lines.append(pass_line)
             continuation_results = results
         else:
             score_lines, specification_score = specification_score_lines(results, specification_ids)
@@ -1353,13 +1680,22 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
                     "**Specification pass rate**: pending until the run completes "
                     f"({total}/{total_benchmarks} tasks finished)"
                 )
-            lines.extend(score_lines)
+            diagnostic_score_lines.extend(score_lines)
             n_pass = specification_score.tasks_passed
             continuation_results = applicable_manifest_results(results, specification_ids)
-        # Separate, clearly-labeled metric — the pass rate above stays pass@1.
+        # One module scores k/n trusted theorems (#132), so this is the primary
+        # proof-from-scratch metric. Whole-module PASS remains a diagnostic.
+        unit_line = proof_unit_rate_line(continuation_results)
+        if unit_line:
+            lines.append(unit_line)
+        lines.extend(diagnostic_score_lines)
+        # Separate, clearly-labeled continuation metrics; pass@1 stays intact.
         cont_line = continuation_rate_line(continuation_results, SCORERS["equal"], n_pass)
         if cont_line:
             lines.append(cont_line)
+        continuation_unit_line = proof_unit_rate_line(continuation_results, with_continuations=True)
+        if continuation_unit_line and any(result.get("continuations") for result in continuation_results):
+            lines.append(continuation_unit_line)
         lines.append(
             f"**Total tokens**: {total_input:,} input / {total_output:,} output" + ("" if supports_cost_time else "\n")
         )
@@ -1403,6 +1739,18 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
             cont = _continuation_note(r)
             if cont:
                 notes = (cont + " " + notes).strip()
+            if r.get("proof_unit_count"):
+                trusted_count = r.get("trusted_proof_unit_count", 0)
+                unit_note = f"pass@1 trusted {trusted_count}/{r['proof_unit_count']} proof units"
+                graded_rounds = [
+                    round_result
+                    for round_result in (r.get("continuations") or [])
+                    if isinstance(round_result, dict) and "trusted_proof_unit_count" in round_result
+                ]
+                if graded_rounds:
+                    latest_count = graded_rounds[-1]["trusted_proof_unit_count"]
+                    unit_note += f"; latest continuation trusted {latest_count}/{r['proof_unit_count']}"
+                notes = (unit_note + " " + notes).strip()
             tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
             if "obligations" in r:
                 obs = str(r["obligations"])
@@ -1433,8 +1781,168 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
         with open(report_path, "w") as f:
             f.write(report)
 
-        with open(os.path.join(output_dir, "results.json"), "w") as f:
-            json.dump(results, f, indent=2)
+        _atomic_json_write(os.path.join(output_dir, "results.json"), results)
+
+
+def _atomic_json_write(path: str, value: object) -> None:
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{os.path.basename(path)}.", suffix=".tmp", dir=directory)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, indent=2, allow_nan=False)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary)
+
+
+def _persist_work_item_result(item: WorkItem, result_dir: str, result: dict) -> bool:
+    checkpointed = True
+    if item.module_checkpoint_identity is not None:
+        try:
+            write_module_checkpoint(item.output_dir, item.module_checkpoint_identity, result)
+        except ModuleCheckpointError as exc:
+            checkpointed = False
+            result["check_verdict"] = "ERROR"
+            result["error"] = f"cannot checkpoint module progress: {exc}"
+            result["termination_reason"] = TerminationReason.INFRA_ERROR
+    _atomic_json_write(os.path.join(result_dir, "result.json"), result)
+    return checkpointed
+
+
+def _preserve_module_submission(
+    item: WorkItem,
+    solution_path: str,
+    *,
+    disposition: str,
+    copy_solution: bool,
+    submission_error: str | None = None,
+) -> tuple[str | None, dict | None]:
+    """Preserve a submitted module, or report a model-owned invalid submission.
+
+    A workspace starts with the canonical task file.  A backend that cannot
+    materialize a response must therefore not let that untouched file become
+    the module artifact (or the input to grading).  Missing and empty files
+    and non-regular target paths are ordinary failed submissions; failures to
+    publish otherwise valid bytes remain infrastructure errors at the call site.
+    """
+    if item.module_checkpoint_identity is None:
+        return None, None
+
+    if disposition != SubmissionDisposition.GRADE or not copy_solution:
+        if os.path.lexists(solution_path):
+            if os.path.islink(solution_path) or os.path.isfile(solution_path):
+                os.unlink(solution_path)
+        return (
+            submission_error or "module submission was not materialized",
+            None,
+        )
+
+    if os.path.islink(solution_path):
+        return "module submission path is a symlink", None
+    try:
+        metadata = os.lstat(solution_path)
+    except FileNotFoundError:
+        return "module submission is missing", None
+    if not stat.S_ISREG(metadata.st_mode):
+        return "module submission path is not a regular file", None
+    descriptor = os.open(
+        solution_path,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
+    )
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            return "module submission path is not a regular file", None
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = -1
+            content = stream.read()
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if not content:
+        return "module submission is empty", None
+    return None, publish_module_artifact(item.output_dir, content)
+
+
+def _restore_latest_durable_module(
+    item: WorkItem,
+    solution_path: str,
+    result: dict,
+    canonical_inputs: CanonicalInputs,
+) -> None:
+    """Match the workspace state a resume reconstructs after invalid output."""
+
+    receipt = result_module_artifact(result)
+    content = read_module_artifact(item.output_dir, receipt) if receipt is not None else canonical_inputs.target_bytes
+    if os.path.lexists(solution_path):
+        if os.path.islink(solution_path) or not os.path.isdir(solution_path):
+            os.unlink(solution_path)
+        else:
+            shutil.rmtree(solution_path)
+    _write_bytes(solution_path, content)
+
+
+def _grade_resumed_module_submission(
+    item: WorkItem,
+    workspace: str,
+    result: dict,
+    result_dir: str,
+    grading_dir: str,
+    basename: str,
+    name_no_ext: str,
+    canonical_inputs: CanonicalInputs,
+) -> None:
+    """Grade the exact artifact named by a pending checkpoint, without an agent."""
+
+    pending_round = result.get("module_grading_pending")
+    if type(pending_round) is not int or pending_round < 0:
+        raise ModuleCheckpointError("resumed module has no valid pending grading round")
+    if pending_round == 0:
+        attempt = result
+        attempt_dir = grading_dir
+    else:
+        rounds = result.get("continuations")
+        if not isinstance(rounds, list) or pending_round != len(rounds) or not isinstance(rounds[-1], dict):
+            raise ModuleCheckpointError("resumed module pending grading does not identify its latest continuation")
+        attempt = rounds[-1]
+        attempt_dir = os.path.join(result_dir, "continuations", f"round-{pending_round}")
+        os.makedirs(attempt_dir, exist_ok=True)
+
+    solution_path = os.path.join(workspace, basename)
+    if not os.path.isfile(solution_path):
+        raise ModuleArtifactError("resumed module artifact did not materialize as a regular task file")
+    shutil.copy2(solution_path, os.path.join(attempt_dir, "solution.tla"))
+    canonical_dir = _make_canonical_dir(name_no_ext, canonical_inputs)
+    try:
+        check_result_path = os.path.join(attempt_dir, "check.result")
+        if item.use_container:
+            _run_grader_container(
+                item,
+                workspace,
+                basename,
+                attempt_dir,
+                check_result_path,
+                attempt,
+                canonical_dir,
+            )
+        else:
+            _run_grader_local(
+                item,
+                workspace,
+                basename,
+                attempt_dir,
+                check_result_path,
+                attempt,
+                canonical_dir,
+            )
+    finally:
+        if isinstance(attempt.get("module_result"), dict):
+            result.pop("module_grading_pending", None)
+        shutil.rmtree(canonical_dir, ignore_errors=True)
 
 
 def run_single_benchmark(item: WorkItem):
@@ -1446,17 +1954,21 @@ def run_single_benchmark(item: WorkItem):
     # invalid direct Python call can clear prior artifacts or touch quota/state.
     item.infra_retries = backend.validate_options(item.infra_retries, item.max_continuations)
 
-    rel_path = os.path.relpath(item.benchmark_path, mode.benchmark_dir())
-    module_dir = os.path.basename(os.path.dirname(item.benchmark_path))
+    rel_path = os.path.relpath(item.benchmark_path, mode.benchmark_dir()).replace(os.sep, "/")
+    module_dir = os.path.dirname(rel_path).replace(os.sep, "/")
     basename = os.path.basename(item.benchmark_path)
     name_no_ext = os.path.splitext(basename)[0]
 
     # Structured result directory: input/, agent/, grading/
-    result_dir = os.path.join(item.output_dir, module_dir, name_no_ext)
+    result_dir = os.path.join(item.output_dir, os.path.splitext(rel_path)[0])
     input_dir = os.path.join(result_dir, "input")
     agent_dir = os.path.join(result_dir, "agent")
     grading_dir = os.path.join(result_dir, "grading")
-    _reset_benchmark_artifacts(item.output_dir, result_dir)
+    _reset_benchmark_artifacts(
+        item.output_dir,
+        result_dir,
+        resume_checkpoint_sequence=(item.module_resume.checkpoint_sequence if item.module_resume is not None else None),
+    )
     for d in (input_dir, agent_dir, grading_dir):
         os.makedirs(d, exist_ok=True)
 
@@ -1478,42 +1990,76 @@ def run_single_benchmark(item: WorkItem):
         "termination_reason": TerminationReason.OK,
         **backend.initial_result_metadata(),
     }
+    module_resume = item.module_resume
+    restored_result = module_resume is not None and module_resume.action in {
+        MODULE_RESUME_GRADE_SAVED,
+        MODULE_RESUME_CONTINUE,
+    }
+    if restored_result:
+        result = copy.deepcopy(module_resume.result)
+    module_spec_loader = getattr(mode, "module_task_spec", None)
+    if module_spec_loader is not None:
+        module_spec = module_spec_loader(item.benchmark_path)
+        result["proof_unit_ids"] = list(module_spec.proof_unit_ids)
+        result["proof_unit_count"] = len(module_spec.proof_unit_ids)
+        result.setdefault("trusted_proof_unit_count", 0)
+    if module_resume is not None:
+        result["resumed_from_checkpoint"] = True
+        result["resume_checkpoint_sequence"] = module_resume.checkpoint_sequence
+        if module_resume.submission is not None:
+            result["resume_submission_sha256"] = hashlib.sha256(module_resume.submission).hexdigest()
+        if module_resume.artifact_receipt is not None:
+            result["resume_artifact_sha256"] = module_resume.artifact_receipt["sha256"]
     if item.run_identity is not None:
         result["corpus_digest"] = item.run_identity["corpus_digest"]
         result["proof_library_digest"] = item.run_identity["proof_library_digest"]
-    if _supports_cost_time(backend):
+    if _supports_cost_time(backend) and not restored_result:
         result["equivalent_cost_usd"] = None
     # Usage is runner-owned structured evidence; backend metadata must not
     # accidentally replace it with a similarly named custom field.
-    result["usage"] = UsageSummary(
-        input_tokens=0,
-        output_tokens=0,
-        model_requests=0,
-        sources=("runner",),
-        available=True,
-        complete=True,
-    ).to_dict()
-    if item.max_continuations > 0:
+    if not restored_result:
+        result["usage"] = UsageSummary(
+            input_tokens=0,
+            output_tokens=0,
+            model_requests=0,
+            sources=("runner",),
+            available=True,
+            complete=True,
+        ).to_dict()
+    if item.max_continuations > 0 and not restored_result:
         # Run-level config, stamped on EVERY result — first-attempt PASSes and
         # non-genuine early exits included — so the continuation metric can
         # state its ≤N budget without guessing from the chains that happened to run.
         result["max_continuations"] = item.max_continuations
 
     skills_snapshot_dir = os.path.join(input_dir, "skills")
-    result["agent_skills"] = _snapshot_agent_skills(backend, skills_snapshot_dir)
+    current_agent_skills = _snapshot_agent_skills(
+        backend,
+        skills_snapshot_dir,
+        item.agent_skills_snapshot,
+    )
+    if not restored_result:
+        result["agent_skills"] = current_agent_skills
 
-    if not quota.wait_for_quota(
+    grading_only_resume = restored_result and module_resume.action == MODULE_RESUME_GRADE_SAVED
+    quota_available = grading_only_resume or quota.wait_for_quota(
         item.usage_script,
         item.quota_5h,
         item.quota_7d,
         item.quota_max_waits,
         log_prefix=f"[{name_no_ext}] ",
-    ):
+    )
+    if not quota_available:
+        if restored_result:
+            _persist_work_item_result(item, result_dir, result)
+            return result
         result["agent_exit"] = -3
         result["error"] = "quota exceeded (max waits reached); skipped"
         result["input_tokens"] = 0
         result["output_tokens"] = 0
         result["termination_reason"] = TerminationReason.QUOTA_EXHAUSTED
+        if item.module_checkpoint_identity is not None:
+            _persist_work_item_result(item, result_dir, result)
         return result
 
     workspace = None
@@ -1529,6 +2075,56 @@ def run_single_benchmark(item: WorkItem):
 
         # Save input artifacts
         canonical_inputs.materialize(input_dir, target_name="benchmark.tla")
+        if module_resume is not None and module_resume.submission is not None:
+            _write_bytes(os.path.join(input_dir, "resume.tla"), module_resume.submission)
+
+        if restored_result:
+            workspace = _make_workspace(
+                backend.name,
+                name_no_ext,
+                canonical_inputs,
+                skills_snapshot_dir=skills_snapshot_dir,
+                project_skills_dir=backend.project_skills_dir,
+                read_only_dependencies=getattr(mode, "read_only_dependencies", False),
+                initial_target_bytes=module_resume.submission,
+            )
+            if module_resume.action == MODULE_RESUME_GRADE_SAVED:
+                _grade_resumed_module_submission(
+                    item,
+                    workspace,
+                    result,
+                    result_dir,
+                    grading_dir,
+                    basename,
+                    name_no_ext,
+                    canonical_inputs,
+                )
+                if not _persist_work_item_result(item, result_dir, result):
+                    return result
+                if result.get("module_grading_pending") is not None:
+                    return result
+            if module_resume.action == MODULE_RESUME_CONTINUE or (
+                not is_pass_with_continuations(result) and not is_non_genuine(result)
+            ):
+                if module_resume.action == MODULE_RESUME_GRADE_SAVED and not quota.wait_for_quota(
+                    item.usage_script,
+                    item.quota_5h,
+                    item.quota_7d,
+                    item.quota_max_waits,
+                    log_prefix=f"[{name_no_ext}] ",
+                ):
+                    return result
+                _run_continuations(
+                    item,
+                    workspace,
+                    result,
+                    result_dir,
+                    basename,
+                    name_no_ext,
+                    canonical_inputs,
+                    checker_bin,
+                )
+            return result
 
         prompt = _build_prompt_from_canonical_inputs(
             backend,
@@ -1538,6 +2134,12 @@ def run_single_benchmark(item: WorkItem):
             item.tlapm_path,
             item.tlapm_lib,
         )
+        if module_resume is not None and module_resume.submission is not None:
+            prompt += (
+                "\n\n# Resumed progress\n\n"
+                "The editable task file already contains the last durably saved partial module from this run. "
+                "Continue from that work and keep any proof units that are already correct.\n"
+            )
         with open(os.path.join(input_dir, "prompt.txt"), "w") as f:
             f.write(prompt)
 
@@ -1562,6 +2164,13 @@ def run_single_benchmark(item: WorkItem):
             skills_snapshot_dir=skills_snapshot_dir,
         )
         workspace, canonical_dir = run.workspace, run.canonical_dir
+        attempt_interrupted = run.quota_exhausted or result.get("termination_reason") == TerminationReason.INFRA_ERROR
+        interrupted_after_model_work = run.model_work_observed and attempt_interrupted
+        if interrupted_after_model_work:
+            # The flag is checkpointed with a pending artifact. It only makes
+            # the attempt genuine after a module_result is also present, so a
+            # crash between publication and grading still resumes safely.
+            result["graded_after_interruption"] = True
 
         destination = os.path.join(workspace, basename)
         submission = backend.prepare_submission(
@@ -1569,7 +2178,7 @@ def run_single_benchmark(item: WorkItem):
             destination,
             result["termination_reason"],
             result.get("error", ""),
-            allow_materialization=not run.quota_exhausted and not run.infra_retriable,
+            allow_materialization=not attempt_interrupted or run.model_work_observed,
         )
         _apply_submission_metadata(result, submission.metadata)
         if submission.error is not None:
@@ -1587,6 +2196,34 @@ def run_single_benchmark(item: WorkItem):
             f.write(run.transcript)
 
         solution_path = os.path.join(workspace, basename)
+        module_submission_failure = None
+        has_new_module_submission = not attempt_interrupted or run.model_work_observed
+        if item.module_checkpoint_identity is not None and has_new_module_submission:
+            try:
+                module_submission_failure, module_artifact = _preserve_module_submission(
+                    item,
+                    solution_path,
+                    disposition=submission.disposition,
+                    copy_solution=submission.copy_solution,
+                    submission_error=submission.error,
+                )
+                if module_artifact is not None:
+                    result["module_artifact"] = module_artifact
+                    result["module_grading_pending"] = 0
+                    if not _persist_work_item_result(item, result_dir, result):
+                        return result
+                elif module_submission_failure is not None and interrupted_after_model_work:
+                    # Missing/empty output after observed model work is a real,
+                    # paid invalid attempt. It has no bytes to grade, but resume
+                    # must consume it instead of replaying pass@1.
+                    result.pop("graded_after_interruption", None)
+                    result["invalid_submission_after_interruption"] = True
+            except (OSError, ModuleArtifactError) as exc:
+                result["check_verdict"] = "ERROR"
+                result["error"] = f"cannot preserve submitted module: {exc}"
+                result["termination_reason"] = TerminationReason.INFRA_ERROR
+                return result
+
         if submission.copy_solution and os.path.isfile(solution_path):
             shutil.copy2(solution_path, os.path.join(agent_dir, "solution.tla"))
 
@@ -1609,25 +2246,44 @@ def run_single_benchmark(item: WorkItem):
                 else "provider usage limit; exhausted quota retries"
             )
             result["termination_reason"] = TerminationReason.QUOTA_EXHAUSTED
-            with open(os.path.join(result_dir, "result.json"), "w") as f:
-                json.dump(result, f, indent=2)
-            return result
+            if item.module_checkpoint_identity is None or (
+                result.get("module_artifact") is None and module_submission_failure is None
+            ):
+                return result
 
-        if run.infra_retriable:
-            # Out of retries with no genuine attempt made: grading the untouched
-            # workspace would turn infra noise into a proof verdict (FAIL, or even
-            # a bogus PASS). Mark ERROR (retriable via --resume), skip the grader.
+        if attempt_interrupted and not run.model_work_observed:
+            # No formal attempt was made. Whether this particular interruption
+            # qualified for an inline retry does not change that fact: never
+            # materialize or grade the untouched canonical workspace.
             result["check_verdict"] = "ERROR"
             if not result.get("error"):
-                result["error"] = f"startup/infra failure ({run.infra_reasons[-1]}); exhausted infra retries"
-            with open(os.path.join(result_dir, "result.json"), "w") as f:
-                json.dump(result, f, indent=2)
+                if run.infra_reasons:
+                    result["error"] = f"startup/infra failure ({run.infra_reasons[-1]}); exhausted infra retries"
+                else:
+                    result["error"] = "agent run ended before any model work was observed"
+            return result
+
+        if module_submission_failure is not None:
+            result["check_verdict"] = "FAIL"
+            result["error"] = module_submission_failure
+            if item.module_checkpoint_identity is not None and not _persist_work_item_result(item, result_dir, result):
+                return result
+            if not run.quota_exhausted and item.max_continuations > 0 and not is_non_genuine(result):
+                _restore_latest_durable_module(item, solution_path, result, canonical_inputs)
+                _run_continuations(
+                    item,
+                    workspace,
+                    result,
+                    result_dir,
+                    basename,
+                    name_no_ext,
+                    canonical_inputs,
+                    checker_bin,
+                )
             return result
 
         if submission.disposition != SubmissionDisposition.GRADE:
             result["check_verdict"] = submission.disposition
-            with open(os.path.join(result_dir, "result.json"), "w") as f:
-                json.dump(result, f, indent=2)
             return result
 
         # Run grader
@@ -1635,26 +2291,36 @@ def run_single_benchmark(item: WorkItem):
         grading_canonical_dir = canonical_dir
         if getattr(mode, "canonical_replay_required", False):
             grading_canonical_dir = _make_canonical_dir(name_no_ext, canonical_inputs)
-        if item.use_container:
-            _run_grader_container(
-                item,
-                workspace,
-                basename,
-                grading_dir,
-                check_result_path,
-                result,
-                grading_canonical_dir,
-            )
-        else:
-            _run_grader_local(
-                item,
-                workspace,
-                basename,
-                grading_dir,
-                check_result_path,
-                result,
-                grading_canonical_dir,
-            )
+        try:
+            if item.use_container:
+                _run_grader_container(
+                    item,
+                    workspace,
+                    basename,
+                    grading_dir,
+                    check_result_path,
+                    result,
+                    grading_canonical_dir,
+                )
+            else:
+                _run_grader_local(
+                    item,
+                    workspace,
+                    basename,
+                    grading_dir,
+                    check_result_path,
+                    result,
+                    grading_canonical_dir,
+                )
+            if interrupted_after_model_work and result.get("module_result") is not None:
+                result["graded_after_interruption"] = True
+        finally:
+            if isinstance(result.get("module_result"), dict):
+                result.pop("module_grading_pending", None)
+        if item.module_checkpoint_identity is not None and not _persist_work_item_result(item, result_dir, result):
+            return result
+        if result.get("module_grading_pending") is not None:
+            return result
 
         # Opt-in continuation rounds: a genuine non-PASS keeps its workspace and
         # the agent is asked to build on its own partial proof. The pass@1 fields
@@ -1671,10 +2337,6 @@ def run_single_benchmark(item: WorkItem):
                 checker_bin,
             )
 
-        # Write per-benchmark result.json
-        with open(os.path.join(result_dir, "result.json"), "w") as f:
-            json.dump(result, f, indent=2)
-
     finally:
         if workspace:
             shutil.rmtree(workspace, ignore_errors=True)
@@ -1682,11 +2344,17 @@ def run_single_benchmark(item: WorkItem):
             shutil.rmtree(grading_canonical_dir, ignore_errors=True)
         if canonical_dir:
             shutil.rmtree(canonical_dir, ignore_errors=True)
+        _persist_work_item_result(item, result_dir, result)
 
     return result
 
 
-def _reset_benchmark_artifacts(output_dir: str, result_dir: str) -> None:
+def _reset_benchmark_artifacts(
+    output_dir: str,
+    result_dir: str,
+    *,
+    resume_checkpoint_sequence: int | None = None,
+) -> None:
     """Remove runner-owned artifacts without following generated-path symlinks."""
     output_root = os.path.abspath(output_dir)
     result_path = os.path.abspath(result_dir)
@@ -1710,7 +2378,28 @@ def _reset_benchmark_artifacts(output_dir: str, result_dir: str) -> None:
         raise RuntimeError(f"benchmark result path resolves outside output directory: {result_dir}")
 
     os.makedirs(result_dir, exist_ok=True)
-    for name in ("input", "agent", "grading", "continuations", "result.json"):
+    owned_names = ("input", "agent", "grading", "continuations", "result.json")
+    if resume_checkpoint_sequence is not None:
+        if resume_checkpoint_sequence <= 0:
+            raise RuntimeError("resume checkpoint sequence must be positive")
+        history_root = os.path.join(result_dir, "resume-history")
+        if os.path.islink(history_root) or (os.path.lexists(history_root) and not os.path.isdir(history_root)):
+            raise RuntimeError(f"refusing unsafe resume history path: {history_root}")
+        existing = [name for name in owned_names if os.path.lexists(os.path.join(result_dir, name))]
+        if existing:
+            os.makedirs(history_root, exist_ok=True)
+            prefix = f"checkpoint-{resume_checkpoint_sequence}"
+            history_dir = os.path.join(history_root, prefix)
+            suffix = 1
+            while os.path.lexists(history_dir):
+                history_dir = os.path.join(history_root, f"{prefix}-resume-{suffix}")
+                suffix += 1
+            os.mkdir(history_dir)
+            for name in existing:
+                os.replace(os.path.join(result_dir, name), os.path.join(history_dir, name))
+        return
+
+    for name in owned_names:
         path = os.path.join(result_dir, name)
         if not os.path.lexists(path):
             continue
@@ -1796,7 +2485,15 @@ def _run_continuations(
     prompt = mode.build_continuation_prompt(basename, item.tlapm_path, item.tlapm_lib)
     agent_check_file = os.path.join(workspace, name_no_ext + ".result")
     rounds: list[dict] = result.setdefault("continuations", [])
-    for rnd in range(1, item.max_continuations + 1):
+    retry_round = None
+    if rounds and is_non_genuine(rounds[-1]):
+        interrupted = rounds.pop()
+        retry_round = interrupted.get("round")
+        if type(retry_round) is not int or retry_round <= 0:
+            raise ModuleCheckpointError("interrupted continuation has no valid round number")
+        result.setdefault("interrupted_continuations", []).append(interrupted)
+    first_round = retry_round if retry_round is not None else len(rounds) + 1
+    for rnd in range(first_round, item.max_continuations + 1):
         prev_verdict = rounds[-1]["check_verdict"] if rounds else result["check_verdict"]
         print(
             f"[{name_no_ext}] {prev_verdict} — continuing in same workspace (round {rnd}/{item.max_continuations})",
@@ -1851,7 +2548,13 @@ def _run_continuations(
             elif run.infra_retriable:
                 round_result["error"] = f"startup/infra failure ({run.infra_reasons[-1]}); exhausted infra retries"
 
-            formal_round = not is_non_genuine(round_result)
+            round_interrupted = (
+                run.quota_exhausted or round_result.get("termination_reason") == TerminationReason.INFRA_ERROR
+            )
+
+            formal_round = not is_non_genuine(round_result) or (
+                item.module_checkpoint_identity is not None and run.model_work_observed
+            )
             if formal_round or not _supports_cost_time(item.backend):
                 aggregate_usage = UsageSummary.from_dict(result.get("usage")).merge(round_usage)
                 result["usage"] = aggregate_usage.to_dict()
@@ -1882,10 +2585,53 @@ def _run_continuations(
             if check_mtime_after is not None and check_mtime_after != check_mtime_before:
                 shutil.copy2(agent_check_file, os.path.join(round_dir, "agent_check.result"))
 
-            # Same rule as the first attempt: never grade a round the model
-            # never got to work on (quota cap or 0-token startup death).
-            cut_short = run.quota_exhausted or run.infra_retriable
-            if not cut_short:
+            # A provider interruption can happen after the module was edited.
+            # Preserve and grade those exact bytes for partial progress. A
+            # zero-work startup failure still has no experiment to grade.
+            cut_short = round_interrupted
+            module_submission_failure = None
+            has_new_module_submission = not round_interrupted or run.model_work_observed
+            if item.module_checkpoint_identity is not None and has_new_module_submission:
+                try:
+                    module_submission_failure, module_artifact = _preserve_module_submission(
+                        item,
+                        solution_path,
+                        disposition=SubmissionDisposition.GRADE,
+                        copy_solution=True,
+                    )
+                    if module_artifact is not None:
+                        round_result["module_artifact"] = module_artifact
+                except (OSError, ModuleArtifactError) as exc:
+                    round_result["check_verdict"] = "ERROR"
+                    round_result["error"] = f"cannot preserve submitted module: {exc}"
+                    round_result["termination_reason"] = TerminationReason.INFRA_ERROR
+                    cut_short = True
+            if module_submission_failure is not None:
+                round_result["check_verdict"] = "FAIL"
+                round_result["error"] = module_submission_failure
+                if round_interrupted and run.model_work_observed:
+                    round_result["invalid_submission_after_interruption"] = True
+
+            grade_interrupted_module = (
+                item.module_checkpoint_identity is not None
+                and round_interrupted
+                and run.model_work_observed
+                and round_result.get("module_artifact") is not None
+            )
+            if grade_interrupted_module:
+                # Preserve the model-work fact in the pending checkpoint. The
+                # round remains non-genuine until a resumed grader supplies a
+                # module_result, but that result must make the already-spent
+                # formal round genuine instead of rerunning it.
+                round_result["graded_after_interruption"] = True
+            rounds.append(round_result)
+            if module_submission_failure is not None:
+                _restore_latest_durable_module(item, solution_path, result, canonical_inputs)
+            if round_result.get("module_artifact") is not None:
+                result["module_grading_pending"] = rnd
+                if not _persist_work_item_result(item, result_dir, result):
+                    cut_short = True
+            if module_submission_failure is None and (not cut_short or grade_interrupted_module):
                 grading_canonical_dir = run.canonical_dir
                 if getattr(mode, "canonical_replay_required", False):
                     grading_canonical_dir = _make_canonical_dir(name_no_ext, canonical_inputs)
@@ -1910,12 +2656,17 @@ def _run_continuations(
                         round_result,
                         grading_canonical_dir,
                     )
+                if isinstance(round_result.get("module_result"), dict):
+                    result.pop("module_grading_pending", None)
+                elif result.get("module_grading_pending") == rnd:
+                    cut_short = True
         finally:
             if grading_canonical_dir and grading_canonical_dir != run.canonical_dir:
                 shutil.rmtree(grading_canonical_dir, ignore_errors=True)
             shutil.rmtree(run.canonical_dir, ignore_errors=True)
 
-        rounds.append(round_result)
+        if item.module_checkpoint_identity is not None:
+            _persist_work_item_result(item, result_dir, result)
         if round_result["check_verdict"] == "PASS":
             print(f"[{name_no_ext}] recovered: PASS on continuation round {rnd}", flush=True)
             break
@@ -1929,9 +2680,9 @@ def _resolve_session_dir(session_dir_arg: str | None, keep_container: bool, use_
     if not use_container:
         return ""
     if session_dir_arg:
-        return os.path.abspath(session_dir_arg)
+        return os.path.realpath(os.path.abspath(session_dir_arg))
     if keep_container:
-        return os.path.expanduser(os.path.join("~", ".tlaps-bench", "sessions"))
+        return os.path.realpath(os.path.expanduser(os.path.join("~", ".tlaps-bench", "sessions")))
     return ""
 
 
@@ -1943,6 +2694,20 @@ def _prepare_session_dir(session_dir: str) -> None:
     if not os.path.exists(gitignore):
         with open(gitignore, "w") as f:
             f.write("# tlaps-bench session data (may contain credentials) — do not commit\n*\n")
+
+
+def _work_item_session_key(item: WorkItem) -> str:
+    """Return one collision-resistant persistent session key per physical task."""
+
+    root = os.path.abspath(item.mode.benchmark_dir())
+    task = os.path.abspath(item.benchmark_path)
+    if os.path.commonpath((root, task)) != root:
+        raise ValueError(f"benchmark task escapes its mode root: {item.benchmark_path}")
+    relative = os.path.relpath(task, root).replace(os.sep, "/")
+    stem = os.path.splitext(relative)[0].replace("/", "__")
+    slug = re.sub(r"[^A-Za-z0-9_.-]", "_", stem).strip("._-") or "task"
+    digest = hashlib.sha256(relative.encode()).hexdigest()[:12]
+    return f"{slug[:80]}-{digest}"
 
 
 def _run_backend_container(
@@ -1987,14 +2752,15 @@ def _run_backend_container(
         # uuid suffix keeps retained containers unique across retries and jobs
         config.container_name = f"tlaps-bench-{safe}-{uuid.uuid4().hex[:8]}"
     if item.session_dir and backend.session_state_dir:
-        # A retained container keys its session by container name (each kept
-        # container ↔ its own dir); otherwise by benchmark, so retries and
-        # continuations resume the same session.
-        host_session = os.path.join(item.session_dir, backend.name, config.container_name or safe)
+        # Every module owns one stable session across retries, continuations,
+        # and --resume. The full mode-relative task identity prevents modules
+        # with the same basename from sharing or concurrently mounting state.
+        session_key = _work_item_session_key(item)
+        host_session = os.path.join(item.session_dir, backend.name, session_key)
         config.session_dir = host_session
         config.session_container_path = backend.session_state_dir
         print(
-            f"[session-dir] persisting {backend.name} session state for '{name_no_ext}' "
+            f"[session-dir] persisting {backend.name} session state for '{session_key}' "
             f"to {host_session} (restore with scripts/restore-session.sh)",
             flush=True,
         )
@@ -2293,7 +3059,14 @@ def _run_grader_container(
             dbg.write(f"exit code: {exit_code}\n")
             dbg.write(f"stdout:\n{stdout}\n")
             dbg.write(f"stderr:\n{stderr}\n")
-        _parse_grader_result(exit_code, stdout, result)
+        module_spec = getattr(mode, "module_task_spec", None)
+        expected_units = tuple(module_spec(item.benchmark_path).proof_unit_ids) if module_spec is not None else None
+        _parse_grader_result(
+            exit_code,
+            stdout,
+            result,
+            expected_module_unit_ids=expected_units,
+        )
     except subprocess.TimeoutExpired:
         result["check_verdict"] = "TIMEOUT"
     except Exception as e:
@@ -2345,7 +3118,14 @@ def _run_grader_local(
             dbg.write(f"exit code: {check_proc.returncode}\n")
             dbg.write(f"stdout:\n{check_proc.stdout}\n")
             dbg.write(f"stderr:\n{check_proc.stderr}\n")
-        _parse_grader_result(check_proc.returncode, check_proc.stdout, result)
+        module_spec = getattr(mode, "module_task_spec", None)
+        expected_units = tuple(module_spec(item.benchmark_path).proof_unit_ids) if module_spec is not None else None
+        _parse_grader_result(
+            check_proc.returncode,
+            check_proc.stdout,
+            result,
+            expected_module_unit_ids=expected_units,
+        )
     except subprocess.TimeoutExpired:
         result["check_verdict"] = "TIMEOUT"
     except Exception as e:
@@ -2353,7 +3133,13 @@ def _run_grader_local(
         result["error"] = str(e)
 
 
-def _parse_grader_result(exit_code: int, stdout: str, result: dict) -> None:
+def _parse_grader_result(
+    exit_code: int,
+    stdout: str,
+    result: dict,
+    *,
+    expected_module_unit_ids: tuple[str, ...] | None = None,
+) -> None:
     """Parse grader exit code + stdout into result dict."""
     # The merged checker is binary: exit 0 = PASS, 1 = FAIL (a cheat is just a
     # FAIL, not a separate exit code). Anything else is unexpected → ERROR.
@@ -2363,14 +3149,63 @@ def _parse_grader_result(exit_code: int, stdout: str, result: dict) -> None:
         result["check_verdict"] = "FAIL"
     else:
         result["check_verdict"] = "ERROR"
-    sm = re.search(r"^SANY-STATUS:\s*(valid|invalid|unavailable)\s*$", stdout or "", re.MULTILINE)
-    if sm:
-        result["sany_status"] = sm.group(1)
-        result["sany_valid"] = sm.group(1) == "valid"
-    else:
+    sany_matches = re.findall(
+        r"^SANY-STATUS:[ \t]*([^\r\n]*?)[ \t]*$",
+        stdout or "",
+        re.MULTILINE,
+    )
+    if not sany_matches:
         result["check_verdict"] = "ERROR"
         result["error"] = "grader did not report a SANY status"
         return
+    if len(sany_matches) != 1:
+        result["check_verdict"] = "ERROR"
+        result["error"] = "grader reported multiple SANY status markers; expected exactly one"
+        return
+    sany_status = sany_matches[0]
+    if sany_status not in {"valid", "invalid", "unavailable"}:
+        result["check_verdict"] = "ERROR"
+        result["error"] = f"grader reported an invalid SANY status marker: {sany_status!r}"
+        return
+    module_matches = re.findall(
+        rf"^{re.escape(MODULE_RESULT_PREFIX)}(.+)$",
+        stdout or "",
+        re.MULTILINE,
+    )
+    if expected_module_unit_ids is not None:
+        if len(module_matches) != 1:
+            result["check_verdict"] = "ERROR"
+            result["error"] = "module grader did not report exactly one machine-readable module result"
+            return
+        try:
+            module_result = parse_module_result_json(module_matches[0], expected_module_unit_ids)
+        except ModuleResultError as exc:
+            result["check_verdict"] = "ERROR"
+            result["error"] = f"module grader reported an invalid result: {exc}"
+            return
+        result["module_result"] = module_result
+        trusted = module_result["trusted_proof_unit_ids"]
+        result["proof_unit_count"] = len(expected_module_unit_ids)
+        result["trusted_proof_unit_count"] = len(trusted)
+        result["trusted_proof_unit_ids"] = list(trusted)
+        if exit_code == 0 and not module_result["complete"]:
+            result["check_verdict"] = "ERROR"
+            result["error"] = "module grader exited PASS without trusting every proof unit"
+            return
+        if exit_code == 1 and module_result["complete"]:
+            result["check_verdict"] = "ERROR"
+            result["error"] = "module grader exited FAIL for a complete trusted module"
+            return
+        if exit_code not in (0, 1):
+            raw_verdicts = {unit["raw_verdict"] for unit in module_result["units"]}
+            result["check_verdict"] = "TIMEOUT" if "TIMEOUT" in raw_verdicts else "ERROR"
+        if module_result["sany_status"] != sany_status:
+            result["check_verdict"] = "ERROR"
+            result["error"] = "module grader SANY status disagrees with SANY-STATUS marker"
+            return
+
+    result["sany_status"] = sany_status
+    result["sany_valid"] = sany_status == "valid"
     # Which gate(s) failed (the grade is binary; this keeps the analysis signal).
     gm = re.search(r"GATES-FAILED:\s*([^\n]+)", stdout or "")
     if gm:
@@ -2682,6 +3517,14 @@ def main():
             2, f"{parser.prog}: error: no benchmarks found for mode {mode.name!r} under {mode.benchmark_dir()}\n"
         )
 
+    # Module runs always persist the exact selected cohort, including Full and
+    # --filter runs. A resume must select the same physical module tasks.
+    recorded_task_ids = task_ids
+    if getattr(mode, "module_task_spec", None) is not None:
+        recorded_task_ids = [
+            os.path.relpath(path, mode.benchmark_dir()).replace(os.sep, "/") for path in benchmark_files
+        ]
+
     if getattr(mode, "requires_workspace_tools", False) and not backend.capabilities.workspace_tools:
         parser.exit(
             2,
@@ -2700,9 +3543,10 @@ def main():
         else:
             output_dir = os.path.join(REPO_ROOT, "results", mode.name, backend.name, timestamp)
     output_dir = os.path.abspath(output_dir)
+    session_dir = _resolve_session_dir(args.session_dir, args.keep_container, use_container)
     if args.resume:
         try:
-            _validate_resume_task_list(output_dir, mode.name, task_ids)
+            _validate_resume_task_list(output_dir, mode.name, recorded_task_ids)
         except ValueError as exc:
             parser.exit(2, f"{parser.prog}: error: {exc}\n")
 
@@ -2710,6 +3554,22 @@ def main():
     run_identity = None
     container_ready = False
     native_toolchain_ready = False
+
+    # Resolve backend-dependent defaults before freezing or comparing the run
+    # identity. A resume may reuse progress only under the exact same model,
+    # limits, retry policy, and continuation budget.
+    try:
+        backend.set_reasoning_effort(args.reasoning_effort)
+        backend.set_max_output_tokens(args.max_output_tokens)
+        args.infra_retries = backend.validate_options(args.infra_retries, args.max_continuations)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    try:
+        agent_skills_snapshot = AgentSkillsSnapshot.capture(backend, SKILLS_DIR)
+    except (OSError, UnicodeError, ValueError) as exc:
+        parser.exit(2, f"{parser.prog}: error: cannot freeze project Agent Skills: {exc}\n")
+
     if mode.name == "proof-from-scratch":
         try:
             if use_container:
@@ -2723,6 +3583,16 @@ def main():
                 mode,
                 proof_library_catalog,
                 verification_toolchain,
+                _execution_policy_identity(
+                    backend,
+                    use_container=use_container,
+                    timeout=args.timeout,
+                    check_timeout=args.check_timeout,
+                    infra_retries=args.infra_retries,
+                    max_continuations=args.max_continuations,
+                    session_dir=session_dir,
+                ),
+                agent_skills_snapshot,
             )
         except (DockerUnavailableError, OSError, RuntimeError, ValueError) as exc:
             parser.exit(2, f"{parser.prog}: error: cannot freeze proof verification environment: {exc}\n")
@@ -2746,15 +3616,80 @@ def main():
         except (OSError, TaskContractError, ValueError) as exc:
             parser.exit(2, f"{parser.prog}: error: cannot capture canonical inputs: {exc}\n")
 
-    # Resolve capability-dependent defaults only after task discovery. This
-    # preserves the useful fail-fast behavior for a misspelled --filter: no
-    # backend validation, auth probe, image build, or model request happens.
-    try:
-        backend.set_reasoning_effort(args.reasoning_effort)
-        backend.set_max_output_tokens(args.max_output_tokens)
-        args.infra_retries = backend.validate_options(args.infra_retries, args.max_continuations)
-    except ValueError as exc:
-        parser.error(str(exc))
+    module_checkpoint_identities: dict[str, ModuleCheckpointIdentity] = {}
+    module_checkpoints = {}
+    results: list[dict] = []
+    done_pass: set[str] = set()
+    module_resumes: dict[str, ModuleResume] = {}
+    module_spec_loader = getattr(mode, "module_task_spec", None)
+    if module_spec_loader is not None:
+        if run_identity is None:
+            parser.exit(2, f"{parser.prog}: error: module evaluation requires a frozen run identity\n")
+        try:
+            identity_digest = module_run_identity_sha256(run_identity)
+            for benchmark_path in benchmark_files:
+                relative = os.path.relpath(benchmark_path, mode.benchmark_dir()).replace(os.sep, "/")
+                spec = module_spec_loader(benchmark_path)
+                canonical_inputs = canonical_inputs_by_path[benchmark_path]
+                module_checkpoint_identities[relative] = ModuleCheckpointIdentity(
+                    task_id=relative,
+                    proof_unit_ids=tuple(spec.proof_unit_ids),
+                    canonical_input_sha256=canonical_inputs.digest(),
+                    run_identity_sha256=identity_digest,
+                )
+            module_checkpoints = prepare_module_checkpoints(
+                output_dir,
+                module_checkpoint_identities,
+                resume=args.resume,
+            )
+        except (KeyError, ModuleCheckpointError) as exc:
+            parser.exit(2, f"{parser.prog}: error: cannot prepare module checkpoints: {exc}\n")
+
+    if args.resume:
+        try:
+            previous_results = _load_resume_results(output_dir)
+            if module_checkpoint_identities:
+                (
+                    results,
+                    module_resumes,
+                    done_pass,
+                ) = _recover_module_resume(
+                    output_dir,
+                    previous_results,
+                    module_checkpoint_identities,
+                    module_checkpoints,
+                    max_continuations=args.max_continuations,
+                )
+            else:
+                for previous_result in previous_results:
+                    _record_result(results, previous_result)
+            _validate_resume_result_accounting(
+                results,
+                supports_cost_time=_supports_cost_time(backend),
+            )
+            if not module_checkpoint_identities:
+                done_pass = _resume_done_benchmarks(results)
+        except (ModuleArtifactError, ValueError) as exc:
+            parser.exit(2, f"{parser.prog}: error: cannot recover prior results: {exc}\n")
+
+        if module_checkpoint_identities:
+            print(
+                f"Resume: recovered {len(results)} durable module result(s), "
+                f"skipping {len(done_pass)} completed module task(s)"
+            )
+        elif results:
+            n_pass = sum(1 for result in results if _resume_should_skip(result) and not is_skipped(result))
+            n_skip = n_skipped(results)
+            non_genuine = n_non_genuine(results)
+            msg = (
+                f"Resume: loaded {len(results)} prior results, skipping {n_pass} genuine PASS "
+                f"(first-attempt or continuation) + {n_skip} SKIP"
+            )
+            if non_genuine:
+                msg += f"; {non_genuine} infra/quota-cut result(s) eligible for rerun"
+            print(msg)
+        else:
+            print(f"Resume: no prior results.json or module checkpoints in {output_dir} — running all")
 
     if not _confirm_public_pricing(
         backend,
@@ -2801,7 +3736,6 @@ def main():
     if args.session_dir and not use_container:
         print("WARNING: --session-dir has no effect with --no-container (no container to mount into)")
 
-    session_dir = _resolve_session_dir(args.session_dir, args.keep_container, use_container)
     if session_dir:
         _prepare_session_dir(session_dir)
 
@@ -2819,8 +3753,10 @@ def main():
             print(f"Preflight: skipped — backend {backend.name!r} does not support a model preflight request")
     os.makedirs(output_dir, exist_ok=True)
     try:
-        _write_task_list_record(output_dir, mode.name, task_ids)
-        _write_run_manifest(output_dir, run_identity)
+        if not args.resume or not os.path.isfile(os.path.join(output_dir, TASK_LIST_RECORD)):
+            _write_task_list_record(output_dir, mode.name, recorded_task_ids)
+        if not args.resume or not os.path.isfile(os.path.join(output_dir, RUN_MANIFEST_RECORD)):
+            _write_run_manifest(output_dir, run_identity)
     except OSError as exc:
         parser.exit(2, f"{parser.prog}: error: cannot record run inputs in {output_dir!r}: {exc}\n")
 
@@ -2866,41 +3802,10 @@ def main():
 
     print(f"Found {len(benchmark_files)} benchmarks")
 
-    # Resume: reuse --output-dir, skip benchmarks already genuinely completed
-    # there, and seed `results` so the summary stays cumulative across the rerun.
-    results = []
-    done_pass = set()
-    if args.resume:
-        prev_json = os.path.join(output_dir, "results.json")
-        if os.path.isfile(prev_json):
-            with open(prev_json) as f:
-                previous_results = json.load(f)
-            for previous_result in previous_results:
-                _record_result(results, previous_result)
-            # Skip genuine PASS (already done) and SKIP (operator-marked
-            # frontier benchmarks deliberately excluded from retry). A PASS
-            # produced by INFRA_ERROR / QUOTA_EXHAUSTED is non-genuine and must
-            # be eligible for rerun.
-            done_pass = _resume_done_benchmarks(results)
-            # Count with the same predicate the skip decision uses, so the
-            # message includes benchmarks solved on a continuation round.
-            n_pass = sum(1 for r in results if _resume_should_skip(r) and not is_skipped(r))
-            n_skip = n_skipped(results)
-            non_genuine = n_non_genuine(results)
-            msg = (
-                f"Resume: loaded {len(results)} prior results, skipping {n_pass} genuine PASS "
-                f"(first-attempt or continuation) + {n_skip} SKIP"
-            )
-            if non_genuine:
-                msg += f"; {non_genuine} infra/quota-cut result(s) eligible for rerun"
-            print(msg)
-        else:
-            print(f"Resume: no prior results.json in {output_dir} — running all")
-
     selected_benchmarks = set()
     work_items = []
     for bf in benchmark_files:
-        rel = os.path.relpath(bf, mode.benchmark_dir())
+        rel = os.path.relpath(bf, mode.benchmark_dir()).replace(os.sep, "/")
         selected_benchmarks.add(rel)
         if rel in done_pass:
             continue
@@ -2926,7 +3831,10 @@ def main():
                 keep_container=use_container and args.keep_container,
                 session_dir=session_dir,
                 canonical_inputs=canonical_inputs_by_path.get(bf),
+                agent_skills_snapshot=agent_skills_snapshot,
                 run_identity=run_identity,
+                module_resume=module_resumes.get(rel),
+                module_checkpoint_identity=module_checkpoint_identities.get(rel),
             )
         )
 

--- a/src/evaluator/score.py
+++ b/src/evaluator/score.py
@@ -33,10 +33,11 @@ infra/quota before resolving is interrupted, not failed: like a non-genuine
 first attempt it is excluded from the continuation rate and reported separately
 (see ``continuation_interrupted``).
 
-The primary score is the strict specification pass rate. A represented source
-specification passes only when all of its applicable selected tasks pass. The
-task-level pass rate and specification-macro partial-credit average remain
-visible as secondary diagnostics.
+For module-level proof-from-scratch results, the primary score is dependency-
+closed proof-unit coverage: a module with k trusted original theorems out of n
+scores k/n, preserving theorem-level partial credit. Strict whole-module
+completion remains visible as a diagnostic. Other modes retain the strict
+specification pass rate as their primary score.
 
 The legacy pluggable task scorer assigns a non-negative weight to each task;
 the score of a group of tasks is
@@ -59,7 +60,9 @@ from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
+from common.proof_from_scratch_manifest import load_module_task_manifest
 from common.task_contract import load_manifest_specification_ids
+from evaluator.proof_module_result import ModuleResultError, validate_module_result
 
 PASS_VERDICT = "PASS"
 SKIP_VERDICT = "SKIP"
@@ -93,6 +96,20 @@ class SpecificationScore:
     non_applicable_results: int
 
 
+@dataclass(frozen=True)
+class ProofUnitScore:
+    """Dependency-closed target coverage across module-level tasks."""
+
+    trusted_units: int
+    total_units: int
+    represented_modules: int
+    excluded_modules: int
+
+    @property
+    def trusted_pct(self) -> float:
+        return 100.0 * self.trusted_units / self.total_units if self.total_units else 0.0
+
+
 def is_pass(result: dict) -> bool:
     """A task passed iff its verdict is exactly PASS (CHEATING/FAIL/... do not)."""
     return result.get("check_verdict") == PASS_VERDICT
@@ -105,8 +122,15 @@ def is_skipped(result: dict) -> bool:
 
 def is_non_genuine(result: dict) -> bool:
     """A run cut short by infra/quota. Missing termination_reason means legacy
-    result files stay scored."""
-    return result.get("termination_reason") in NON_GENUINE_TERMINATIONS
+    result files stay scored. A last-saved module that was successfully graded
+    after model work remains a genuine capability result despite the external
+    interruption that ended its agent process."""
+    interrupted = result.get("termination_reason") in NON_GENUINE_TERMINATIONS
+    graded_progress = result.get("graded_after_interruption") is True and isinstance(result.get("module_result"), dict)
+    invalid_submission = (
+        result.get("invalid_submission_after_interruption") is True and result.get("check_verdict") == "FAIL"
+    )
+    return interrupted and not (graded_progress or invalid_submission)
 
 
 def continuation_passed(result: dict) -> bool:
@@ -160,6 +184,76 @@ def continuation_rate_line(results: list[dict], weight: Callable[[dict], float],
     n_cut = sum(1 for r in results if continuation_interrupted(r))
     if n_cut:
         line += f" · {n_cut} chain(s) infra/quota-cut (excluded — re-run)"
+    return line
+
+
+def _module_proof_unit_ids(result: Mapping[str, object]) -> tuple[str, ...] | None:
+    value = result.get("proof_unit_ids")
+    if type(value) is not list or not value or any(type(unit_id) is not str or not unit_id for unit_id in value):
+        return None
+    if len(value) != len(set(value)):
+        return None
+    return tuple(value)
+
+
+def _effective_module_attempt(result: dict, *, with_continuations: bool) -> Mapping[str, object]:
+    if not with_continuations:
+        return result
+    attempts = [result, *(attempt for attempt in (result.get("continuations") or []) if isinstance(attempt, Mapping))]
+    passing = [
+        attempt
+        for attempt in attempts
+        if attempt.get("check_verdict") == PASS_VERDICT and isinstance(attempt.get("module_result"), dict)
+    ]
+    if passing:
+        return passing[0]
+    graded = [attempt for attempt in attempts if isinstance(attempt.get("module_result"), dict)]
+    return graded[-1] if graded else result
+
+
+def proof_unit_score(results: list[dict], *, with_continuations: bool = False) -> ProofUnitScore:
+    """Return proof-unit micro coverage without trusting persisted derived counts."""
+
+    trusted = 0
+    total = 0
+    represented = 0
+    excluded = 0
+    for result in results:
+        unit_ids = _module_proof_unit_ids(result)
+        if unit_ids is None:
+            continue
+        represented += 1
+        if is_skipped(result) or is_non_genuine(result) or (with_continuations and continuation_interrupted(result)):
+            excluded += 1
+            continue
+        total += len(unit_ids)
+        attempt = _effective_module_attempt(result, with_continuations=with_continuations)
+        raw_report = attempt.get("module_result")
+        if not isinstance(raw_report, dict):
+            continue
+        try:
+            report = validate_module_result(raw_report, unit_ids)
+        except ModuleResultError:
+            continue
+        trusted += len(report["trusted_proof_unit_ids"])
+    return ProofUnitScore(
+        trusted_units=trusted,
+        total_units=total,
+        represented_modules=represented,
+        excluded_modules=excluded,
+    )
+
+
+def proof_unit_rate_line(results: list[dict], *, with_continuations: bool = False) -> str | None:
+    score = proof_unit_score(results, with_continuations=with_continuations)
+    if not score.represented_modules:
+        return None
+    qualifier = "with continuations" if with_continuations else "pass@1"
+    line = (
+        f"**Proof-unit score (k/n, {qualifier})**: {score.trusted_units}/{score.total_units} ({score.trusted_pct:.1f}%)"
+    )
+    if score.excluded_modules:
+        line += f" · {score.excluded_modules} module(s) skipped or interrupted (excluded — re-run)"
     return line
 
 
@@ -302,7 +396,14 @@ def load_current_specification_ids(
     for mode in sorted(set(modes)):
         if mode not in supported_modes:
             raise ValueError(f"cannot load specification identities for unknown mode {mode!r}")
-        task_specification_ids = load_manifest_specification_ids(root / mode, suite_name=mode)
+        if mode == "proof-from-scratch":
+            manifest = load_module_task_manifest(
+                root / "proof-from-scratch-module",
+                corpus_manifest_path=root / "proof-from-scratch" / "manifest.json",
+            )
+            task_specification_ids = {entry.spec.task_id: entry.spec.task_id for entry in manifest.entries}
+        else:
+            task_specification_ids = load_manifest_specification_ids(root / mode, suite_name=mode)
         specification_ids.update(scope_specification_ids(mode, task_specification_ids))
     return specification_ids
 
@@ -440,6 +541,11 @@ def scorecard_md(
         "",
         f"**Source**: {run['path']}",
     ]
+    unit_line = proof_unit_rate_line(scoring_results)
+    if unit_line:
+        # Issue #132 defines one module's score as k/n trusted theorems. Keep
+        # this ahead of strict whole-module completion diagnostics.
+        lines.append(unit_line)
     if specification_ids is None:
         skipped = n_skipped(results)
         non_genuine = n_non_genuine(results)
@@ -458,6 +564,9 @@ def scorecard_md(
     cont_line = continuation_rate_line(scoring_results, weight, n_pass)
     if cont_line:
         lines.append(cont_line)
+    continuation_unit_line = proof_unit_rate_line(scoring_results, with_continuations=True)
+    if continuation_unit_line and any(result.get("continuations") for result in scoring_results):
+        lines.append(continuation_unit_line)
     if has_equivalent_cost:
         lines.append(f"**Tokens**: {in_tok:,} in / {out_tok:,} out")
         lines.append(f"**Total task time**: {_format_time(secs)}")
@@ -519,6 +628,14 @@ def comparison_md(
     if scoring_name not in {"equal", SPECIFICATION_EQUAL}:
         lines += [f"**Scoring**: {scoring_name} (weighted)", ""]
     show_equivalent_cost = any(_has_equivalent_cost(run["results"]) for run in runs)
+    show_proof_units = any(
+        proof_unit_score(
+            run["results"]
+            if specification_ids is None
+            else applicable_manifest_results(run["results"], specification_ids)
+        ).represented_modules
+        for run in runs
+    )
     score_columns = (
         "Specification pass rate | Task pass rate | Specification macro"
         if specification_ids is not None
@@ -529,6 +646,9 @@ def comparison_md(
         if specification_ids is not None
         else "-------:|-------------:"
     )
+    if show_proof_units:
+        score_columns = "Proof-unit score (k/n) | " + score_columns
+        score_alignment = "----------------------:|" + score_alignment
     if show_equivalent_cost:
         lines += [
             f"| Run | Backend | Mode | {score_columns} | Tokens (in/out) | Time | Equivalent cost |",
@@ -584,6 +704,16 @@ def comparison_md(
                 f"{n_pass}/{n_total} ({specification_score.task_micro_pct:.1f}%){score_notes} | "
                 f"{specification_score.specification_macro_pct:.1f}%"
             )
+        if show_proof_units:
+            unit_score = proof_unit_score(scoring_results)
+            unit_cell = (
+                f"{unit_score.trusted_units}/{unit_score.total_units} ({unit_score.trusted_pct:.1f}%)"
+                if unit_score.represented_modules
+                else "—"
+            )
+            if unit_score.excluded_modules:
+                unit_cell += f" (+{unit_score.excluded_modules} excluded)"
+            score_cells = f"{unit_cell} | {score_cells}"
         row = f"| {run['id']} | {run['backend']} | {run['mode']} | {score_cells} | {in_tok:,}/{out_tok:,} | "
         if show_equivalent_cost:
             time_text = (
@@ -609,7 +739,10 @@ def comparison_md(
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="tlaps-bench score",
-        description="Score benchmark results (strict specification pass rate plus diagnostics) from results.json.",
+        description=(
+            "Score benchmark results (proof-unit k/n for module tasks; strict specification completion otherwise) "
+            "from results.json."
+        ),
     )
     parser.add_argument("paths", nargs="+", help="One or more results.json files or run directories")
     parser.add_argument(
@@ -617,7 +750,7 @@ def main() -> int:
         default=SPECIFICATION_EQUAL,
         choices=[SPECIFICATION_EQUAL, *sorted(SCORERS)],
         help=(
-            "Scoring scheme (default: specification-equal with strict specification pass rate primary; "
+            "Scoring scheme (default: proof-unit k/n for module tasks and specification-equal otherwise; "
             "'equal' retains legacy task-level scoring)"
         ),
     )

--- a/tests/common/test_check_proof_module_task.py
+++ b/tests/common/test_check_proof_module_task.py
@@ -1,0 +1,366 @@
+"""Focused tests for the checker’s complete module-task path."""
+
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from common import check_proof
+from common.proof_from_scratch_module import begin_agent_proof, end_agent_proof
+from common.task_contract import BEGIN_AGENT_HELPERS, END_AGENT_HELPERS
+from evaluator.proof_module_result import validate_module_result
+from tlacore.model import Loc, Module, Theorem
+from tlacore.sany.dump import SanyRun, SanyStatus
+
+UNIT_A = "Suite/Task_A.tla"
+UNIT_B = "Suite/Task_B.tla"
+HELPER = "helper:Bridge"
+
+
+def _unit(
+    unit_id: str,
+    *,
+    kind: str = "target",
+    theorem_name: str | None = "Target",
+    line_start: int = 10,
+    line_end: int = 20,
+    dependencies: tuple[str, ...] = (),
+    admitted: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        unit_id=unit_id,
+        kind=kind,
+        theorem_name=theorem_name,
+        line_start=line_start,
+        line_end=line_end,
+        dependencies=dependencies,
+        admitted=admitted,
+    )
+
+
+def _analysis(
+    target_units: tuple[SimpleNamespace, ...],
+    helper_units: tuple[SimpleNamespace, ...] = (),
+) -> SimpleNamespace:
+    checked_units = (*target_units, *helper_units)
+    return SimpleNamespace(
+        target_units=target_units,
+        helper_units=helper_units,
+        checked_units=checked_units,
+        local_dependencies={unit.unit_id: unit.dependencies for unit in checked_units},
+        unused_helper_names=(),
+    )
+
+
+def _write_inputs(
+    tmp_path,
+    *,
+    canonical_source: str = "---- MODULE Task ----\n====\n",
+    submitted_source: str | None = None,
+    context: tuple[tuple[str, str], ...] = (),
+):
+    workspace = tmp_path / "workspace"
+    benchmark = tmp_path / "canonical"
+    workspace.mkdir()
+    benchmark.mkdir()
+    if submitted_source is None:
+        submitted_source = canonical_source
+    (workspace / "Task.tla").write_text(submitted_source, encoding="utf-8")
+    (benchmark / "Task.tla").write_text(canonical_source, encoding="utf-8")
+    for name, source in context:
+        (benchmark / name).write_text(source, encoding="utf-8")
+        (workspace / name).write_text(source, encoding="utf-8")
+    return workspace / "Task.tla", benchmark
+
+
+def _valid_sany() -> SanyRun:
+    return SanyRun(SanyStatus.VALID, ("sany",), 0, "", "", "", {})
+
+
+def _report(lines: list[str]) -> dict[str, object]:
+    reports = [
+        line.removeprefix(check_proof.MODULE_RESULT_PREFIX)
+        for line in lines
+        if line.startswith(check_proof.MODULE_RESULT_PREFIX)
+    ]
+    assert len(reports) == 1
+    return json.loads(reports[0])
+
+
+def _tlapm_responses(responses: dict[int, tuple[str, str, int]], calls: list[list[str]]):
+    def run(command, _timeout, _cwd):
+        calls.append(command)
+        start = int(command[command.index("--toolbox") + 1])
+        return responses[start]
+
+    return run
+
+
+def _patch_common(monkeypatch, analysis, *, run_killgroup):
+    monkeypatch.setattr(check_proof, "run_normalized", lambda *_args, **_kwargs: _valid_sany())
+    monkeypatch.setattr(check_proof, "analyze_module_submission", lambda **_kwargs: analysis)
+    monkeypatch.setattr(check_proof, "find_community_lib", lambda _filepath: None)
+    monkeypatch.setattr(check_proof, "run_killgroup", run_killgroup)
+
+
+def _run_module_check(monkeypatch, tmp_path, analysis, *, responses, context=()):
+    filepath, benchmark = _write_inputs(tmp_path, context=context)
+    calls: list[list[str]] = []
+    _patch_common(monkeypatch, analysis, run_killgroup=_tlapm_responses(responses, calls))
+    lines: list[str] = []
+    output = tmp_path / "check.result"
+    exit_code = check_proof.run_module_task_check(
+        filepath=str(filepath),
+        benchmark_dir=str(benchmark),
+        expected_unit_ids=tuple(unit.unit_id for unit in analysis.target_units),
+        tlapm_path="tlapm",
+        tlapm_lib="/tlaps/lib",
+        timeout=30,
+        output_path=str(output),
+        import_violations=[],
+        emit=lines.append,
+    )
+    return exit_code, lines, calls
+
+
+def test_module_check_reports_raw_results_and_dependency_closed_trust(tmp_path, monkeypatch):
+    target_a = _unit(UNIT_A, theorem_name="A", line_start=10)
+    target_b = _unit(UNIT_B, theorem_name="B", line_start=50, line_end=60, dependencies=(HELPER,))
+    helper = _unit(HELPER, kind="helper", theorem_name="Bridge", line_start=30, line_end=40)
+    analysis = _analysis((target_a, target_b), (helper,))
+    passed = ("[INFO]: All 1 obligation proved.\n", "", 0)
+
+    exit_code, lines, _calls = _run_module_check(
+        monkeypatch,
+        tmp_path,
+        analysis,
+        responses={10: passed, 30: passed, 50: passed},
+    )
+
+    assert exit_code == 0
+    report = _report(lines)
+    assert report["proof_unit_ids"] == [UNIT_A, UNIT_B]
+    assert report["trusted_unit_ids"] == [UNIT_A, UNIT_B, HELPER]
+    assert report["trusted_proof_unit_ids"] == [UNIT_A, UNIT_B]
+    assert report["complete"] is True
+    units = {unit["unit_id"]: unit for unit in report["units"]}
+    assert {unit_id: unit["raw_verdict"] for unit_id, unit in units.items()} == {
+        UNIT_A: "PASS",
+        UNIT_B: "PASS",
+        HELPER: "PASS",
+    }
+    assert all(unit["trusted"] for unit in units.values())
+    validate_module_result(report, (UNIT_A, UNIT_B))
+
+
+def _marked_source(unit_id: str, proof: str = "PROOF OMITTED") -> str:
+    return "\n".join(
+        (
+            "---- MODULE Task ----",
+            BEGIN_AGENT_HELPERS,
+            END_AGENT_HELPERS,
+            "",
+            "THEOREM Target == TRUE",
+            begin_agent_proof(unit_id),
+            proof,
+            end_agent_proof(unit_id),
+            "====",
+            "",
+        )
+    )
+
+
+def _module_for_marked_source(source: str, unit_id: str) -> Module:
+    lines = source.splitlines()
+    statement = lines.index("THEOREM Target == TRUE") + 1
+    begin = lines.index(begin_agent_proof(unit_id)) + 1
+    end = lines.index(end_agent_proof(unit_id)) + 1
+    body = begin + 1
+    theorem = Theorem(
+        name="Target",
+        loc=Loc(statement, 1, end, 1),
+        statement_loc=Loc(statement, 1, statement, 22),
+        proof_loc=Loc(body, 1, body, len(lines[body - 1]) + 1),
+        proof_is_omitted=True,
+        references=[],
+        statement_references=[],
+        shape={},
+    )
+    return Module(
+        name="Task",
+        source_file="Task.tla",
+        filename="Task.tla",
+        line_start=1,
+        line_end=len(lines),
+        extends=[],
+        constants=[],
+        variables=[],
+        assumes=[],
+        instances=[],
+        operators=[],
+        spec_formulas=[],
+        theorems=[theorem],
+    )
+
+
+def test_unchanged_proof_omitted_is_unresolved_and_not_trusted(tmp_path, monkeypatch):
+    unit_id = UNIT_A
+    source = _marked_source(unit_id)
+    filepath, benchmark = _write_inputs(tmp_path, canonical_source=source)
+    module = _module_for_marked_source(source, unit_id)
+    monkeypatch.setattr(check_proof, "run_normalized", lambda *_args, **_kwargs: _valid_sany())
+    monkeypatch.setattr(check_proof.Module, "parse", lambda _raw: module)
+    monkeypatch.setattr(check_proof, "find_community_lib", lambda _filepath: None)
+    monkeypatch.setattr(
+        check_proof,
+        "run_killgroup",
+        lambda *_args, **_kwargs: pytest.fail("an admitted PROOF OMITTED unit must not invoke TLAPM"),
+    )
+    lines: list[str] = []
+
+    exit_code = check_proof.run_module_task_check(
+        filepath=str(filepath),
+        benchmark_dir=str(benchmark),
+        expected_unit_ids=(unit_id,),
+        tlapm_path="tlapm",
+        tlapm_lib="/tlaps/lib",
+        timeout=30,
+        output_path=str(tmp_path / "check.result"),
+        import_violations=[],
+        emit=lines.append,
+    )
+
+    assert exit_code == 1
+    report = _report(lines)
+    assert report["units"][0]["raw_verdict"] == "UNRESOLVED"
+    assert report["units"][0]["missing_proofs"] == 1
+    assert report["units"][0]["trusted"] is False
+    assert report["trusted_unit_ids"] == []
+    assert report["trusted_proof_unit_ids"] == []
+    assert report["complete"] is False
+    validate_module_result(report, (unit_id,))
+
+
+def test_raw_pass_with_untrusted_dependency_is_blocked(tmp_path, monkeypatch):
+    admitted = _unit(UNIT_A, theorem_name="A", line_start=10, admitted=True)
+    dependent = _unit(UNIT_B, theorem_name="B", line_start=50, line_end=60, dependencies=(UNIT_A,))
+    analysis = _analysis((admitted, dependent))
+    passed = ("[INFO]: All 1 obligation proved.\n", "", 0)
+
+    exit_code, lines, calls = _run_module_check(
+        monkeypatch,
+        tmp_path,
+        analysis,
+        responses={50: passed},
+    )
+
+    assert exit_code == 1
+    assert len(calls) == 1
+    report = _report(lines)
+    units = {unit["unit_id"]: unit for unit in report["units"]}
+    assert units[UNIT_A]["raw_verdict"] == "UNRESOLVED"
+    assert units[UNIT_B]["raw_verdict"] == "PASS"
+    assert units[UNIT_A]["trusted"] is False
+    assert units[UNIT_B]["trusted"] is False
+    assert report["trusted_unit_ids"] == []
+    assert report["trusted_proof_unit_ids"] == []
+    assert report["complete"] is False
+    validate_module_result(report, (UNIT_A, UNIT_B))
+
+
+def test_tlapm_exit_eleven_cannot_be_a_raw_module_unit_pass(tmp_path, monkeypatch):
+    analysis = _analysis((_unit(UNIT_A, theorem_name="A", line_start=10),))
+    admitted_output = (
+        "Proof incomplete in module Task: 0 missing, 1 omitted\n",
+        "",
+        11,
+    )
+
+    exit_code, lines, _calls = _run_module_check(
+        monkeypatch,
+        tmp_path,
+        analysis,
+        responses={10: admitted_output},
+    )
+
+    assert exit_code == 1
+    report = _report(lines)
+    assert report["units"][0]["raw_verdict"] == "FAIL"
+    assert report["units"][0]["tlapm_exit"] == 11
+    assert report["units"][0]["trusted"] is False
+    assert report["trusted_proof_unit_ids"] == []
+    validate_module_result(report, (UNIT_A,))
+
+
+def test_context_integrity_failure_emits_machine_report_and_exit_one(tmp_path, monkeypatch):
+    context_source = "---- MODULE Model ----\n====\n"
+    analysis = _analysis((_unit(UNIT_A, line_start=10),))
+    filepath, benchmark = _write_inputs(tmp_path, context=(("Model.tla", context_source),))
+    (filepath.parent / "Model.tla").write_text(
+        "---- MODULE Model ----\nTHEOREM Changed == TRUE\n====\n", encoding="utf-8"
+    )
+    _patch_common(monkeypatch, analysis, run_killgroup=lambda *_args: pytest.fail("context failure must stop TLAPM"))
+    lines: list[str] = []
+
+    exit_code = check_proof.run_module_task_check(
+        filepath=str(filepath),
+        benchmark_dir=str(benchmark),
+        expected_unit_ids=(UNIT_A,),
+        tlapm_path="tlapm",
+        tlapm_lib="/tlaps/lib",
+        timeout=30,
+        output_path=str(tmp_path / "check.result"),
+        import_violations=[],
+        emit=lines.append,
+    )
+
+    assert exit_code == 1
+    report = _report(lines)
+    assert report["units"] == []
+    assert report["trusted_unit_ids"] == []
+    assert report["trusted_proof_unit_ids"] == []
+    assert report["complete"] is False
+    assert [issue["code"] for issue in report["integrity_issues"]] == ["CONTEXT_MODIFIED"]
+    validate_module_result(report, (UNIT_A,))
+
+
+def test_context_hardlink_alias_is_rejected(tmp_path):
+    context_source = "---- MODULE Model ----\n====\n"
+    filepath, benchmark = _write_inputs(tmp_path, context=(("Model.tla", context_source),))
+    workspace_context = filepath.parent / "Model.tla"
+    workspace_context.unlink()
+    os.link(benchmark / "Model.tla", workspace_context)
+
+    assert check_proof._module_context_issues(str(filepath), str(benchmark)) == [
+        ("CONTEXT_MODIFIED", "context file 'Model.tla' aliases the canonical input")
+    ]
+
+
+def test_unit_checker_error_emits_machine_report_and_exit_three(tmp_path, monkeypatch):
+    unit = _unit(UNIT_A, line_start=10)
+    analysis = _analysis((unit,))
+    filepath, benchmark = _write_inputs(tmp_path)
+    _patch_common(monkeypatch, analysis, run_killgroup=lambda *_args: (_ for _ in ()).throw(OSError("tlapm missing")))
+    lines: list[str] = []
+
+    exit_code = check_proof.run_module_task_check(
+        filepath=str(filepath),
+        benchmark_dir=str(benchmark),
+        expected_unit_ids=(UNIT_A,),
+        tlapm_path="tlapm",
+        tlapm_lib="/tlaps/lib",
+        timeout=30,
+        output_path=str(tmp_path / "check.result"),
+        import_violations=[],
+        emit=lines.append,
+    )
+
+    assert exit_code == 3
+    report = _report(lines)
+    assert report["units"][0]["raw_verdict"] == "ERROR"
+    assert report["units"][0]["trusted"] is False
+    assert report["complete"] is False
+    validate_module_result(report, (UNIT_A,))

--- a/tests/common/test_proof_from_scratch_grading.py
+++ b/tests/common/test_proof_from_scratch_grading.py
@@ -1,0 +1,580 @@
+"""Pure tests for module-level proof-from-scratch grading analysis."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+
+import pytest
+
+from common.proof_from_scratch_grading import (
+    HELPER_UNIT_PREFIX,
+    ModuleSubmissionError,
+    analyze_module_submission,
+    proof_unit_ids_from_markers,
+)
+from common.proof_from_scratch_module import (
+    begin_agent_proof,
+    compute_trusted_units,
+    end_agent_proof,
+)
+from common.task_contract import BEGIN_AGENT_HELPERS, END_AGENT_HELPERS
+from tlacore.model import Assumption, Loc, Module, ModuleDirective, Symbol, Theorem
+
+UNIT_A = "Suite/Task_A.tla"
+UNIT_B = "Suite/Task_B.tla"
+UNITS = (UNIT_A, UNIT_B)
+STATEMENTS = {
+    UNIT_A: "THEOREM A == TRUE",
+    UNIT_B: "THEOREM B == TRUE",
+}
+PROOF_BODIES = {UNIT_A: "PROOF OMITTED", UNIT_B: "PROOF OMITTED"}
+
+
+def _source(
+    *,
+    helper_lines: Sequence[str] = (),
+    proof_bodies: Mapping[str, str] | None = None,
+    statements: Mapping[str, str] | None = None,
+    marker_order: Sequence[str] = UNITS,
+) -> str:
+    bodies = dict(PROOF_BODIES if proof_bodies is None else proof_bodies)
+    target_statements = dict(STATEMENTS if statements is None else statements)
+    lines = [
+        "---- MODULE Task ----",
+        "EXTENDS TaskDefs",
+        "",
+        BEGIN_AGENT_HELPERS,
+        *helper_lines,
+        END_AGENT_HELPERS,
+    ]
+    for unit_id in marker_order:
+        lines.extend(
+            [
+                "",
+                target_statements[unit_id],
+                begin_agent_proof(unit_id),
+                *bodies[unit_id].splitlines(),
+                end_agent_proof(unit_id),
+            ]
+        )
+    lines.extend(("====", ""))
+    return "\n".join(lines)
+
+
+def _line_loc(source: str, text: str, *, occurrence: int = 0) -> Loc:
+    matches = [line_no for line_no, line in enumerate(source.splitlines(), start=1) if line == text]
+    if len(matches) <= occurrence:
+        raise AssertionError(f"could not find occurrence {occurrence} of {text!r}")
+    line_no = matches[occurrence]
+    return Loc(line_no, 1, line_no, len(text) + 1)
+
+
+def _body_loc(source: str, begin_marker: str, end_marker: str) -> Loc | None:
+    lines = source.splitlines()
+    begin = lines.index(begin_marker)
+    end = lines.index(end_marker)
+    if begin + 1 >= end:
+        return None
+    return Loc(begin + 2, 1, end, len(lines[end - 1]) + 1)
+
+
+def _helper_lines(helper_specs: Iterable[tuple[str, Sequence[str], str]]) -> list[str]:
+    lines: list[str] = []
+    for name, _references, proof_body in helper_specs:
+        lines.extend([f"THEOREM {name} == TRUE", *proof_body.splitlines()])
+    return lines
+
+
+def _module(
+    source: str,
+    *,
+    target_references: Mapping[str, Sequence[str]] | None = None,
+    helper_specs: Sequence[tuple[str, Sequence[str], str]] = (),
+    statements: Mapping[str, str] | None = None,
+    proof_loc_overrides: Mapping[str, Loc | None] | None = None,
+    helper_loc_overrides: Mapping[str, Loc | None] | None = None,
+    constants: Sequence[Symbol] = (),
+    variables: Sequence[Symbol] = (),
+    assumes: Sequence[Assumption] = (),
+    inner_modules: Sequence[Symbol] = (),
+    directives: Sequence[ModuleDirective] = (),
+) -> Module:
+    target_references = target_references or {}
+    target_statements = dict(STATEMENTS if statements is None else statements)
+    proof_loc_overrides = proof_loc_overrides or {}
+    helper_loc_overrides = helper_loc_overrides or {}
+
+    theorems: list[Theorem] = []
+    for unit_id in UNITS:
+        statement = target_statements[unit_id]
+        statement_loc = _line_loc(source, statement)
+        body_loc = _body_loc(source, begin_agent_proof(unit_id), end_agent_proof(unit_id))
+        proof_loc = proof_loc_overrides.get(unit_id, body_loc)
+        body_text = (
+            "" if body_loc is None else "\n".join(source.splitlines()[body_loc.line_start - 1 : body_loc.line_end])
+        )
+        theorems.append(
+            Theorem(
+                name=statement.split()[1],
+                loc=Loc(statement_loc.line_start, 1, proof_loc.line_end if proof_loc else statement_loc.line_end, 1),
+                statement_loc=statement_loc,
+                proof_loc=proof_loc,
+                proof_is_omitted=body_text.strip() == "PROOF OMITTED",
+                references=list(target_references.get(unit_id, ())),
+                statement_references=[],
+                shape={},
+            )
+        )
+
+    lines = source.splitlines()
+    for name, references, proof_body in helper_specs:
+        declaration = f"THEOREM {name} == TRUE"
+        declaration_loc = _line_loc(source, declaration)
+        declaration_index = declaration_loc.line_start - 1
+        proof_lines = proof_body.splitlines()
+        body_loc = Loc(
+            declaration_loc.line_start + 1,
+            1,
+            declaration_loc.line_start + len(proof_lines),
+            len(lines[declaration_index + len(proof_lines)]) + 1,
+        )
+        proof_loc = helper_loc_overrides.get(name, body_loc)
+        theorems.append(
+            Theorem(
+                name=name,
+                loc=Loc(
+                    declaration_loc.line_start, 1, proof_loc.line_end if proof_loc else declaration_loc.line_end, 1
+                ),
+                statement_loc=declaration_loc,
+                proof_loc=proof_loc,
+                proof_is_omitted=proof_body.strip() == "PROOF OMITTED",
+                references=list(references),
+                statement_references=[],
+                shape={},
+            )
+        )
+
+    theorems.sort(key=lambda theorem: theorem.loc.line_start if theorem.loc else 0)
+    return Module(
+        name="Task",
+        source_file="Task.tla",
+        filename="Task.tla",
+        line_start=1,
+        line_end=len(lines),
+        extends=["TaskDefs"],
+        constants=list(constants),
+        variables=list(variables),
+        assumes=list(assumes),
+        instances=[],
+        operators=[],
+        spec_formulas=[],
+        theorems=theorems,
+        inner_modules=list(inner_modules),
+        directives=list(directives),
+    )
+
+
+def _submission(
+    *,
+    helper_specs: Sequence[tuple[str, Sequence[str], str]] = (),
+    helper_lines: Sequence[str] | None = None,
+    target_references: Mapping[str, Sequence[str]] | None = None,
+    proof_bodies: Mapping[str, str] | None = None,
+    statements: Mapping[str, str] | None = None,
+    marker_order: Sequence[str] = UNITS,
+    proof_loc_overrides: Mapping[str, Loc | None] | None = None,
+    helper_loc_overrides: Mapping[str, Loc | None] | None = None,
+    constants: Sequence[Symbol] = (),
+    variables: Sequence[Symbol] = (),
+    assumes: Sequence[Assumption] = (),
+    inner_modules: Sequence[Symbol] = (),
+    directives: Sequence[ModuleDirective] = (),
+) -> tuple[str, str, Module]:
+    submitted_helper_lines = _helper_lines(helper_specs) if helper_lines is None else list(helper_lines)
+    submitted = _source(
+        helper_lines=submitted_helper_lines,
+        proof_bodies=proof_bodies,
+        statements=statements,
+        marker_order=marker_order,
+    )
+    canonical = _source()
+    module = _module(
+        submitted,
+        target_references=target_references,
+        helper_specs=helper_specs,
+        statements=statements,
+        proof_loc_overrides=proof_loc_overrides,
+        helper_loc_overrides=helper_loc_overrides,
+        constants=constants,
+        variables=variables,
+        assumes=assumes,
+        inner_modules=inner_modules,
+        directives=directives,
+    )
+    return canonical, submitted, module
+
+
+def _analyze(**kwargs) -> object:
+    canonical, submitted, module = _submission(**kwargs)
+    return analyze_module_submission(
+        canonical_source=canonical,
+        submitted_source=submitted,
+        expected_unit_ids=UNITS,
+        module=module,
+    )
+
+
+def test_independent_targets_allow_partial_trust():
+    analysis = _analyze(
+        proof_bodies={UNIT_A: "PROOF BY TRUE", UNIT_B: "PROOF BY TRUE"},
+    )
+
+    assert analysis.local_dependencies == {UNIT_A: (), UNIT_B: ()}
+    assert compute_trusted_units({UNIT_A}, analysis.local_dependencies) == frozenset({UNIT_A})
+
+
+def test_target_to_target_dependency_requires_the_prerequisite():
+    analysis = _analyze(
+        proof_bodies={UNIT_A: "PROOF BY TRUE", UNIT_B: "PROOF BY A"},
+        target_references={UNIT_B: ("A",)},
+    )
+
+    assert analysis.local_dependencies == {UNIT_A: (), UNIT_B: (UNIT_A,)}
+    assert compute_trusted_units({UNIT_B}, analysis.local_dependencies) == frozenset()
+    assert compute_trusted_units(set(UNITS), analysis.local_dependencies) == frozenset(UNITS)
+
+
+def test_reachable_helper_dependencies_are_included_in_the_graph():
+    helper = HELPER_UNIT_PREFIX + "Bridge"
+    analysis = _analyze(
+        helper_specs=(("Bridge", ("A",), "PROOF BY A"),),
+        proof_bodies={UNIT_A: "PROOF BY TRUE", UNIT_B: "PROOF BY Bridge"},
+        target_references={UNIT_B: ("Bridge",)},
+    )
+
+    assert [unit.unit_id for unit in analysis.helper_units] == [helper]
+    assert analysis.local_dependencies == {
+        UNIT_A: (),
+        UNIT_B: (helper,),
+        helper: (UNIT_A,),
+    }
+    assert compute_trusted_units(set(analysis.local_dependencies), analysis.local_dependencies) == frozenset(
+        analysis.local_dependencies
+    )
+
+
+def test_unused_helpers_are_not_scored_or_added_to_local_dependencies():
+    helper = HELPER_UNIT_PREFIX + "Unused"
+    analysis = _analyze(
+        helper_specs=(("Unused", (), "PROOF BY TRUE"),),
+        proof_bodies={UNIT_A: "PROOF BY TRUE", UNIT_B: "PROOF BY TRUE"},
+    )
+
+    assert analysis.helper_units == ()
+    assert analysis.unused_helper_names == ("Unused",)
+    assert helper not in analysis.local_dependencies
+
+
+def test_cycle_of_targets_cannot_trust_itself():
+    analysis = _analyze(
+        proof_bodies={UNIT_A: "PROOF BY B", UNIT_B: "PROOF BY A"},
+        target_references={UNIT_A: ("B",), UNIT_B: ("A",)},
+    )
+
+    assert analysis.local_dependencies == {UNIT_A: (UNIT_B,), UNIT_B: (UNIT_A,)}
+    assert compute_trusted_units(set(UNITS), analysis.local_dependencies) == frozenset()
+
+
+def test_omitted_helper_is_rejected_before_dependency_scoring():
+    with pytest.raises(ModuleSubmissionError) as caught:
+        _analyze(
+            helper_specs=(("Bridge", (), "PROOF OMITTED"),),
+            proof_bodies={UNIT_A: "PROOF BY TRUE", UNIT_B: "PROOF BY Bridge"},
+            target_references={UNIT_B: ("Bridge",)},
+        )
+
+    assert caught.value.code == "PROOF_OMITTED_ADDED"
+
+
+def test_nested_omitted_step_in_target_is_rejected():
+    with pytest.raises(ModuleSubmissionError) as caught:
+        _analyze(
+            proof_bodies={
+                UNIT_A: "PROOF\n<1>1. TRUE\n  PROOF OMITTED\n<1> QED BY <1>1",
+                UNIT_B: "PROOF BY TRUE",
+            }
+        )
+
+    assert caught.value.code == "PROOF_OMITTED_ADDED"
+
+
+def test_omitted_text_in_comments_and_strings_is_not_an_admission():
+    analysis = _analyze(
+        helper_lines=('Message == "OMITTED"',),
+        proof_bodies={
+            UNIT_A: 'PROOF BY "OMITTED" = "OMITTED"',
+            UNIT_B: r"PROOF BY TRUE \* OMITTED is forbidden here",
+        },
+    )
+
+    assert analysis.local_dependencies == {UNIT_A: (), UNIT_B: ()}
+
+
+@pytest.mark.parametrize("budget", ["1", "5", "30", "01"])
+@pytest.mark.parametrize("spacing", ["", " ", "  \n  "])
+def test_deterministic_smt_budget_accepts_bounded_smt_calls(budget: str, spacing: str):
+    smt_call = f'SMTT{spacing}({spacing}"r{budget}"{spacing})'
+    analysis = _analyze(
+        helper_lines=[f"Helper == {smt_call}"],
+        proof_bodies={UNIT_A: f"PROOF BY {smt_call}", UNIT_B: "PROOF BY TRUE"},
+    )
+
+    assert analysis.local_dependencies == {UNIT_A: (), UNIT_B: ()}
+
+
+@pytest.mark.parametrize(
+    "smt_call",
+    [
+        "SMT",
+        "SMTT",
+        'SMTT("r0")',
+        'SMTT("r31")',
+        "SMTT(5)",
+        'SMTT("R5")',
+        'SMTT("r5", 1)',
+    ],
+)
+def test_invalid_deterministic_smt_budget_is_rejected(smt_call: str):
+    with pytest.raises(ModuleSubmissionError) as caught:
+        _analyze(proof_bodies={UNIT_A: f"PROOF BY {smt_call}", UNIT_B: "PROOF BY TRUE"})
+
+    assert caught.value.code == "SMT_BUDGET_INVALID"
+
+
+def test_smt_budget_scan_ignores_comments_and_strings():
+    analysis = _analyze(
+        helper_lines=[r'Message == "SMT SMTT(5) SMTT(\"r0\")"'],
+        proof_bodies={
+            UNIT_A: 'PROOF BY TRUE \\* SMT SMTT(5) SMTT("r0")',
+            UNIT_B: r'PROOF BY "SMT SMTT(5) SMTT(\"r0\")" = "SMT"',
+        },
+    )
+
+    assert analysis.local_dependencies == {UNIT_A: (), UNIT_B: ()}
+
+
+def test_proof_unit_ids_are_read_in_marker_order():
+    assert proof_unit_ids_from_markers(_source()) == UNITS
+
+
+def test_unknown_forged_marker_is_rejected():
+    forged = "Suite/Forged.tla"
+    canonical, submitted, module = _submission()
+    submitted = submitted.replace(
+        "====\n",
+        f"{begin_agent_proof(forged)}\nPROOF BY TRUE\n{end_agent_proof(forged)}\n====\n",
+    )
+
+    with pytest.raises(ModuleSubmissionError) as caught:
+        analyze_module_submission(
+            canonical_source=canonical,
+            submitted_source=submitted,
+            expected_unit_ids=UNITS,
+            module=module,
+        )
+
+    assert caught.value.code == "MODULE_MARKERS_INVALID"
+
+
+def test_reordered_markers_are_rejected():
+    canonical, submitted, module = _submission(
+        marker_order=(UNIT_B, UNIT_A),
+        proof_bodies={UNIT_A: "PROOF BY TRUE", UNIT_B: "PROOF BY TRUE"},
+    )
+
+    with pytest.raises(ModuleSubmissionError) as caught:
+        analyze_module_submission(
+            canonical_source=canonical,
+            submitted_source=submitted,
+            expected_unit_ids=UNITS,
+            module=module,
+        )
+
+    assert caught.value.code == "MODULE_MARKERS_INVALID"
+
+
+@pytest.mark.parametrize(
+    ("mutated", "statements"),
+    [
+        ("EXTENDS OtherDefs", None),
+        ("THEOREM B == FALSE", {UNIT_A: STATEMENTS[UNIT_A], UNIT_B: "THEOREM B == FALSE"}),
+    ],
+)
+def test_scaffold_and_statement_modification_are_rejected(mutated: str, statements: Mapping[str, str] | None):
+    canonical = _source()
+    submitted = (
+        canonical.replace("EXTENDS TaskDefs", mutated)
+        if mutated.startswith("EXTENDS")
+        else canonical.replace(STATEMENTS[UNIT_B], mutated)
+    )
+    module = _module(submitted, statements=statements)
+
+    with pytest.raises(ModuleSubmissionError) as caught:
+        analyze_module_submission(
+            canonical_source=canonical,
+            submitted_source=submitted,
+            expected_unit_ids=UNITS,
+            module=module,
+        )
+
+    assert caught.value.code == "SCAFFOLD_MODIFIED"
+
+
+def test_proof_region_cannot_lexically_extend_the_fixed_target_statement():
+    canonical, submitted, module = _submission(
+        proof_bodies={UNIT_A: "=> TRUE\nPROOF OBVIOUS", UNIT_B: "PROOF BY TRUE"},
+    )
+    statement = _line_loc(submitted, STATEMENTS[UNIT_A])
+    extension = _line_loc(submitted, "=> TRUE")
+    module.theorems[0].statement_loc = Loc(
+        statement.line_start,
+        statement.column_start,
+        extension.line_end,
+        extension.column_end,
+    )
+
+    with pytest.raises(ModuleSubmissionError) as caught:
+        analyze_module_submission(
+            canonical_source=canonical,
+            submitted_source=submitted,
+            expected_unit_ids=UNITS,
+            module=module,
+        )
+
+    assert caught.value.code == "TARGET_STATEMENT_MODIFIED"
+
+
+def test_helper_region_cannot_lexically_extend_canonical_imports():
+    submitted = _source(helper_lines=[", Naturals"])
+    module = _module(submitted)
+    module.extends.append("Naturals")
+
+    with pytest.raises(ModuleSubmissionError) as caught:
+        analyze_module_submission(
+            canonical_source=_source(),
+            submitted_source=submitted,
+            expected_unit_ids=UNITS,
+            module=module,
+            expected_extends=("TaskDefs",),
+        )
+
+    assert caught.value.code == "MODULE_EXTENDS_MODIFIED"
+
+
+def test_proof_outside_its_identified_region_is_rejected():
+    canonical, submitted, module = _submission(
+        proof_bodies={UNIT_A: "PROOF BY TRUE", UNIT_B: "PROOF BY TRUE"},
+        proof_loc_overrides={UNIT_A: Loc(1, 1, 1, 5)},
+    )
+
+    with pytest.raises(ModuleSubmissionError) as caught:
+        analyze_module_submission(
+            canonical_source=canonical,
+            submitted_source=submitted,
+            expected_unit_ids=UNITS,
+            module=module,
+        )
+
+    assert caught.value.code == "PROOF_OUTSIDE_REGION"
+
+
+@pytest.mark.parametrize(
+    ("helper_line", "declaration_kind"),
+    [
+        ("CONSTANT C", "constant"),
+        ("VARIABLE v", "variable"),
+        ("ASSUME A", "assume"),
+        ("---- MODULE Inner ----", "inner_module"),
+        ("USE Fact", "directive"),
+    ],
+)
+def test_forbidden_helper_declarations_are_rejected(helper_line: str, declaration_kind: str):
+    submitted = _source(helper_lines=[helper_line])
+    location = _line_loc(submitted, helper_line)
+    declarations = {
+        "constant": {"constants": [Symbol("C", location)]},
+        "variable": {"variables": [Symbol("v", location)]},
+        "assume": {"assumes": [Assumption("A", False, location, [])]},
+        "inner_module": {"inner_modules": [Symbol("Inner", location)]},
+        "directive": {"directives": [ModuleDirective("USE", False, location)]},
+    }[declaration_kind]
+    module = _module(submitted, **declarations)
+
+    with pytest.raises(ModuleSubmissionError) as caught:
+        analyze_module_submission(
+            canonical_source=_source(),
+            submitted_source=submitted,
+            expected_unit_ids=UNITS,
+            module=module,
+        )
+
+    assert caught.value.code in {"FORBIDDEN_HELPER_DECLARATION", "FORBIDDEN_HELPER_DIRECTIVE"}
+
+
+def test_extra_top_level_theorem_inside_target_proof_region_is_rejected():
+    proof_bodies = {
+        UNIT_A: "PROOF OBVIOUS\n\nTHEOREM Admitted == FALSE\nPROOF OMITTED",
+        UNIT_B: "PROOF BY Admitted",
+    }
+    canonical, submitted, module = _submission(
+        proof_bodies=proof_bodies,
+        target_references={UNIT_B: ("Admitted",)},
+    )
+    declaration = _line_loc(submitted, "THEOREM Admitted == FALSE")
+    proof = _line_loc(submitted, "PROOF OMITTED")
+    module.theorems.append(
+        Theorem(
+            name="Admitted",
+            loc=Loc(declaration.line_start, 1, proof.line_end, proof.column_end),
+            statement_loc=declaration,
+            proof_loc=proof,
+            proof_is_omitted=True,
+            references=[],
+            statement_references=[],
+            shape={},
+        )
+    )
+
+    with pytest.raises(ModuleSubmissionError) as caught:
+        analyze_module_submission(
+            canonical_source=canonical,
+            submitted_source=submitted,
+            expected_unit_ids=UNITS,
+            module=module,
+        )
+
+    assert caught.value.code == "TOP_LEVEL_DECLARATION_IN_PROOF"
+
+
+def test_axiom_inside_target_proof_region_is_rejected():
+    proof_bodies = {
+        UNIT_A: "PROOF OBVIOUS\n\nAXIOM Bad == FALSE",
+        UNIT_B: "PROOF BY Bad",
+    }
+    submitted = _source(proof_bodies=proof_bodies)
+    bad_location = _line_loc(submitted, "AXIOM Bad == FALSE")
+    module = _module(
+        submitted,
+        target_references={UNIT_B: ("Bad",)},
+        assumes=[Assumption("Bad", True, bad_location, [])],
+    )
+
+    with pytest.raises(ModuleSubmissionError) as caught:
+        analyze_module_submission(
+            canonical_source=_source(),
+            submitted_source=submitted,
+            expected_unit_ids=UNITS,
+            module=module,
+        )
+
+    assert caught.value.code == "TOP_LEVEL_DECLARATION_IN_PROOF"

--- a/tests/common/test_proof_from_scratch_manifest.py
+++ b/tests/common/test_proof_from_scratch_manifest.py
@@ -1,0 +1,268 @@
+"""Focused tests for the strict module-task manifest loader."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import pickle
+from pathlib import Path
+
+import pytest
+
+from common.proof_from_scratch_manifest import (
+    MANIFEST_FILENAME,
+    ModuleTaskManifestError,
+    load_module_task_manifest,
+)
+from common.proof_from_scratch_module import (
+    MODULE_TASK_FORMAT_VERSION,
+    begin_agent_proof,
+    end_agent_proof,
+    statement_sha256,
+)
+from common.task_contract import BEGIN_AGENT_HELPERS, END_AGENT_HELPERS
+
+TASK_ID = "Group/Source.tla"
+UNIT_A = "Group/Source_Alpha.tla"
+UNIT_B = "Group/Source_Beta.tla"
+CONTEXT_ID = "Group/SourceDefs.tla"
+CORPUS_BYTES = (
+    b'{"Group/Source_Alpha.tla":{"spec_id":"Group/Source.tla","context":[]},'
+    b'"Group/Source_Beta.tla":{"spec_id":"Group/Source.tla","context":[]}}\n'
+)
+STATEMENT_A = "THEOREM Alpha == captured = captured"
+STATEMENT_B = "THEOREM Beta == TRUE"
+
+
+def _task_source(*, statement_a: str = STATEMENT_A, statement_b: str = STATEMENT_B) -> str:
+    lines = [
+        "---- MODULE Source ----",
+        "EXTENDS SourceDefs",
+        "",
+        BEGIN_AGENT_HELPERS,
+        END_AGENT_HELPERS,
+        "",
+        statement_a,
+        begin_agent_proof(UNIT_A),
+        "PROOF OMITTED",
+        end_agent_proof(UNIT_A),
+        "",
+        statement_b,
+        begin_agent_proof(UNIT_B),
+        "PROOF OMITTED",
+        end_agent_proof(UNIT_B),
+        "====",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _context_source() -> str:
+    return "---- MODULE SourceDefs ----\n====\n"
+
+
+def _entry() -> dict:
+    return {
+        "spec": {
+            "format_version": MODULE_TASK_FORMAT_VERSION,
+            "task_id": TASK_ID,
+            "source_sha256": hashlib.sha256(b"original Source.tla").hexdigest(),
+            "proof_units": [
+                {"task_id": UNIT_A, "statement_sha256": statement_sha256(STATEMENT_A)},
+                {"task_id": UNIT_B, "statement_sha256": statement_sha256(STATEMENT_B)},
+            ],
+        },
+        "context": [CONTEXT_ID],
+        "renamed_bindings": {UNIT_A: {"captured": "captured_renamed"}},
+    }
+
+
+def _document(*, entries: list[dict] | None = None, complete: bool = True, corpus_bytes: bytes = CORPUS_BYTES) -> dict:
+    return {
+        "format_version": MODULE_TASK_FORMAT_VERSION,
+        "corpus_sha256": hashlib.sha256(corpus_bytes).hexdigest(),
+        "complete": complete,
+        "module_tasks": [_entry()] if entries is None else entries,
+    }
+
+
+def _write_document(root: Path, document: dict) -> None:
+    (root / MANIFEST_FILENAME).write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+
+
+def _materialize(
+    tmp_path: Path,
+    *,
+    document: dict | None = None,
+    task_source: str | None = None,
+    context_source: str | None = None,
+    corpus_bytes: bytes = CORPUS_BYTES,
+    source_bytes: bytes = b"original Source.tla",
+) -> tuple[Path, Path]:
+    root = tmp_path / "module-suite"
+    root.mkdir()
+    document = _document() if document is None else document
+
+    task_path = root / TASK_ID
+    task_path.parent.mkdir(parents=True, exist_ok=True)
+    task_path.write_text(_task_source() if task_source is None else task_source, encoding="utf-8")
+
+    context_path = root / CONTEXT_ID
+    context_path.parent.mkdir(parents=True, exist_ok=True)
+    context_path.write_text(_context_source() if context_source is None else context_source, encoding="utf-8")
+
+    source_path = tmp_path / "source" / TASK_ID
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_bytes(source_bytes)
+
+    _write_document(root, document)
+
+    corpus_path = tmp_path / "proof-from-scratch" / MANIFEST_FILENAME
+    corpus_path.parent.mkdir()
+    corpus_path.write_bytes(corpus_bytes)
+    return root, corpus_path
+
+
+def _load(root: Path, corpus_path: Path):
+    return load_module_task_manifest(root, corpus_manifest_path=corpus_path, source_root=root.parent / "source")
+
+
+def test_loads_a_complete_manifest_strictly(tmp_path):
+    root, corpus_path = _materialize(tmp_path)
+
+    manifest = _load(root, corpus_path)
+
+    assert manifest.format_version == MODULE_TASK_FORMAT_VERSION
+    assert manifest.proof_unit_ids == (UNIT_A, UNIT_B)
+    assert manifest.entries[0].context == (CONTEXT_ID,)
+    assert manifest.entries[0].renamed_bindings == ((UNIT_A, (("captured", "captured_renamed"),)),)
+
+
+def test_rejects_duplicate_module_task_ids(tmp_path):
+    entry = _entry()
+    root, corpus_path = _materialize(tmp_path, document=_document(entries=[entry, copy.deepcopy(entry)]))
+
+    with pytest.raises(ModuleTaskManifestError, match="repeats task ID"):
+        _load(root, corpus_path)
+
+
+def test_rejects_duplicate_proof_unit_ids_across_tasks(tmp_path):
+    first = _entry()
+    second = copy.deepcopy(first)
+    second["spec"]["task_id"] = "Group/Other.tla"
+    root, corpus_path = _materialize(tmp_path, document=_document(entries=[first, second]))
+
+    with pytest.raises(ModuleTaskManifestError, match="more than one module task"):
+        _load(root, corpus_path)
+
+
+def test_rejects_a_forged_proof_unit_id(tmp_path):
+    document = _document()
+    document["module_tasks"][0]["spec"]["proof_units"][0]["task_id"] = "Group/Forged.tla"
+    document["module_tasks"][0]["renamed_bindings"] = {"Group/Forged.tla": {"captured": "captured_renamed"}}
+    root, corpus_path = _materialize(tmp_path, document=document)
+
+    with pytest.raises(ModuleTaskManifestError, match="BEGIN"):
+        _load(root, corpus_path)
+
+
+def test_rejects_statement_digest_mismatch(tmp_path):
+    root, corpus_path = _materialize(tmp_path, task_source=_task_source(statement_a="THEOREM Alpha == FALSE"))
+
+    with pytest.raises(ModuleTaskManifestError, match="statement digest does not match"):
+        _load(root, corpus_path)
+
+
+def test_rejects_a_source_hash_mismatch(tmp_path):
+    root, corpus_path = _materialize(tmp_path, source_bytes=b"changed Source.tla")
+
+    with pytest.raises(ModuleTaskManifestError, match="source_sha256 does not match"):
+        _load(root, corpus_path)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda source: source.replace(f"{end_agent_proof(UNIT_B)}\n", "", 1),
+            "exactly one END",
+        ),
+        (
+            lambda source: source.replace(
+                "====\n",
+                f"{begin_agent_proof('Group/Forged.tla')}\n====\n",
+                1,
+            ),
+            "unknown proof marker",
+        ),
+    ],
+)
+def test_rejects_malformed_or_unknown_markers(tmp_path, mutate, message):
+    original = _task_source()
+    root, corpus_path = _materialize(tmp_path, task_source=mutate(original))
+
+    with pytest.raises(ModuleTaskManifestError, match=message):
+        _load(root, corpus_path)
+
+
+def test_rejects_context_that_is_tampered_to_include_the_task(tmp_path):
+    document = _document()
+    document["module_tasks"][0]["context"] = [TASK_ID]
+    root, corpus_path = _materialize(tmp_path, document=document)
+
+    with pytest.raises(ModuleTaskManifestError, match="also appears in its context"):
+        _load(root, corpus_path)
+
+
+def test_rejects_a_missing_context_file(tmp_path):
+    root, corpus_path = _materialize(tmp_path)
+    (root / CONTEXT_ID).unlink()
+
+    with pytest.raises(ModuleTaskManifestError, match="context"):
+        _load(root, corpus_path)
+
+
+def test_rejects_proof_artifacts_in_tampered_context(tmp_path):
+    context = _context_source() + f"{begin_agent_proof(UNIT_A)}\nPROOF OBVIOUS\n{end_agent_proof(UNIT_A)}\n"
+    root, corpus_path = _materialize(tmp_path, context_source=context)
+
+    with pytest.raises(ModuleTaskManifestError, match="context|proof"):
+        _load(root, corpus_path)
+
+
+def test_rejects_a_corpus_digest_mismatch(tmp_path):
+    root, corpus_path = _materialize(tmp_path)
+    corpus_path.write_bytes(b"a different source corpus\n")
+
+    with pytest.raises(ModuleTaskManifestError, match="different proof-from-scratch corpus"):
+        _load(root, corpus_path)
+
+
+def test_rejects_self_consistent_manifest_that_drops_a_corpus_proof_unit(tmp_path):
+    document = _document()
+    document["module_tasks"][0]["spec"]["proof_units"] = document["module_tasks"][0]["spec"]["proof_units"][:1]
+    source = _task_source()
+    second_start = source.index("\n" + STATEMENT_B)
+    second_end = source.index("\n====", second_start)
+    source = source[:second_start] + source[second_end:]
+    root, corpus_path = _materialize(tmp_path, document=document, task_source=source)
+
+    with pytest.raises(ModuleTaskManifestError, match="proof-unit coverage differs"):
+        _load(root, corpus_path)
+
+
+def test_rejects_an_incomplete_manifest(tmp_path):
+    root, corpus_path = _materialize(tmp_path, document=_document(complete=False))
+
+    with pytest.raises(ModuleTaskManifestError, match="complete corpus"):
+        _load(root, corpus_path)
+
+
+def test_validated_manifest_is_pickleable(tmp_path):
+    root, corpus_path = _materialize(tmp_path)
+    manifest = _load(root, corpus_path)
+
+    restored = pickle.loads(pickle.dumps(manifest))
+
+    assert restored == manifest

--- a/tests/dataset/test_sany_dumper.py
+++ b/tests/dataset/test_sany_dumper.py
@@ -34,6 +34,149 @@ PROOF OBVIOUS
     assert {"Filtered", "Keep"} <= compute_reachable(dump, target)
 
 
+def test_proof_local_definition_cannot_hide_a_theorem_dependency(tmp_path):
+    source = tmp_path / "ProofLocalDefinition.tla"
+    source.write_text(
+        """---------------------- MODULE ProofLocalDefinition ----------------------
+THEOREM Earlier == TRUE
+PROOF OMITTED
+
+THEOREM Later == TRUE
+<1> DEFINE Alias == Earlier
+<1>. QED BY DEF Alias
+=============================================================================
+"""
+    )
+
+    dump = dump_sany(str(source))
+    later = next(theorem for theorem in dump["theorems"] if theorem["name"] == "Later")
+
+    assert later["references"] == ["Earlier"]
+
+
+def test_operator_definition_cannot_hide_a_theorem_dependency(tmp_path):
+    source = tmp_path / "OperatorDefinition.tla"
+    source.write_text(
+        """------------------------ MODULE OperatorDefinition ------------------------
+THEOREM Earlier == FALSE
+PROOF OMITTED
+
+Alias == Earlier
+
+THEOREM Later == FALSE
+<1>. QED BY Alias DEF Alias
+=============================================================================
+"""
+    )
+
+    dump = dump_sany(str(source))
+    later = next(theorem for theorem in dump["theorems"] if theorem["name"] == "Later")
+
+    assert later["references"] == ["Earlier"]
+
+
+def test_operator_argument_cannot_hide_a_theorem_dependency(tmp_path):
+    source = tmp_path / "OperatorArgumentDependency.tla"
+    source.write_text(
+        """------------------ MODULE OperatorArgumentDependency ------------------
+THEOREM Earlier == FALSE
+PROOF OMITTED
+
+Id(x) == x
+
+THEOREM Later == FALSE
+PROOF BY Id(Earlier) DEF Id
+=============================================================================
+"""
+    )
+
+    dump = dump_sany(str(source))
+    later = next(theorem for theorem in dump["theorems"] if theorem["name"] == "Later")
+
+    assert later["references"] == ["Earlier"]
+
+
+def test_theorem_name_in_a_suffices_formula_is_not_a_fact_dependency(tmp_path):
+    source = tmp_path / "SufficesFormula.tla"
+    source.write_text(
+        """-------------------------- MODULE SufficesFormula --------------------------
+THEOREM Earlier == FALSE
+PROOF OMITTED
+
+THEOREM Later == Earlier => Earlier
+PROOF
+  <1> SUFFICES Earlier => Earlier
+    OBVIOUS
+  <1> QED OBVIOUS
+=============================================================================
+"""
+    )
+
+    dump = dump_sany(str(source))
+    later = next(theorem for theorem in dump["theorems"] if theorem["name"] == "Later")
+
+    assert later["references"] == []
+
+
+def test_theorem_name_in_a_composite_by_fact_is_conservatively_a_dependency(tmp_path):
+    source = tmp_path / "CompositeByFact.tla"
+    source.write_text(
+        """-------------------------- MODULE CompositeByFact --------------------------
+THEOREM Earlier == FALSE
+PROOF OMITTED
+
+THEOREM Later == Earlier => Earlier
+PROOF BY Earlier => Earlier
+=============================================================================
+"""
+    )
+
+    dump = dump_sany(str(source))
+    later = next(theorem for theorem in dump["theorems"] if theorem["name"] == "Later")
+
+    assert later["references"] == ["Earlier"]
+
+
+def test_let_fact_cannot_hide_a_theorem_dependency(tmp_path):
+    source = tmp_path / "LetFactDependency.tla"
+    source.write_text(
+        """------------------------- MODULE LetFactDependency -------------------------
+THEOREM Earlier == FALSE
+PROOF OMITTED
+
+THEOREM Later == FALSE
+PROOF BY (LET Id(x) == x IN Id(Earlier))
+=============================================================================
+"""
+    )
+
+    dump = dump_sany(str(source))
+    later = next(theorem for theorem in dump["theorems"] if theorem["name"] == "Later")
+
+    assert later["references"] == ["Earlier"]
+
+
+def test_hide_directive_does_not_create_a_theorem_dependency(tmp_path):
+    source = tmp_path / "HideIsNotDependency.tla"
+    source.write_text(
+        """------------------------- MODULE HideIsNotDependency -------------------------
+THEOREM Earlier == FALSE
+PROOF OMITTED
+
+THEOREM Later == TRUE
+PROOF
+  <1> HIDE Earlier
+  <1> QED OBVIOUS
+=============================================================================
+"""
+    )
+
+    dump = dump_sany(str(source))
+    later = next(theorem for theorem in dump["theorems"] if theorem["name"] == "Later")
+
+    assert later["references"] == []
+
+
 def test_duplicate_record_fields_are_rejected_by_sany(tmp_path):
     source = tmp_path / "Foo.tla"
     source.write_text(

--- a/tests/evaluator/test_agent_skills.py
+++ b/tests/evaluator/test_agent_skills.py
@@ -449,6 +449,21 @@ def test_supported_backends_receive_byte_exact_skills_in_clean_fresh_workspaces(
             runner.shutil.rmtree(workspace)
 
 
+def test_agent_skill_snapshot_freezes_bytes_and_has_content_identity(tmp_path):
+    catalog = tmp_path / "catalog"
+    expected = _write_catalog(catalog)
+    backend = get_backend("codex")
+
+    frozen = runner.AgentSkillsSnapshot.capture(backend, catalog)
+    (catalog / "zeta-skill" / "references" / "payload.bin").write_bytes(b"changed after capture")
+    changed = runner.AgentSkillsSnapshot.capture(backend, catalog)
+    destination = tmp_path / "snapshot"
+    frozen.materialize(destination)
+
+    assert frozen.digest() != changed.digest()
+    assert (destination / "alpha-skill" / "SKILL.md").read_bytes() == expected["alpha-skill"]["SKILL.md"]
+
+
 @pytest.mark.parametrize("backend_name", UNSUPPORTED_BACKENDS)
 def test_unsupported_backends_receive_no_skills_and_report_empty_metadata(tmp_path, monkeypatch, backend_name):
     catalog = tmp_path / "catalog"

--- a/tests/evaluator/test_container.py
+++ b/tests/evaluator/test_container.py
@@ -740,18 +740,22 @@ class TestRunAgentContainerSessionWiring:
         session_dir="",
         read_only_files=None,
         canonical_replay_required=False,
+        benchmark_relative="My-Bench.tla",
     ):
         from evaluator import runner as runner_mod
 
         backend = CopilotBackend()
         item = MagicMock(
-            benchmark_path=str(tmp_path / "My-Bench.tla"),
+            benchmark_path=str(tmp_path / benchmark_relative),
             timeout=0,
             check_timeout=600,
             keep_container=keep_container,
             session_dir=session_dir,
             container_image="tlaps-bench-base:immutable",
-            mode=MagicMock(canonical_replay_required=canonical_replay_required),
+            mode=SimpleNamespace(
+                canonical_replay_required=canonical_replay_required,
+                benchmark_dir=lambda: str(tmp_path),
+            ),
         )
         captured = {}
 
@@ -781,18 +785,43 @@ class TestRunAgentContainerSessionWiring:
         return captured["config"]
 
     def test_session_dir_keyed_by_benchmark_without_keep_container(self, tmp_path):
+        from evaluator import runner as runner_mod
+
         session_root = tmp_path / "sessions"
         config = self._capture_config(tmp_path, session_dir=str(session_root))
-        # <root>/<backend>/<sanitized-benchmark>; build_docker_args creates it
-        assert config.session_dir == str(session_root / "copilot" / "My-Bench")
+        key = runner_mod._work_item_session_key(
+            SimpleNamespace(
+                benchmark_path=str(tmp_path / "My-Bench.tla"),
+                mode=SimpleNamespace(benchmark_dir=lambda: str(tmp_path)),
+            )
+        )
+        assert config.session_dir == str(session_root / "copilot" / key)
         assert config.session_container_path == "/root/.copilot"
 
-    def test_session_dir_keyed_by_container_name_with_keep_container(self, tmp_path):
+    def test_keep_container_reuses_the_task_session_key(self, tmp_path):
         session_root = tmp_path / "sessions"
-        config = self._capture_config(tmp_path, session_dir=str(session_root), keep_container=True)
-        # Each retained container gets its own session dir, keyed by its name.
-        assert config.session_dir == str(session_root / "copilot" / config.container_name)
-        assert config.container_name.startswith("tlaps-bench-My-Bench-")
+        ordinary = self._capture_config(tmp_path, session_dir=str(session_root))
+        retained = self._capture_config(tmp_path, session_dir=str(session_root), keep_container=True)
+
+        assert retained.session_dir == ordinary.session_dir
+        assert retained.container_name.startswith("tlaps-bench-My-Bench-")
+
+    def test_same_basename_in_different_modules_gets_distinct_sessions(self, tmp_path):
+        session_root = tmp_path / "sessions"
+        first = self._capture_config(
+            tmp_path,
+            session_dir=str(session_root),
+            benchmark_relative="SuiteA/Consensus.tla",
+        )
+        second = self._capture_config(
+            tmp_path,
+            session_dir=str(session_root),
+            benchmark_relative="SuiteB/Consensus.tla",
+        )
+
+        assert first.session_dir != second.session_dir
+        assert os.path.basename(first.session_dir).startswith("SuiteA__Consensus-")
+        assert os.path.basename(second.session_dir).startswith("SuiteB__Consensus-")
 
     def test_no_session_dir_leaves_config_empty(self, tmp_path):
         config = self._capture_config(tmp_path, session_dir="")
@@ -828,6 +857,25 @@ class TestResolveSessionDir:
 
         got = _resolve_session_dir(str(tmp_path / "s"), keep_container=False, use_container=True)
         assert got == str(tmp_path / "s")
+
+    def test_session_dir_is_bound_to_its_physical_tree_before_resume(self, tmp_path):
+        from evaluator.runner import _resolve_session_dir
+
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+        link = tmp_path / "sessions"
+        link.symlink_to(first, target_is_directory=True)
+
+        recorded = _resolve_session_dir(str(link), keep_container=False, use_container=True)
+        link.unlink()
+        link.symlink_to(second, target_is_directory=True)
+        resumed = _resolve_session_dir(str(link), keep_container=False, use_container=True)
+
+        assert recorded == str(first)
+        assert resumed == str(second)
+        assert recorded != resumed
 
     def test_keep_container_defaults_to_home_dir(self):
         from evaluator.runner import _resolve_session_dir

--- a/tests/evaluator/test_copilot_usage.py
+++ b/tests/evaluator/test_copilot_usage.py
@@ -491,6 +491,27 @@ def test_backend_marks_missing_telemetry_without_activity_unavailable(tmp_path):
     assert usage.output_tokens is None
 
 
+def test_copilot_retry_detection_distinguishes_activity_from_an_unreadable_stream(tmp_path):
+    activity = tmp_path / "activity.jsonl"
+    _write_jsonl(
+        activity,
+        {
+            "type": "assistant.message",
+            "data": {
+                "content": "working",
+                "toolRequests": [{"toolCallId": "edit-1", "name": "edit"}],
+            },
+        },
+    )
+    malformed = tmp_path / "malformed.jsonl"
+    malformed.write_text("not json\n")
+    backend = CopilotBackend()
+
+    assert backend.retry_may_duplicate_model_work(str(activity)) is True
+    assert backend.retry_may_duplicate_model_work(str(malformed)) is False
+    assert backend.retry_may_duplicate_model_work(str(tmp_path / "missing.jsonl")) is False
+
+
 def test_cli_otel_output_mismatch_downgrades_usage(tmp_path):
     output = tmp_path / "output.jsonl"
     output.write_text("")

--- a/tests/evaluator/test_cursor_backend.py
+++ b/tests/evaluator/test_cursor_backend.py
@@ -98,6 +98,26 @@ def test_cursor_trusts_zero_terminal_usage(tmp_path):
     assert (usage.input_tokens, usage.output_tokens) == (0, 0)
 
 
+def test_cursor_retry_detection_distinguishes_activity_from_an_unreadable_stream(tmp_path):
+    activity = tmp_path / "activity.jsonl"
+    _write_jsonl(
+        activity,
+        {
+            "type": "tool_call",
+            "subtype": "completed",
+            "call_id": "edit-1",
+            "tool_call": {"editToolCall": {"args": {"path": "Task.tla"}}},
+        },
+    )
+    malformed = tmp_path / "malformed.jsonl"
+    malformed.write_text("not json\n")
+    backend = CursorBackend()
+
+    assert backend.retry_may_duplicate_model_work(str(activity)) is True
+    assert backend.retry_may_duplicate_model_work(str(malformed)) is False
+    assert backend.retry_may_duplicate_model_work(str(tmp_path / "missing.jsonl")) is False
+
+
 def test_cursor_transcript_uses_the_tool_field_among_metadata(tmp_path):
     output = tmp_path / "output.jsonl"
     _write_jsonl(

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -18,6 +18,8 @@ from evaluator import runner
 from evaluator.backends.agentic import AgenticBackend
 from evaluator.backends.base import SubmissionPlan
 from evaluator.backends.codex import CodexBackend
+from evaluator.backends.copilot import CopilotBackend
+from evaluator.backends.cursor import CursorBackend
 from evaluator.backends.pi import PiBackend
 from evaluator.termination import TerminationReason
 from evaluator.usage import RequestUsage, UsageCost, UsageSummary
@@ -699,6 +701,105 @@ def test_codex_item_activity_prevents_retry_when_failed_turn_has_no_usage(tmp_pa
     assert grader["n"] == 1
     assert result["termination_reason"] == TerminationReason.INFRA_ERROR
     assert result["usage"]["status"] == "unavailable"
+    assert "infra_retries" not in result
+    assert sleeps == []
+
+
+def test_cursor_partial_edit_activity_prevents_retry_without_terminal_usage(tmp_path, monkeypatch):
+    backend = CursorBackend(model="test-model")
+    failed_after_edit = {
+        "exit": 1,
+        "events": [
+            {"type": "system", "subtype": "init"},
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "I will update the proof."}]},
+            },
+            {
+                "type": "tool_call",
+                "subtype": "started",
+                "call_id": "edit-1",
+                "tool_call": {"editToolCall": {"args": {"path": "Bar.tla"}}},
+            },
+            {
+                "type": "tool_call",
+                "subtype": "completed",
+                "call_id": "edit-1",
+                "tool_call": {
+                    "editToolCall": {
+                        "args": {"path": "Bar.tla"},
+                        "result": {"success": True},
+                    }
+                },
+            },
+        ],
+    }
+    agent = _install_agent(monkeypatch, backend, [failed_after_edit])
+    grader = _install_grader(monkeypatch, verdict="FAIL")
+    sleeps = _no_sleep(monkeypatch)
+
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, infra_retries=3))
+
+    assert agent["n"] == 1
+    assert grader["n"] == 1
+    assert result["termination_reason"] == TerminationReason.INFRA_ERROR
+    assert result["tool_calls"]["total"] == 1
+    assert result["tool_calls"]["is_lower_bound"] is True
+    assert "infra_retries" not in result
+    assert sleeps == []
+
+
+def test_copilot_partial_edit_activity_prevents_retry_without_terminal_otel(tmp_path, monkeypatch):
+    backend = CopilotBackend(model="test-model")
+    failed_after_edit = {
+        "exit": 1,
+        "events": [
+            {
+                "type": "assistant.message",
+                "data": {
+                    "content": "I will update the proof.",
+                    "toolRequests": [
+                        {
+                            "toolCallId": "edit-1",
+                            "name": "edit",
+                            "arguments": {"path": "Bar.tla"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "tool.execution_start",
+                "data": {
+                    "toolCallId": "edit-1",
+                    "toolName": "edit",
+                    "arguments": {"path": "Bar.tla"},
+                },
+            },
+            {
+                "type": "tool.execution_complete",
+                "data": {
+                    "toolCallId": "edit-1",
+                    "success": True,
+                    "result": {"content": "updated Bar.tla"},
+                },
+            },
+            {
+                "type": "session.error",
+                "data": {"errorType": "query", "message": "stream closed"},
+            },
+        ],
+    }
+    agent = _install_agent(monkeypatch, backend, [failed_after_edit])
+    grader = _install_grader(monkeypatch, verdict="FAIL")
+    sleeps = _no_sleep(monkeypatch)
+
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, infra_retries=3))
+
+    assert agent["n"] == 1
+    assert grader["n"] == 1
+    assert result["termination_reason"] == TerminationReason.INFRA_ERROR
+    assert result["tool_calls"]["total"] == 1
+    assert result["tool_calls"]["is_lower_bound"] is True
     assert "infra_retries" not in result
     assert sleeps == []
 

--- a/tests/evaluator/test_proof_from_scratch_mode.py
+++ b/tests/evaluator/test_proof_from_scratch_mode.py
@@ -2,49 +2,164 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import pickle
+from pathlib import Path
 
 import pytest
 
-from common.proof_from_scratch_contract import (
-    BEGIN_AGENT_HELPERS,
-    BEGIN_AGENT_PROOF,
-    END_AGENT_HELPERS,
-    END_AGENT_PROOF,
-    ManifestError,
+from common.proof_from_scratch_manifest import ModuleTaskManifestError
+from common.proof_from_scratch_module import (
+    MODULE_TASK_FORMAT_VERSION,
+    begin_agent_proof,
+    end_agent_proof,
+    statement_sha256,
 )
+from common.task_contract import BEGIN_AGENT_HELPERS, END_AGENT_HELPERS
 from evaluator.modes.proof_completion import ProofCompletion
 from evaluator.modes.proof_from_scratch import ProofFromScratch
 
+ALPHA_TASK_ID = "Alpha/Alpha.tla"
+ALPHA_UNIT_A = "Alpha/Alpha_First.tla"
+ALPHA_UNIT_B = "Alpha/Alpha_Second.tla"
+ALPHA_STATEMENT_A = "THEOREM First == TRUE"
+ALPHA_STATEMENT_B = "THEOREM Second == TRUE"
+BETA_TASK_ID = "Beta/Beta.tla"
+BETA_UNIT = "Beta/Beta_Target.tla"
+BETA_STATEMENT = "THEOREM Target == TRUE"
+CONTEXT_B = "Context/ModelB.tla"
+CONTEXT_A = "Context/ModelA.tla"
 
-def _write_module(suite, relative_path, body=""):
+
+def _write_module(suite: Path, relative_path: str, body: str = "") -> Path:
     path = suite / relative_path
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(f"---- MODULE {path.stem} ----\n{body}====\n", encoding="utf-8")
     return path.resolve()
 
 
-def _write_task(suite, relative_path, body=""):
-    marked_body = (
-        f"{body}"
-        f"{BEGIN_AGENT_HELPERS}\n"
-        f"{END_AGENT_HELPERS}\n"
-        "THEOREM Target == TRUE\n"
-        f"{BEGIN_AGENT_PROOF}\n"
-        "PROOF OBVIOUS\n"
-        f"{END_AGENT_PROOF}\n"
+def _write_task(
+    suite: Path,
+    relative_path: str,
+    proof_units: tuple[tuple[str, str], ...],
+    *,
+    extends: tuple[str, ...] = (),
+) -> Path:
+    path = suite / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"---- MODULE {path.stem} ----"]
+    if extends:
+        lines.append(f"EXTENDS {', '.join(extends)}")
+    lines.extend(("", BEGIN_AGENT_HELPERS, END_AGENT_HELPERS, ""))
+    for index, (unit_id, statement) in enumerate(proof_units):
+        if index:
+            lines.append("")
+        lines.extend(
+            (
+                statement,
+                begin_agent_proof(unit_id),
+                "PROOF OMITTED",
+                end_agent_proof(unit_id),
+            )
+        )
+    lines.extend(("====", ""))
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path.resolve()
+
+
+def _module_task_entry(
+    task_id: str,
+    task_path: Path,
+    proof_units: tuple[tuple[str, str], ...],
+    context: tuple[str, ...],
+) -> dict:
+    return {
+        "spec": {
+            "format_version": MODULE_TASK_FORMAT_VERSION,
+            "task_id": task_id,
+            "source_sha256": hashlib.sha256(task_path.read_bytes()).hexdigest(),
+            "proof_units": [
+                {"task_id": unit_id, "statement_sha256": statement_sha256(statement)}
+                for unit_id, statement in proof_units
+            ],
+        },
+        "context": list(context),
+        "renamed_bindings": {},
+    }
+
+
+def _write_corpus_manifest(root: Path) -> bytes:
+    corpus_root = root / "proof-from-scratch"
+    corpus_root.mkdir(parents=True, exist_ok=True)
+    corpus = {
+        ALPHA_UNIT_A: {"spec_id": ALPHA_TASK_ID, "context": list((CONTEXT_B, CONTEXT_A))},
+        ALPHA_UNIT_B: {"spec_id": ALPHA_TASK_ID, "context": list((CONTEXT_B, CONTEXT_A))},
+        BETA_UNIT: {"spec_id": BETA_TASK_ID, "context": []},
+    }
+    corpus_bytes = (json.dumps(corpus, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    (corpus_root / "manifest.json").write_bytes(corpus_bytes)
+    return corpus_bytes
+
+
+def _write_module_manifest(suite: Path, entries: list[dict], corpus_bytes: bytes) -> None:
+    document = {
+        "format_version": MODULE_TASK_FORMAT_VERSION,
+        "corpus_sha256": hashlib.sha256(corpus_bytes).hexdigest(),
+        "complete": True,
+        "module_tasks": entries,
+    }
+    (suite / "manifest.json").write_text(json.dumps(document), encoding="utf-8")
+
+
+def _fixture(tmp_path: Path) -> dict[str, Path]:
+    benchmark_root = tmp_path / "benchmark"
+    suite = benchmark_root / "proof-from-scratch-module"
+    corpus_bytes = _write_corpus_manifest(benchmark_root)
+
+    alpha = _write_task(
+        suite,
+        ALPHA_TASK_ID,
+        ((ALPHA_UNIT_A, ALPHA_STATEMENT_A), (ALPHA_UNIT_B, ALPHA_STATEMENT_B)),
+        extends=("ModelB", "ModelA"),
     )
-    return _write_module(suite, relative_path, marked_body)
+    beta = _write_task(suite, BETA_TASK_ID, ((BETA_UNIT, BETA_STATEMENT),))
+    context_b = _write_module(suite, CONTEXT_B, "ModelB == TRUE\n")
+    context_a = _write_module(suite, CONTEXT_A, "ModelA == TRUE\n")
+    undeclared = _write_module(suite, "Alpha/Undeclared.tla", "THEOREM Leaked == TRUE\n")
+    _write_module(suite, "Context/Unrelated.tla", "Unrelated == TRUE\n")
+
+    source_root = tmp_path / "source"
+    for task_id, task_path in ((ALPHA_TASK_ID, alpha), (BETA_TASK_ID, beta)):
+        source_path = source_root / task_id
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_bytes(task_path.read_bytes())
+
+    _write_module_manifest(
+        suite,
+        [
+            _module_task_entry(
+                ALPHA_TASK_ID,
+                alpha,
+                ((ALPHA_UNIT_A, ALPHA_STATEMENT_A), (ALPHA_UNIT_B, ALPHA_STATEMENT_B)),
+                (CONTEXT_B, CONTEXT_A),
+            ),
+            _module_task_entry(BETA_TASK_ID, beta, ((BETA_UNIT, BETA_STATEMENT),), ()),
+        ],
+        corpus_bytes,
+    )
+    return {
+        "suite": suite,
+        "alpha": alpha,
+        "beta": beta,
+        "context_b": context_b,
+        "context_a": context_a,
+        "undeclared": undeclared,
+    }
 
 
-def _write_manifest(suite, manifest):
-    suite.mkdir(parents=True, exist_ok=True)
-    (suite / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
-
-
-def _mode(tmp_path):
-    return ProofFromScratch(str(tmp_path), "/checker")
+def _mode(tmp_path: Path) -> ProofFromScratch:
+    return ProofFromScratch(str(tmp_path / "benchmark"), "/checker")
 
 
 def test_both_modes_keep_dependencies_read_only(tmp_path):
@@ -54,96 +169,104 @@ def test_both_modes_keep_dependencies_read_only(tmp_path):
     assert ProofCompletion(str(tmp_path), "/checker").read_only_dependencies is True
 
 
-def test_discovers_only_sorted_manifest_tasks(tmp_path):
-    suite = tmp_path / "proof-from-scratch"
-    target_z = _write_task(suite, "Zed/Zed_Target.tla")
-    target_a = _write_task(suite, "Alpha/Alpha_Target.tla")
-    _write_module(suite, "Alpha/Undeclared_Theorem.tla", "THEOREM Leaked == TRUE\n")
-    _write_manifest(
-        suite,
-        {
-            "Zed/Zed_Target.tla": {"spec_id": "Fixture.tla", "context": []},
-            "Alpha/Alpha_Target.tla": {"spec_id": "Fixture.tla", "context": []},
-        },
-    )
-
+def test_discovers_only_sorted_manifest_module_tasks(tmp_path):
+    fixture = _fixture(tmp_path)
     mode = _mode(tmp_path)
 
-    assert mode.get_benchmark_files() == [str(target_a), str(target_z)]
-    assert mode.is_benchmark_file(str(target_a))
-    assert not mode.is_benchmark_file(str(suite / "Alpha/Undeclared_Theorem.tla"))
+    assert mode.get_benchmark_files() == [str(fixture["alpha"]), str(fixture["beta"])]
+    assert mode.is_benchmark_file(str(fixture["alpha"]))
+    assert not mode.is_benchmark_file(str(fixture["undeclared"]))
+    assert not mode.is_benchmark_file(str(fixture["context_a"]))
 
 
-def test_filters_manifest_tasks_with_existing_comma_separated_substrings(tmp_path):
-    suite = tmp_path / "proof-from-scratch"
-    target_a = _write_task(suite, "Alpha/Alpha_Target.tla")
-    target_b = _write_task(suite, "Beta/Beta_Target.tla")
-    target_c = _write_task(suite, "Gamma/Gamma_Target.tla")
-    _write_manifest(
-        suite,
-        {
-            "Alpha/Alpha_Target.tla": {"spec_id": "Fixture.tla", "context": []},
-            "Beta/Beta_Target.tla": {"spec_id": "Fixture.tla", "context": []},
-            "Gamma/Gamma_Target.tla": {"spec_id": "Fixture.tla", "context": []},
-        },
-    )
-
+def test_filters_manifest_module_tasks_without_changing_manifest_order(tmp_path):
+    fixture = _fixture(tmp_path)
     mode = _mode(tmp_path)
 
-    assert mode.get_benchmark_files("Alpha_Target, Gamma/") == [str(target_a), str(target_c)]
+    assert mode.get_benchmark_files("Beta/, Alpha/") == [str(fixture["alpha"]), str(fixture["beta"])]
+    assert mode.get_benchmark_files("Alpha/") == [str(fixture["alpha"])]
     assert mode.get_benchmark_files("missing,") == []
-    assert str(target_b) not in mode.get_benchmark_files("Alpha_Target, Gamma/")
 
 
 def test_returns_only_manifest_context_in_declared_order(tmp_path):
-    suite = tmp_path / "proof-from-scratch"
-    target = _write_task(suite, "Example/Example_Target.tla")
-    context_b = _write_module(suite, "Context/ModelB.tla")
-    context_a = _write_module(suite, "Context/ModelA.tla")
-    _write_module(suite, "Example/UnrelatedDefs.tla")
-    _write_manifest(
-        suite,
-        {
-            "Example/Example_Target.tla": {
-                "spec_id": "Fixture.tla",
-                "context": ["Context/ModelB.tla", "Context/ModelA.tla"],
-            }
-        },
-    )
+    fixture = _fixture(tmp_path)
 
-    assert _mode(tmp_path).get_dependencies(str(target)) == [str(context_b), str(context_a)]
-    assert _mode(tmp_path).specification_ids() == {"Example/Example_Target.tla": "Fixture.tla"}
+    assert _mode(tmp_path).get_dependencies(str(fixture["alpha"])) == [
+        str(fixture["context_b"]),
+        str(fixture["context_a"]),
+    ]
 
 
 def test_rejects_dependency_lookup_for_undeclared_file(tmp_path):
-    suite = tmp_path / "proof-from-scratch"
-    _write_task(suite, "Example/Example_Target.tla")
-    undeclared = _write_module(suite, "Example/Other_Target.tla")
-    _write_manifest(suite, {"Example/Example_Target.tla": {"spec_id": "Fixture.tla", "context": []}})
+    fixture = _fixture(tmp_path)
 
     with pytest.raises(ValueError, match="is not declared"):
-        _mode(tmp_path).get_dependencies(str(undeclared))
+        _mode(tmp_path).get_dependencies(str(fixture["undeclared"]))
 
 
 def test_missing_manifest_fails_closed_during_discovery(tmp_path):
-    (tmp_path / "proof-from-scratch").mkdir()
+    benchmark_root = tmp_path / "benchmark"
+    _write_corpus_manifest(benchmark_root)
+    (benchmark_root / "proof-from-scratch-module").mkdir()
 
-    with pytest.raises(ManifestError, match="missing proof-from-scratch manifest"):
+    with pytest.raises(ModuleTaskManifestError, match="cannot read module-task manifest"):
         _mode(tmp_path).get_benchmark_files()
 
 
+def test_invalid_manifest_fails_closed_during_discovery(tmp_path):
+    benchmark_root = tmp_path / "benchmark"
+    _write_corpus_manifest(benchmark_root)
+    suite = benchmark_root / "proof-from-scratch-module"
+    suite.mkdir()
+    (suite / "manifest.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ModuleTaskManifestError, match="must contain exactly"):
+        _mode(tmp_path).get_benchmark_files()
+
+
+def test_rejects_a_mismatched_sibling_corpus_manifest(tmp_path):
+    _fixture(tmp_path)
+    (tmp_path / "benchmark" / "proof-from-scratch" / "manifest.json").write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ModuleTaskManifestError, match="different proof-from-scratch corpus"):
+        _mode(tmp_path).get_benchmark_files()
+
+
+def test_rejects_a_mismatched_shipped_source(tmp_path):
+    _fixture(tmp_path)
+    (tmp_path / "source" / ALPHA_TASK_ID).write_text("changed source\n", encoding="utf-8")
+
+    with pytest.raises(ModuleTaskManifestError, match="source_sha256 does not match"):
+        _mode(tmp_path).get_benchmark_files()
+
+
+def test_exposes_module_spec_proof_units_and_identity(tmp_path):
+    fixture = _fixture(tmp_path)
+    mode = _mode(tmp_path)
+
+    spec = mode.module_task_spec(str(fixture["alpha"]))
+
+    assert spec.task_id == ALPHA_TASK_ID
+    assert spec.source_sha256 == hashlib.sha256(fixture["alpha"].read_bytes()).hexdigest()
+    assert spec.proof_unit_ids == (ALPHA_UNIT_A, ALPHA_UNIT_B)
+    assert [unit.statement_sha256 for unit in spec.proof_units] == [
+        statement_sha256(ALPHA_STATEMENT_A),
+        statement_sha256(ALPHA_STATEMENT_B),
+    ]
+    assert mode.module_task_entry(str(fixture["alpha"])).spec == spec
+    assert mode.specification_ids() == {ALPHA_TASK_ID: ALPHA_TASK_ID, BETA_TASK_ID: BETA_TASK_ID}
+
+
 def test_mode_remains_pickleable_after_manifest_discovery(tmp_path):
-    suite = tmp_path / "proof-from-scratch"
-    target = _write_task(suite, "Example/Example_Target.tla")
-    context = _write_module(suite, "Context/Model.tla")
-    _write_manifest(
-        suite,
-        {"Example/Example_Target.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"]}},
-    )
+    fixture = _fixture(tmp_path)
     mode = _mode(tmp_path)
     mode.get_benchmark_files()
 
     restored = pickle.loads(pickle.dumps(mode))
 
-    assert restored.get_benchmark_files() == [str(target)]
-    assert restored.get_dependencies(str(target)) == [str(context)]
+    assert restored.get_benchmark_files() == [str(fixture["alpha"]), str(fixture["beta"])]
+    assert restored.get_dependencies(str(fixture["alpha"])) == [
+        str(fixture["context_b"]),
+        str(fixture["context_a"]),
+    ]
+    assert restored.module_task_spec(str(fixture["alpha"])) == mode.module_task_spec(str(fixture["alpha"]))

--- a/tests/evaluator/test_proof_from_scratch_runner.py
+++ b/tests/evaluator/test_proof_from_scratch_runner.py
@@ -10,16 +10,17 @@ from pathlib import Path
 
 import pytest
 
-from common.proof_from_scratch_contract import (
-    BEGIN_AGENT_HELPERS,
-    BEGIN_AGENT_PROOF,
-    END_AGENT_HELPERS,
-    END_AGENT_PROOF,
+from common.proof_from_scratch_module import (
+    MODULE_TASK_FORMAT_VERSION,
+    begin_agent_proof,
+    end_agent_proof,
+    statement_sha256,
 )
 from common.proof_libraries import OfficialLibraryCatalog
+from common.task_contract import BEGIN_AGENT_HELPERS, END_AGENT_HELPERS
 from evaluator import runner
 from evaluator.backends.agentic import AgenticBackend
-from evaluator.backends.base import BackendCapabilities
+from evaluator.backends.base import BackendCapabilities, SubmissionDisposition, SubmissionPlan
 from evaluator.modes.proof_from_scratch import ProofFromScratch
 
 
@@ -40,6 +41,11 @@ def _module(name, body=""):
     return f"---- MODULE {name} ----\n{body}====\n"
 
 
+MODULE_TASK_ID = "Suite/Task.tla"
+PROOF_UNIT_ID = "Suite/Task_Target.tla"
+TARGET_STATEMENT = "THEOREM Target == TRUE"
+
+
 def _task():
     return "\n".join(
         (
@@ -48,14 +54,77 @@ def _task():
             BEGIN_AGENT_HELPERS,
             "",
             END_AGENT_HELPERS,
-            "THEOREM Target == TRUE",
-            BEGIN_AGENT_PROOF,
-            "PROOF OBVIOUS",
-            END_AGENT_PROOF,
+            TARGET_STATEMENT,
+            begin_agent_proof(PROOF_UNIT_ID),
+            "PROOF OMITTED",
+            end_agent_proof(PROOF_UNIT_ID),
             "====",
             "",
         )
     )
+
+
+def _write_module_manifests(benchmark_root, task_source):
+    """Write a strict module manifest bound to its source-corpus manifest."""
+    corpus_manifest = (
+        json.dumps(
+            {
+                PROOF_UNIT_ID: {
+                    "spec_id": MODULE_TASK_ID,
+                    "context": ["Context/Model.tla"],
+                }
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
+    corpus_manifest_path = benchmark_root / "proof-from-scratch" / "manifest.json"
+    corpus_manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    corpus_manifest_path.write_bytes(corpus_manifest)
+
+    module_manifest = {
+        "format_version": MODULE_TASK_FORMAT_VERSION,
+        "corpus_sha256": hashlib.sha256(corpus_manifest).hexdigest(),
+        "complete": True,
+        "module_tasks": [
+            {
+                "spec": {
+                    "format_version": MODULE_TASK_FORMAT_VERSION,
+                    "task_id": MODULE_TASK_ID,
+                    "source_sha256": hashlib.sha256(task_source.encode("utf-8")).hexdigest(),
+                    "proof_units": [
+                        {
+                            "task_id": PROOF_UNIT_ID,
+                            "statement_sha256": statement_sha256(TARGET_STATEMENT),
+                        }
+                    ],
+                },
+                "context": ["Context/Model.tla"],
+                "renamed_bindings": {},
+            }
+        ],
+    }
+    module_manifest_path = benchmark_root / "proof-from-scratch-module" / "manifest.json"
+    module_manifest_path.write_text(json.dumps(module_manifest), encoding="utf-8")
+
+
+def _write_fixture(tmp_path):
+    benchmark_root = tmp_path / "benchmark"
+    suite = benchmark_root / "proof-from-scratch-module"
+    task = suite / MODULE_TASK_ID
+    model = suite / "Context" / "Model.tla"
+    task.parent.mkdir(parents=True)
+    model.parent.mkdir(parents=True)
+    task_source = _task()
+    model_source = _module("Model", "Value == TRUE\n")
+    task.write_text(task_source, encoding="utf-8")
+    model.write_text(model_source, encoding="utf-8")
+    source = tmp_path / "source" / MODULE_TASK_ID
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_bytes(task_source.encode("utf-8"))
+    _write_module_manifests(benchmark_root, task_source)
+    return benchmark_root, suite, task, model, task_source, model_source
 
 
 def _catalog():
@@ -69,24 +138,17 @@ def _toolchain():
 
 
 def test_runner_grades_from_pre_agent_canonical_bytes(tmp_path, monkeypatch):
-    suite = tmp_path / "benchmark" / "proof-from-scratch"
-    task = suite / "Suite" / "Task.tla"
-    model = suite / "Context" / "Model.tla"
+    benchmark_root, suite, task, model, task_source, model_source = _write_fixture(tmp_path)
     sibling = suite / "Suite" / "Sibling_Task.tla"
     unrelated = suite / "Suite" / "UnrelatedDefs.tla"
-    task.parent.mkdir(parents=True)
-    model.parent.mkdir(parents=True)
-    task_source = _task()
-    model_source = _module("Model", "Value == TRUE\n")
-    task.write_text(task_source)
-    model.write_text(model_source)
     sibling.write_text(_module("Sibling_Task", "THEOREM Leak == TRUE\nPROOF OBVIOUS\n"))
     unrelated.write_text(_module("UnrelatedDefs", "Leak == TRUE\n"))
-    (suite / "manifest.json").write_text(
-        json.dumps({"Suite/Task.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"]}})
-    )
 
-    mode = ProofFromScratch(str(tmp_path / "benchmark"), "/checker")
+    mode = ProofFromScratch(str(benchmark_root), "/checker")
+    # Strict module metadata is validated before workers start. Warm its
+    # manifest cache before simulating host-file mutation below so this direct
+    # WorkItem call exercises canonical replay rather than manifest discovery.
+    assert mode.get_benchmark_files() == [str(task.resolve())]
     backend = _Backend()
     agent_canonical_dirs = []
     grader_canonical_dirs = []
@@ -154,25 +216,98 @@ def test_runner_grades_from_pre_agent_canonical_bytes(tmp_path, monkeypatch):
     assert sorted(path.name for path in input_dir.iterdir()) == ["Model.tla", "benchmark.tla", "prompt.txt", "skills"]
     assert (input_dir / "benchmark.tla").read_text() == task_source
     assert (input_dir / "Model.tla").read_text() == model_source
-    assert BEGIN_AGENT_HELPERS in (input_dir / "prompt.txt").read_text()
+    assert "identified AGENT PROOF region" in (input_dir / "prompt.txt").read_text()
     assert list((input_dir / "skills").iterdir()) == []
     assert grader_canonical_dirs[0] != agent_canonical_dirs[0]
 
 
-def test_cli_captures_all_replay_inputs_before_backend_setup(tmp_path, monkeypatch):
-    benchmark_root = tmp_path / "benchmark"
-    suite = benchmark_root / "proof-from-scratch"
-    task = suite / "Suite" / "Task.tla"
-    model = suite / "Context" / "Model.tla"
-    task.parent.mkdir(parents=True)
-    model.parent.mkdir(parents=True)
-    task_source = _task()
-    model_source = _module("Model", "Value == TRUE\n")
-    task.write_text(task_source)
-    model.write_text(model_source)
-    (suite / "manifest.json").write_text(
-        json.dumps({"Suite/Task.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"]}})
+@pytest.mark.parametrize("mutation", ["deleted", "empty", "symlink", "directory", "fifo", "not_materialized"])
+def test_invalid_module_submission_fails_without_grading_canonical_input(tmp_path, monkeypatch, mutation):
+    benchmark_root, _suite, task, model, task_source, _model_source = _write_fixture(tmp_path)
+    mode = ProofFromScratch(str(benchmark_root), "/checker")
+    backend = _Backend()
+    canonical_inputs = runner.CanonicalInputs.capture(str(task), task.name, [str(model)])
+    identity = runner.ModuleCheckpointIdentity(
+        task_id=MODULE_TASK_ID,
+        proof_unit_ids=(PROOF_UNIT_ID,),
+        canonical_input_sha256=canonical_inputs.digest(),
+        run_identity_sha256="0" * 64,
     )
+    grader_calls = []
+
+    def fake_agent(
+        item,
+        backend_,
+        mode_,
+        workspace,
+        agent_dir,
+        agent_jsonl,
+        prompt,
+        result,
+        checker_bin,
+        canonical_dir=None,
+    ):
+        if mutation == "deleted":
+            os.unlink(os.path.join(workspace, task.name))
+        elif mutation == "empty":
+            Path(workspace, task.name).write_bytes(b"")
+        elif mutation == "symlink":
+            Path(workspace, task.name).unlink()
+            Path(workspace, task.name).symlink_to(model.name)
+        elif mutation == "directory":
+            Path(workspace, task.name).unlink()
+            Path(workspace, task.name).mkdir()
+        elif mutation == "fifo":
+            Path(workspace, task.name).unlink()
+            os.mkfifo(Path(workspace, task.name))
+        with open(agent_jsonl, "w") as f:
+            f.write('{"type": "result", "exitCode": 0}\n')
+        result["agent_exit"] = 0
+
+    def fake_grader(item, workspace, basename, grading_dir, check_result_path, result, canonical_dir=None):
+        submitted = Path(workspace, basename)
+        grader_calls.append((submitted.exists(), submitted.read_bytes() if submitted.exists() else None))
+        assert Path(canonical_dir, basename).read_text() == task_source
+        result["check_verdict"] = "PASS"
+
+    if mutation == "not_materialized":
+        monkeypatch.setattr(
+            backend,
+            "prepare_submission",
+            lambda *args, **kwargs: SubmissionPlan(
+                disposition=SubmissionDisposition.FAIL,
+                copy_solution=False,
+                error="module submission was not materialized",
+            ),
+        )
+    monkeypatch.setattr(runner, "_run_backend_local", fake_agent)
+    monkeypatch.setattr(runner, "_run_grader_local", fake_grader)
+
+    item = runner.WorkItem(
+        benchmark_path=str(task),
+        output_dir=str(tmp_path / "results"),
+        timeout=10,
+        check_timeout=10,
+        backend=backend,
+        mode=mode,
+        tlapm_path="/opt/tlapm",
+        tlapm_lib="/opt/tlapm/lib",
+        infra_retries=0,
+        canonical_inputs=canonical_inputs,
+        module_checkpoint_identity=identity,
+    )
+
+    result = runner.run_single_benchmark(item)
+
+    assert result["check_verdict"] == "FAIL"
+    assert result["termination_reason"] == runner.TerminationReason.OK
+    assert "module_artifact" not in result
+    assert grader_calls == []
+    assert runner._module_resume_action(result, max_continuations=0) == runner.MODULE_RESUME_COMPLETE
+
+
+def test_cli_captures_all_replay_inputs_before_backend_setup(tmp_path, monkeypatch):
+    benchmark_root, _suite, task, model, task_source, model_source = _write_fixture(tmp_path)
 
     mode = ProofFromScratch(str(benchmark_root), "/checker")
     backend = _Backend()
@@ -222,20 +357,15 @@ def test_cli_captures_all_replay_inputs_before_backend_setup(tmp_path, monkeypat
     assert canonical_inputs is not None
     assert canonical_inputs.target_bytes == task_source.encode()
     assert canonical_inputs.dependencies == (("Model.tla", model_source.encode()),)
+    checkpoint_identity = captured_items[0].module_checkpoint_identity
+    assert checkpoint_identity is not None
+    assert checkpoint_identity.task_id == MODULE_TASK_ID
+    assert checkpoint_identity.proof_unit_ids == (PROOF_UNIT_ID,)
+    assert checkpoint_identity.canonical_input_sha256 == canonical_inputs.digest()
 
 
 def test_proof_from_scratch_tool_free_backend_fails_before_setup(tmp_path, monkeypatch, capsys):
-    benchmark_root = tmp_path / "benchmark"
-    suite = benchmark_root / "proof-from-scratch"
-    task = suite / "Suite" / "Task.tla"
-    model = suite / "Context" / "Model.tla"
-    task.parent.mkdir(parents=True)
-    model.parent.mkdir(parents=True)
-    task.write_text(_task())
-    model.write_text(_module("Model"))
-    (suite / "manifest.json").write_text(
-        json.dumps({"Suite/Task.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"]}})
-    )
+    benchmark_root, _suite, _task_path, _model, _task_source, _model_source = _write_fixture(tmp_path)
     mode = ProofFromScratch(str(benchmark_root), "/checker")
     backend = _Backend()
     backend.name = "tool-free"
@@ -260,17 +390,7 @@ def test_proof_from_scratch_tool_free_backend_fails_before_setup(tmp_path, monke
 
 
 def test_container_proof_from_scratch_uses_image_environment(tmp_path, monkeypatch):
-    benchmark_root = tmp_path / "benchmark"
-    suite = benchmark_root / "proof-from-scratch"
-    task = suite / "Suite" / "Task.tla"
-    model = suite / "Context" / "Model.tla"
-    task.parent.mkdir(parents=True)
-    model.parent.mkdir(parents=True)
-    task.write_text(_task())
-    model.write_text(_module("Model"))
-    (suite / "manifest.json").write_text(
-        json.dumps({"Suite/Task.tla": {"spec_id": "Fixture.tla", "context": ["Context/Model.tla"]}})
-    )
+    benchmark_root, _suite, _task, _model, _task_source, _model_source = _write_fixture(tmp_path)
     mode = ProofFromScratch(str(benchmark_root), "/checker")
     backend = _Backend()
     captured_items = []

--- a/tests/evaluator/test_proof_module_checkpoint.py
+++ b/tests/evaluator/test_proof_module_checkpoint.py
@@ -1,0 +1,484 @@
+"""Durable module artifacts and checkpoint recovery."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from evaluator import runner
+from evaluator.backends.agentic import AgenticBackend
+from evaluator.proof_module_artifact import (
+    ModuleArtifactError,
+    publish_module_artifact,
+    read_module_artifact,
+    result_module_artifact,
+)
+from evaluator.proof_module_checkpoint import (
+    MODULE_CHECKPOINT_FORMAT_VERSION,
+    ModuleCheckpointError,
+    ModuleCheckpointIdentity,
+    checkpoint_path,
+    load_module_checkpoint,
+    prepare_module_checkpoints,
+    run_identity_sha256,
+    write_module_checkpoint,
+)
+
+TASK_ID = "Suite/Task.tla"
+UNIT_ID = "Suite/Task-Target.tla"
+CANONICAL_INPUT_SHA256 = "1" * 64
+RUN_IDENTITY_SHA256 = "2" * 64
+
+
+def _identity(**changes: object) -> ModuleCheckpointIdentity:
+    values: dict[str, object] = {
+        "task_id": TASK_ID,
+        "proof_unit_ids": (UNIT_ID,),
+        "canonical_input_sha256": CANONICAL_INPUT_SHA256,
+        "run_identity_sha256": RUN_IDENTITY_SHA256,
+    }
+    values.update(changes)
+    return ModuleCheckpointIdentity(**values)  # type: ignore[arg-type]
+
+
+def _module_result(*, complete: bool = True, schema_version: int = 1) -> dict[str, object]:
+    unit = {
+        "unit_id": UNIT_ID,
+        "kind": "target",
+        "theorem_name": "Target",
+        "line_start": 4,
+        "line_end": 6,
+        "dependencies": [],
+        "raw_verdict": "PASS" if complete else "FAIL",
+        "tlapm_exit": 0 if complete else 1,
+        "missing_proofs": 0 if complete else 1,
+        "obligation_failed": False,
+        "trusted": complete,
+    }
+    return {
+        "schema_version": schema_version,
+        "sany_status": "valid",
+        "proof_unit_ids": [UNIT_ID],
+        "units": [unit],
+        "trusted_unit_ids": [UNIT_ID] if complete else [],
+        "trusted_proof_unit_ids": [UNIT_ID] if complete else [],
+        "complete": complete,
+    }
+
+
+def _result(
+    *, artifact: dict[str, object] | None = None, module_result: dict[str, object] | None = None
+) -> dict[str, object]:
+    result: dict[str, object] = {
+        "benchmark": TASK_ID,
+        "proof_unit_ids": [UNIT_ID],
+        "proof_unit_count": 1,
+        "trusted_proof_unit_count": len(module_result.get("trusted_proof_unit_ids", [])) if module_result else 0,
+        "trusted_proof_unit_ids": list(module_result.get("trusted_proof_unit_ids", [])) if module_result else [],
+        "check_verdict": "PASS" if module_result is None or module_result.get("complete", False) else "FAIL",
+    }
+    if artifact is not None:
+        result["module_artifact"] = artifact
+    if module_result is not None:
+        result["module_result"] = module_result
+    return result
+
+
+def test_module_artifact_publish_read_is_content_addressed_and_idempotent(tmp_path):
+    content = b"---- MODULE Task ----\nPROOF OBVIOUS\n====\n"
+
+    receipt = publish_module_artifact(tmp_path, content)
+    duplicate_receipt = publish_module_artifact(tmp_path, content)
+
+    assert receipt == duplicate_receipt
+    assert receipt == {
+        "schema_version": 1,
+        "sha256": hashlib.sha256(content).hexdigest(),
+        "path": f"module-artifacts/{hashlib.sha256(content).hexdigest()[:2]}/{hashlib.sha256(content).hexdigest()}.tla",
+        "byte_count": len(content),
+    }
+    assert read_module_artifact(tmp_path, receipt) == content
+    assert list((tmp_path / "module-artifacts").rglob("*.tmp")) == []
+
+
+def test_parallel_module_artifact_publish_handles_directory_creation_race(tmp_path, monkeypatch):
+    original_mkdir = Path.mkdir
+    barrier = threading.Barrier(2)
+
+    def synchronized_mkdir(path, *args, **kwargs):
+        if path.name == "module-artifacts" and not path.exists():
+            barrier.wait(timeout=5)
+        return original_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", synchronized_mkdir)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        receipts = list(executor.map(lambda content: publish_module_artifact(tmp_path, content), (b"a", b"b")))
+
+    assert [read_module_artifact(tmp_path, receipt) for receipt in receipts] == [b"a", b"b"]
+
+
+def test_module_artifact_read_rejects_tampered_bytes(tmp_path):
+    content = b"canonical module bytes"
+    receipt = publish_module_artifact(tmp_path, content)
+    artifact_path = tmp_path / receipt["path"]
+    artifact_path.write_bytes(b"changed module bytes")
+
+    with pytest.raises(ModuleArtifactError, match="no longer matches its receipt"):
+        read_module_artifact(tmp_path, receipt)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("schema_version", True, "unsupported"),
+        ("sha256", "f" * 64, "digest-owned path"),
+        ("path", "module-artifacts/../outside.tla", "digest-owned path"),
+        ("byte_count", 1, "no longer matches"),
+    ],
+)
+def test_module_artifact_read_rejects_tampered_receipt(tmp_path, field, value, message):
+    content = b"canonical module bytes"
+    receipt = publish_module_artifact(tmp_path, content)
+    tampered = {**receipt, field: value}
+
+    with pytest.raises(ModuleArtifactError, match=message):
+        read_module_artifact(tmp_path, tampered)
+
+
+def test_result_module_artifact_uses_latest_continuation_receipt(tmp_path):
+    first = publish_module_artifact(tmp_path, b"first")
+    latest = publish_module_artifact(tmp_path, b"latest")
+    result = {
+        "module_artifact": first,
+        "continuations": [{"module_artifact": first}, {"module_artifact": latest}],
+    }
+
+    assert result_module_artifact(result) == latest
+    assert read_module_artifact(tmp_path, result_module_artifact(result)) == b"latest"
+
+
+def test_checkpoint_save_load_and_sequence_are_durable(tmp_path):
+    identity = _identity()
+    artifact = publish_module_artifact(tmp_path, b"partial module")
+    result = _result(artifact=artifact, module_result=_module_result(complete=False))
+
+    first = write_module_checkpoint(tmp_path, identity, result)
+    assert first.sequence == 1
+    assert load_module_checkpoint(tmp_path, identity) == first
+
+    second = write_module_checkpoint(tmp_path, identity, {**result, "check_verdict": "ERROR"})
+    assert second.sequence == 2
+    assert load_module_checkpoint(tmp_path, identity) == second
+
+    path = checkpoint_path(tmp_path, TASK_ID)
+    assert json.loads(path.read_text()) == {
+        "format_version": MODULE_CHECKPOINT_FORMAT_VERSION,
+        "identity": identity.as_dict(),
+        "sequence": 2,
+        "result": second.result,
+    }
+    assert [entry for entry in path.parent.iterdir() if entry.name.endswith(".tmp")] == []
+
+
+def test_checkpoint_identical_write_is_idempotent(tmp_path):
+    identity = _identity()
+    artifact = publish_module_artifact(tmp_path, b"partial module")
+    result = _result(artifact=artifact, module_result=_module_result(complete=False))
+
+    first = write_module_checkpoint(tmp_path, identity, result)
+    second = write_module_checkpoint(tmp_path, identity, result)
+
+    assert second == first
+    assert load_module_checkpoint(tmp_path, identity).sequence == 1
+
+
+def test_checkpoint_atomic_save_preserves_previous_file_on_replace_failure(tmp_path, monkeypatch):
+    identity = _identity()
+    artifact = publish_module_artifact(tmp_path, b"partial module")
+    result = _result(artifact=artifact, module_result=_module_result(complete=False))
+    write_module_checkpoint(tmp_path, identity, result)
+    path = checkpoint_path(tmp_path, TASK_ID)
+    before = path.read_bytes()
+
+    def fail_replace(*_args):
+        raise OSError("simulated interrupted checkpoint replacement")
+
+    monkeypatch.setattr("evaluator.proof_module_checkpoint.os.replace", fail_replace)
+    with pytest.raises(ModuleCheckpointError, match="cannot write module checkpoint"):
+        write_module_checkpoint(tmp_path, identity, {**result, "check_verdict": "ERROR"})
+
+    assert path.read_bytes() == before
+    assert load_module_checkpoint(tmp_path, identity).sequence == 1
+    assert [entry for entry in path.parent.iterdir() if entry.name.endswith(".tmp")] == []
+
+
+def test_checkpoint_load_rejects_identity_mismatch(tmp_path):
+    identity = _identity()
+    artifact = publish_module_artifact(tmp_path, b"partial module")
+    write_module_checkpoint(
+        tmp_path, identity, _result(artifact=artifact, module_result=_module_result(complete=False))
+    )
+
+    with pytest.raises(ModuleCheckpointError, match="identity differs from the current run"):
+        load_module_checkpoint(tmp_path, _identity(run_identity_sha256="3" * 64))
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda payload: payload.update(format_version=True), "format_version"),
+        (lambda payload: payload["identity"].update(task_id=1), "task_id"),
+        (lambda payload: payload["identity"].update(proof_unit_ids=[[UNIT_ID]]), "proof_unit_ids"),
+        (lambda payload: payload["identity"].update(run_identity_sha256=1), "run_identity_sha256"),
+    ],
+)
+def test_checkpoint_load_rejects_malformed_scalar_types(tmp_path, mutate, message):
+    identity = _identity()
+    artifact = publish_module_artifact(tmp_path, b"partial module")
+    write_module_checkpoint(
+        tmp_path, identity, _result(artifact=artifact, module_result=_module_result(complete=False))
+    )
+    path = checkpoint_path(tmp_path, TASK_ID)
+    payload = json.loads(path.read_text())
+    mutate(payload)
+    path.write_text(json.dumps(payload))
+
+    with pytest.raises(ModuleCheckpointError, match=message):
+        load_module_checkpoint(tmp_path, identity)
+
+
+@pytest.mark.parametrize(
+    "module_result",
+    [
+        _module_result(schema_version=0),
+        {"schema_version": 1, "sany_status": "valid"},
+    ],
+)
+def test_checkpoint_rejects_invalid_or_old_module_result(tmp_path, module_result):
+    identity = _identity()
+    artifact = publish_module_artifact(tmp_path, b"partial module")
+
+    with pytest.raises(ModuleCheckpointError, match="invalid .* checker result"):
+        write_module_checkpoint(tmp_path, identity, _result(artifact=artifact, module_result=module_result))
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda result: result.update(proof_unit_count=True), "proof-unit count"),
+        (lambda result: result.update(trusted_proof_unit_count=True), "trusted proof-unit count"),
+        (lambda result: result.update(check_verdict=[]), "checker verdict"),
+    ],
+)
+def test_checkpoint_rejects_malformed_derived_module_fields(tmp_path, mutate, message):
+    identity = _identity()
+    artifact = publish_module_artifact(tmp_path, b"partial module")
+    result = _result(artifact=artifact, module_result=_module_result(complete=False))
+    mutate(result)
+
+    with pytest.raises(ModuleCheckpointError, match=message):
+        write_module_checkpoint(tmp_path, identity, result)
+
+
+def test_checkpoint_rejects_pass_without_module_result(tmp_path):
+    identity = _identity()
+
+    with pytest.raises(ModuleCheckpointError, match="PASS without a complete module checker result"):
+        write_module_checkpoint(tmp_path, identity, _result())
+
+
+def test_checkpoint_rejects_continuation_pass_without_module_result(tmp_path):
+    identity = _identity()
+    first_artifact = publish_module_artifact(tmp_path, b"first module")
+    continuation_artifact = publish_module_artifact(tmp_path, b"continued module")
+    result = _result(artifact=first_artifact, module_result=_module_result(complete=False))
+    result["max_continuations"] = 1
+    continuation = _result(artifact=continuation_artifact)
+    continuation["round"] = 1
+    result["continuations"] = [continuation]
+
+    with pytest.raises(ModuleCheckpointError, match="continuation 1.*PASS without a complete module checker result"):
+        write_module_checkpoint(tmp_path, identity, result)
+
+
+def test_checkpoint_preserves_cheating_verdict(tmp_path):
+    identity = _identity()
+    artifact = publish_module_artifact(tmp_path, b"cheating module")
+    module_result = {
+        "schema_version": 1,
+        "sany_status": "valid",
+        "proof_unit_ids": [UNIT_ID],
+        "units": [],
+        "trusted_unit_ids": [],
+        "trusted_proof_unit_ids": [],
+        "complete": False,
+        "integrity_issues": [{"code": "SCAFFOLD_MODIFIED", "message": "scaffold changed"}],
+    }
+    result = _result(artifact=artifact, module_result=module_result)
+    result["check_verdict"] = "CHEATING"
+
+    checkpoint = write_module_checkpoint(tmp_path, identity, result)
+
+    assert checkpoint.result["check_verdict"] == "CHEATING"
+    assert load_module_checkpoint(tmp_path, identity).result["check_verdict"] == "CHEATING"
+
+
+def test_checkpoint_recovery_returns_last_partial_module_bytes(tmp_path):
+    identity = _identity()
+    partial = b"partial module to continue"
+    artifact = publish_module_artifact(tmp_path, partial)
+    result = _result(artifact=artifact, module_result=_module_result(complete=False))
+    write_module_checkpoint(tmp_path, identity, result)
+    (tmp_path / "run-manifest.json").write_text("{}\n")
+    (tmp_path / "task-list.json").write_text("{}\n")
+
+    recovered = prepare_module_checkpoints(tmp_path, {TASK_ID: identity}, resume=True)
+
+    assert recovered[TASK_ID].sequence == 1
+    recovered_receipt = result_module_artifact(recovered[TASK_ID].result)
+    assert read_module_artifact(tmp_path, recovered_receipt) == partial
+
+
+def test_runner_recovery_rejects_old_result_without_checkpoint(tmp_path):
+    identity = _identity()
+
+    with pytest.raises(ValueError, match="cannot resume theorem-level or pre-checkpoint"):
+        runner._recover_module_resume(
+            str(tmp_path),
+            [{"benchmark": TASK_ID, "check_verdict": "FAIL"}],
+            {TASK_ID: identity},
+            {},
+            max_continuations=0,
+        )
+
+
+def test_run_identity_hash_ignores_provenance_revision():
+    identity = {"mode": "proof-from-scratch", "benchmark_revision": "old", "corpus_digest": "corpus"}
+    changed_revision = {**identity, "benchmark_revision": "new"}
+
+    assert run_identity_sha256(identity) == run_identity_sha256(changed_revision)
+
+
+class _ModuleBackend(AgenticBackend):
+    name = "copilot"
+
+    def build_command(self, workspace, result_dir):
+        return ["fake-agent"]
+
+    def parse_output(self, jsonl_path):
+        return "", 0, 0
+
+
+class _ModuleMode:
+    name = "proof-from-scratch"
+    description = "module fixture"
+    canonical_replay_required = True
+    requires_workspace_tools = True
+
+    def __init__(self, root: Path, task: Path):
+        self._root = root
+        self._task = task
+
+    def benchmark_dir(self):
+        return str(self._root)
+
+    def get_benchmark_files(self, _filter=None):
+        return [str(self._task)]
+
+    def get_dependencies(self, _benchmark_path):
+        return []
+
+    def module_task_spec(self, _benchmark_path):
+        return SimpleNamespace(proof_unit_ids=(UNIT_ID,))
+
+
+def test_runner_resume_work_item_carries_checkpoint_identity_and_submission(tmp_path, monkeypatch):
+    benchmark_root = tmp_path / "proof-from-scratch-module"
+    task = benchmark_root / TASK_ID
+    task.parent.mkdir(parents=True)
+    task.write_bytes(b"canonical module task")
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    (tmp_path / "lib" / "tlapm").mkdir(parents=True)
+
+    run_identity = {
+        "schema_version": 2,
+        "mode": "proof-from-scratch",
+        "corpus_digest": "corpus",
+        "proof_library_digest": "libraries",
+        "verification_toolchain_digest": "toolchain",
+    }
+    canonical_inputs = runner.CanonicalInputs.capture(str(task), task.name, [])
+    identity = ModuleCheckpointIdentity(
+        task_id=TASK_ID,
+        proof_unit_ids=(UNIT_ID,),
+        canonical_input_sha256=canonical_inputs.digest(),
+        run_identity_sha256=run_identity_sha256(run_identity),
+    )
+    partial = b"partial module to continue"
+    artifact = publish_module_artifact(output_dir, partial)
+    pending = _result(artifact=artifact)
+    pending["check_verdict"] = "ERROR"
+    pending["module_grading_pending"] = 0
+    write_module_checkpoint(output_dir, identity, pending)
+    (output_dir / "run-manifest.json").write_text(json.dumps(run_identity))
+    (output_dir / "task-list.json").write_text(json.dumps({"mode": "proof-from-scratch", "tasks": [TASK_ID]}))
+    (output_dir / "results.json").write_text(json.dumps([{"benchmark": TASK_ID, "check_verdict": "FAIL"}]))
+
+    backend = _ModuleBackend()
+    mode = _ModuleMode(benchmark_root, task)
+    captured: list[runner.WorkItem] = []
+    monkeypatch.setattr(runner, "get_backend", lambda *_args, **_kwargs: backend)
+    monkeypatch.setattr(runner, "get_mode", lambda *_args, **_kwargs: mode)
+    monkeypatch.setattr(runner, "resolve_paths", lambda: (str(tmp_path), "/checker"))
+    monkeypatch.setattr(runner, "REPO_ROOT", str(tmp_path))
+    monkeypatch.setattr(runner, "_native_verification_environment", lambda: (None, {"digest": "toolchain"}))
+    monkeypatch.setattr(runner, "_proof_from_scratch_run_identity", lambda *_args: run_identity)
+    monkeypatch.setattr(runner, "_run_sany_preflight", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        runner,
+        "run_single_benchmark",
+        lambda item: (
+            captured.append(item)
+            or {
+                "benchmark": TASK_ID,
+                "check_verdict": "FAIL",
+                "time_secs": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(runner, "update_summary", lambda *_args: None)
+    monkeypatch.setattr(
+        runner.sys,
+        "argv",
+        [
+            "tlaps-bench",
+            "--backend",
+            "copilot",
+            "--mode",
+            "proof-from-scratch",
+            "--no-container",
+            "--resume",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    runner.main()
+
+    assert len(captured) == 1
+    assert captured[0].module_checkpoint_identity == identity
+    module_resume = captured[0].module_resume
+    assert module_resume is not None
+    assert module_resume.action == runner.MODULE_RESUME_GRADE_SAVED
+    assert module_resume.submission == partial
+    assert module_resume.artifact_receipt == artifact
+    assert module_resume.checkpoint_sequence == 1

--- a/tests/evaluator/test_proof_module_result.py
+++ b/tests/evaluator/test_proof_module_result.py
@@ -1,0 +1,400 @@
+"""Focused tests for module checker reports and their runner parser seam."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from evaluator.proof_module_result import (
+    MODULE_RESULT_PREFIX,
+    MODULE_RESULT_SCHEMA_VERSION,
+    ModuleResultError,
+    module_result_from_result,
+    parse_module_result_json,
+    validate_module_result,
+)
+from evaluator.runner import _parse_grader_result
+
+UNIT_A = "Suite/Source_A.tla"
+UNIT_B = "Suite/Source_B.tla"
+HELPER = "helper:Bridge"
+EXPECTED_UNITS = (UNIT_A, UNIT_B)
+
+
+def _unit(
+    unit_id: str,
+    *,
+    dependencies: tuple[str, ...] = (),
+    raw_verdict: str = "PASS",
+    tlapm_exit: int | None = 0,
+    missing_proofs: int | None = 0,
+    obligation_failed: bool | None = False,
+    trusted: bool = True,
+) -> dict[str, object]:
+    kind = "helper" if unit_id.startswith("helper:") else "target"
+    return {
+        "unit_id": unit_id,
+        "kind": kind,
+        "theorem_name": unit_id.rsplit("/", 1)[-1].removesuffix(".tla") if kind == "target" else "Bridge",
+        "line_start": 10 if unit_id == UNIT_A else 20 if unit_id == HELPER else 30,
+        "line_end": 11 if unit_id == UNIT_A else 21 if unit_id == HELPER else 31,
+        "dependencies": list(dependencies),
+        "raw_verdict": raw_verdict,
+        "tlapm_exit": tlapm_exit,
+        "missing_proofs": missing_proofs,
+        "obligation_failed": obligation_failed,
+        "trusted": trusted,
+    }
+
+
+def _complete_report() -> dict[str, object]:
+    units = [
+        _unit(UNIT_A),
+        _unit(HELPER, dependencies=(UNIT_A,)),
+        _unit(UNIT_B, dependencies=(HELPER,)),
+    ]
+    return {
+        "schema_version": MODULE_RESULT_SCHEMA_VERSION,
+        "sany_status": "valid",
+        "proof_unit_ids": list(EXPECTED_UNITS),
+        "units": units,
+        "trusted_unit_ids": sorted((UNIT_A, HELPER, UNIT_B)),
+        "trusted_proof_unit_ids": list(EXPECTED_UNITS),
+        "complete": True,
+    }
+
+
+def _partial_report() -> dict[str, object]:
+    units = [
+        _unit(UNIT_A),
+        _unit(
+            UNIT_B,
+            raw_verdict="FAIL",
+            tlapm_exit=11,
+            missing_proofs=1,
+            obligation_failed=False,
+            trusted=False,
+        ),
+    ]
+    return {
+        "schema_version": MODULE_RESULT_SCHEMA_VERSION,
+        "sany_status": "valid",
+        "proof_unit_ids": list(EXPECTED_UNITS),
+        "units": units,
+        "trusted_unit_ids": [UNIT_A],
+        "trusted_proof_unit_ids": [UNIT_A],
+        "complete": False,
+    }
+
+
+def _assert_invalid(report: dict[str, object], message: str | None = None) -> None:
+    match = pytest.raises(ModuleResultError, match=message) if message else pytest.raises(ModuleResultError)
+    with match:
+        validate_module_result(report, EXPECTED_UNITS)
+
+
+def test_accepts_a_complete_dependency_closed_report() -> None:
+    report = _complete_report()
+
+    assert validate_module_result(report, EXPECTED_UNITS) == report
+
+
+def test_accepts_a_partial_report_with_only_the_first_target_trusted() -> None:
+    report = _partial_report()
+
+    assert validate_module_result(report, EXPECTED_UNITS) == report
+
+
+def test_rejects_pass_evidence_from_tlapm_exit_eleven() -> None:
+    report = _complete_report()
+    report["units"][0]["tlapm_exit"] = 11
+
+    _assert_invalid(report, "inconsistent PASS evidence")
+
+
+def test_accepts_sany_invalid_report_without_proof_data() -> None:
+    report = {
+        "schema_version": MODULE_RESULT_SCHEMA_VERSION,
+        "sany_status": "invalid",
+        "proof_unit_ids": list(EXPECTED_UNITS),
+        "units": [],
+        "trusted_unit_ids": [],
+        "trusted_proof_unit_ids": [],
+        "complete": False,
+    }
+
+    assert validate_module_result(report, EXPECTED_UNITS) == report
+
+
+def test_module_result_from_result_only_extracts_a_mapping_result() -> None:
+    report = _partial_report()
+
+    assert module_result_from_result({"module_result": report}) == report
+    assert module_result_from_result({}) is None
+    assert module_result_from_result({"module_result": None}) is None
+    assert module_result_from_result({"module_result": []}) is None
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda report: report["trusted_unit_ids"].remove(UNIT_A), "trusted-unit set"),
+        (lambda report: report["units"][0].update(trusted=False), "per-unit trust"),
+        (
+            lambda report: report.update(trusted_proof_unit_ids=[UNIT_B, UNIT_A]),
+            "trusted proof-unit IDs|manifest order",
+        ),
+    ],
+)
+def test_rejects_inconsistent_trust_evidence(mutate, message: str) -> None:
+    report = _complete_report()
+    mutate(report)
+
+    _assert_invalid(report, message)
+
+
+def test_rejects_targets_out_of_manifest_order() -> None:
+    report = _complete_report()
+    report["units"] = [report["units"][2], report["units"][1], report["units"][0]]
+
+    _assert_invalid(report, "manifest order")
+
+
+def test_rejects_proof_unit_ids_that_do_not_match_the_selected_task() -> None:
+    report = _complete_report()
+    report["proof_unit_ids"] = [UNIT_B, UNIT_A]
+
+    _assert_invalid(report, "differ from the selected module task")
+
+
+@pytest.mark.parametrize(
+    ("dependencies", "message"),
+    [
+        (("helper:Missing",), "unknown local dependencies"),
+        ((UNIT_A, UNIT_A), "must not contain duplicates"),
+    ],
+)
+def test_rejects_unknown_or_repeated_dependencies(dependencies: tuple[str, ...], message: str) -> None:
+    report = _partial_report()
+    report["units"][1]["dependencies"] = list(dependencies)
+
+    _assert_invalid(report, message)
+
+
+def test_rejects_a_raw_pass_cycle_as_trusted() -> None:
+    report = _complete_report()
+    report["units"][0]["dependencies"] = [UNIT_B]
+    report["units"][2]["dependencies"] = [UNIT_A]
+
+    _assert_invalid(report, "trusted-unit set")
+
+
+def test_rejects_an_unknown_raw_verdict() -> None:
+    report = _partial_report()
+    report["units"][1]["raw_verdict"] = "MAYBE"
+
+    _assert_invalid(report, "invalid raw_verdict")
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda report: report.pop("units"), "missing or unknown fields"),
+        (lambda report: report.update(extra=True), "missing or unknown fields"),
+        (lambda report: report.update(schema_version=True), "unsupported"),
+        (lambda report: report.update(schema_version=MODULE_RESULT_SCHEMA_VERSION + 1), "unsupported"),
+        (lambda report: report.update(sany_status=[]), "sany_status"),
+        (lambda report: report.update(sany_status="unknown"), "sany_status"),
+    ],
+)
+def test_rejects_schema_and_status_variants(mutate, message: str) -> None:
+    report = _complete_report()
+    mutate(report)
+
+    _assert_invalid(report, message)
+
+
+@pytest.mark.parametrize(
+    ("complete", "trusted_targets", "message"),
+    [
+        (True, [UNIT_A], "trusted proof-unit IDs|trusted proof-unit list"),
+        (False, list(EXPECTED_UNITS), "complete flag"),
+        (True, [], "trusted proof-unit list"),
+    ],
+)
+def test_rejects_totals_that_disagree_with_trusted_target_coverage(
+    complete: bool,
+    trusted_targets: list[str],
+    message: str,
+) -> None:
+    report = _complete_report()
+    report["complete"] = complete
+    report["trusted_proof_unit_ids"] = trusted_targets
+
+    _assert_invalid(report, message)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("tlapm_exit", "0"),
+        ("missing_proofs", -1),
+        ("obligation_failed", "false"),
+    ],
+)
+def test_rejects_malformed_unit_totals(field: str, value: object) -> None:
+    report = _partial_report()
+    report["units"][0][field] = value
+
+    _assert_invalid(report, f"{field}|invalid|boolean|integer|count")
+
+
+@pytest.mark.parametrize(("field", "value"), [("kind", []), ("raw_verdict", [])])
+def test_rejects_unhashable_unit_enums(field: str, value: object) -> None:
+    report = _partial_report()
+    report["units"][0][field] = value
+
+    _assert_invalid(report, f"invalid {field}")
+
+
+def _machine_output(report: dict[str, object], *, status: str = "valid") -> str:
+    return f"SANY-STATUS: {status}\n{MODULE_RESULT_PREFIX}{json.dumps(report, separators=(',', ':'))}\n"
+
+
+def _parse(report: dict[str, object], exit_code: int, *, output: str | None = None) -> dict[str, object]:
+    result: dict[str, object] = {}
+    _parse_grader_result(
+        exit_code,
+        _machine_output(report) if output is None else output,
+        result,
+        expected_module_unit_ids=EXPECTED_UNITS,
+    )
+    return result
+
+
+def test_parser_records_complete_report_and_derived_totals() -> None:
+    result = _parse(_complete_report(), 0)
+
+    assert result["check_verdict"] == "PASS"
+    assert result["proof_unit_count"] == 2
+    assert result["trusted_proof_unit_count"] == 2
+    assert result["trusted_proof_unit_ids"] == list(EXPECTED_UNITS)
+
+
+def test_parser_records_partial_report_as_fail_with_derived_totals() -> None:
+    result = _parse(_partial_report(), 1)
+
+    assert result["check_verdict"] == "FAIL"
+    assert result["proof_unit_count"] == 2
+    assert result["trusted_proof_unit_count"] == 1
+    assert result["trusted_proof_unit_ids"] == [UNIT_A]
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "SANY-STATUS: valid\n",
+        _machine_output(_partial_report())
+        + f"{MODULE_RESULT_PREFIX}{json.dumps(_partial_report(), separators=(',', ':'))}\n",
+        f"SANY-STATUS: valid\n{MODULE_RESULT_PREFIX}not-json\n",
+        _machine_output(_partial_report()).replace("}\n", "} trailing\n", 1),
+    ],
+)
+def test_parser_requires_exactly_one_valid_machine_result(output: str) -> None:
+    result: dict[str, object] = {}
+    _parse_grader_result(1, output, result, expected_module_unit_ids=EXPECTED_UNITS)
+
+    assert result["check_verdict"] == "ERROR"
+    assert "module" in result["error"]
+
+
+@pytest.mark.parametrize(
+    ("report", "exit_code", "message"),
+    [
+        (_partial_report(), 0, "exited PASS"),
+        (_complete_report(), 1, "exited FAIL"),
+    ],
+)
+def test_parser_rejects_exit_code_and_report_completion_mismatch(
+    report: dict[str, object], exit_code: int, message: str
+) -> None:
+    result = _parse(report, exit_code)
+
+    assert result["check_verdict"] == "ERROR"
+    expected_error = (
+        f"module grader {message} without trusting every proof unit"
+        if exit_code == 0
+        else "module grader exited FAIL for a complete trusted module"
+    )
+    assert result["error"] == expected_error
+
+
+def test_parser_requires_a_sany_status_marker() -> None:
+    result = _parse(_complete_report(), 0, output=f"{MODULE_RESULT_PREFIX}{json.dumps(_complete_report())}\n")
+
+    assert result["check_verdict"] == "ERROR"
+    assert result["error"] == "grader did not report a SANY status"
+
+
+@pytest.mark.parametrize(
+    "markers",
+    [
+        "SANY-STATUS: valid\nSANY-STATUS: valid\n",
+        "SANY-STATUS: valid\nSANY-STATUS: invalid\n",
+    ],
+)
+def test_parser_requires_exactly_one_sany_status_marker(markers: str) -> None:
+    result: dict[str, object] = {}
+    _parse_grader_result(
+        1,
+        markers + f"{MODULE_RESULT_PREFIX}{json.dumps(_partial_report(), separators=(',', ':'))}\n",
+        result,
+        expected_module_unit_ids=EXPECTED_UNITS,
+    )
+
+    assert result["check_verdict"] == "ERROR"
+    assert result["error"] == "grader reported multiple SANY status markers; expected exactly one"
+
+
+def test_parser_rejects_an_invalid_sany_status_marker() -> None:
+    result: dict[str, object] = {}
+    _parse_grader_result(
+        1,
+        f"SANY-STATUS: unknown\n{MODULE_RESULT_PREFIX}{json.dumps(_partial_report(), separators=(',', ':'))}\n",
+        result,
+        expected_module_unit_ids=EXPECTED_UNITS,
+    )
+
+    assert result["check_verdict"] == "ERROR"
+    assert result["error"] == "grader reported an invalid SANY status marker: 'unknown'"
+
+
+def test_parser_requires_module_sany_status_to_match_the_marker() -> None:
+    result = _parse(_complete_report(), 0, output=_machine_output(_complete_report(), status="invalid"))
+
+    assert result["check_verdict"] == "ERROR"
+    assert result["error"] == "module grader SANY status disagrees with SANY-STATUS marker"
+
+
+def test_strict_module_result_parser_rejects_duplicate_json_object_keys() -> None:
+    report = json.dumps(_partial_report(), separators=(",", ":"))
+    duplicate = report[:-1] + ',"complete":false}'
+
+    with pytest.raises(ModuleResultError, match="duplicate JSON key"):
+        parse_module_result_json(duplicate, EXPECTED_UNITS)
+
+
+def test_parser_rejects_duplicate_json_object_keys() -> None:
+    report = json.dumps(_partial_report(), separators=(",", ":"))
+    duplicate = report[:-1] + ',"complete":false}'
+    result: dict[str, object] = {}
+    _parse_grader_result(
+        1,
+        f"SANY-STATUS: valid\n{MODULE_RESULT_PREFIX}{duplicate}\n",
+        result,
+        expected_module_unit_ids=EXPECTED_UNITS,
+    )
+
+    assert result["check_verdict"] == "ERROR"
+    assert "invalid result" in result["error"]

--- a/tests/evaluator/test_proof_module_resume_regressions.py
+++ b/tests/evaluator/test_proof_module_resume_regressions.py
@@ -1,0 +1,1767 @@
+"""Regression coverage for durable proof-from-scratch module resume state."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from evaluator import runner
+from evaluator.backends.agentic import AgenticBackend
+from evaluator.proof_module_artifact import publish_module_artifact
+from evaluator.proof_module_checkpoint import (
+    MODULE_CHECKPOINT_DIRECTORY,
+    ModuleCheckpointError,
+    ModuleCheckpointIdentity,
+    checkpoint_filename,
+    checkpoint_path,
+    load_module_checkpoint,
+    prepare_module_checkpoints,
+    write_module_checkpoint,
+)
+from evaluator.usage import UsageSummary
+
+TASK_ID = "Suite/Task.tla"
+UNIT_ID = "Suite/Task-Target.tla"
+
+
+def _identity(**changes: object) -> ModuleCheckpointIdentity:
+    values: dict[str, object] = {
+        "task_id": TASK_ID,
+        "proof_unit_ids": (UNIT_ID,),
+        "canonical_input_sha256": "1" * 64,
+        "run_identity_sha256": "2" * 64,
+    }
+    values.update(changes)
+    return ModuleCheckpointIdentity(**values)  # type: ignore[arg-type]
+
+
+def _module_result(*, complete: bool) -> dict[str, object]:
+    unit = {
+        "unit_id": UNIT_ID,
+        "kind": "target",
+        "theorem_name": "Target",
+        "line_start": 4,
+        "line_end": 6,
+        "dependencies": [],
+        "raw_verdict": "PASS" if complete else "FAIL",
+        "tlapm_exit": 0 if complete else 1,
+        "missing_proofs": 0 if complete else 1,
+        "obligation_failed": False,
+        "trusted": complete,
+    }
+    return {
+        "schema_version": 1,
+        "sany_status": "valid",
+        "proof_unit_ids": [UNIT_ID],
+        "units": [unit],
+        "trusted_unit_ids": [UNIT_ID] if complete else [],
+        "trusted_proof_unit_ids": [UNIT_ID] if complete else [],
+        "complete": complete,
+    }
+
+
+def _attempt(
+    *,
+    artifact: dict[str, object] | None = None,
+    module_result: dict[str, object] | None = None,
+    verdict: str | None = None,
+    round: int | None = None,
+    termination_reason: str | None = None,
+) -> dict[str, object]:
+    result: dict[str, object] = {
+        "benchmark": TASK_ID,
+        "proof_unit_ids": [UNIT_ID],
+        "proof_unit_count": 1,
+        "trusted_proof_unit_count": len(module_result.get("trusted_proof_unit_ids", [])) if module_result else 0,
+        "trusted_proof_unit_ids": list(module_result.get("trusted_proof_unit_ids", [])) if module_result else [],
+        "check_verdict": verdict
+        or ("PASS" if module_result is None or module_result.get("complete", False) else "FAIL"),
+    }
+    if artifact is not None:
+        result["module_artifact"] = artifact
+    if module_result is not None:
+        result["module_result"] = module_result
+    if round is not None:
+        result["round"] = round
+    if termination_reason is not None:
+        result["termination_reason"] = termination_reason
+    return result
+
+
+def _checkpoint_result(
+    output_dir: Path,
+    *,
+    first_content: bytes = b"first partial module",
+    first_complete: bool = False,
+    continuation_contents: tuple[bytes, ...] = (),
+    continuation_verdicts: tuple[str, ...] = (),
+    continuation_termination_reasons: tuple[str | None, ...] = (),
+    max_continuations: int | None = None,
+) -> tuple[ModuleCheckpointIdentity, dict[str, object]]:
+    first_receipt = publish_module_artifact(output_dir, first_content)
+    first_result = _attempt(
+        artifact=first_receipt,
+        module_result=_module_result(complete=first_complete),
+    )
+    if not first_complete:
+        first_result["check_verdict"] = "FAIL"
+    result = first_result
+    if continuation_contents:
+        rounds: list[dict[str, object]] = []
+        for index, content in enumerate(continuation_contents, start=1):
+            receipt = publish_module_artifact(output_dir, content)
+            verdict = continuation_verdicts[index - 1] if continuation_verdicts else "FAIL"
+            reason = (
+                continuation_termination_reasons[index - 1]
+                if index - 1 < len(continuation_termination_reasons)
+                else None
+            )
+            round_result = _attempt(
+                artifact=receipt,
+                module_result=_module_result(complete=verdict == "PASS") if verdict in {"PASS", "FAIL"} else None,
+                verdict=verdict,
+                round=index,
+                termination_reason=reason,
+            )
+            rounds.append(round_result)
+        result["continuations"] = rounds
+        result["max_continuations"] = max_continuations if max_continuations is not None else len(continuation_contents)
+    identity = _identity()
+    write_module_checkpoint(output_dir, identity, result)
+    return identity, result
+
+
+class _ResumeBackend(AgenticBackend):
+    name = "copilot"
+
+    def build_command(self, workspace, result_dir):
+        return ["fake-agent"]
+
+    def parse_output(self, jsonl_path):
+        return "", 0, 0
+
+
+class _ResumeMode:
+    name = "proof-from-scratch"
+    canonical_replay_required = True
+    requires_workspace_tools = True
+
+    def __init__(self, root: Path, task: Path):
+        self._root = root
+        self._task = task
+
+    def benchmark_dir(self):
+        return str(self._root)
+
+    def get_dependencies(self, _benchmark_path):
+        return []
+
+    def checker_binary_path(self):
+        return "/checker"
+
+    def module_task_spec(self, _benchmark_path):
+        return SimpleNamespace(proof_unit_ids=(UNIT_ID,))
+
+    def build_prompt(self, *_args):
+        return "prove the module"
+
+    def build_continuation_prompt(self, *_args):
+        return "continue the module"
+
+
+def _resume_item(
+    tmp_path: Path,
+    result: dict[str, object],
+    submission: bytes,
+    *,
+    action: str = runner.MODULE_RESUME_GRADE_SAVED,
+    checkpoint_sequence: int = 1,
+    max_continuations: int = 0,
+) -> runner.WorkItem:
+    benchmark_root = tmp_path / "benchmark"
+    task = benchmark_root / TASK_ID
+    task.parent.mkdir(parents=True, exist_ok=True)
+    task.write_bytes(b"canonical task module")
+    output_dir = tmp_path / "results"
+    artifact = result.get("module_artifact")
+    if isinstance(result.get("continuations"), list) and result["continuations"]:
+        artifact = result["continuations"][-1].get("module_artifact")
+    if not isinstance(artifact, dict):
+        raise AssertionError("resume test result must contain an artifact")
+    canonical_inputs = runner.CanonicalInputs.capture(str(task), task.name, [])
+    # The caller constructs the durable identity before this helper is used;
+    # the fixed digest keeps the small direct WorkItem fixture aligned with the
+    # checkpoint written by the test.
+    identity = _identity()
+    mode = _ResumeMode(benchmark_root, task)
+    backend = _ResumeBackend()
+    return runner.WorkItem(
+        benchmark_path=str(task),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=backend,
+        mode=mode,
+        tlapm_path="/opt/tlapm",
+        tlapm_lib="/opt/tlapm/lib",
+        infra_retries=0,
+        max_continuations=max_continuations,
+        canonical_inputs=canonical_inputs,
+        module_resume=runner.ModuleResume(
+            action=action,
+            result=result,
+            submission=submission,
+            artifact_receipt=artifact,
+            checkpoint_sequence=checkpoint_sequence,
+        ),
+        module_checkpoint_identity=identity,
+    )
+
+
+def _complete_grading(result: dict[str, object]) -> None:
+    module_result = _module_result(complete=True)
+    result.update(
+        {
+            "check_verdict": "PASS",
+            "module_result": module_result,
+            "proof_unit_count": 1,
+            "trusted_proof_unit_count": 1,
+            "trusted_proof_unit_ids": [UNIT_ID],
+        }
+    )
+
+
+def test_pending_first_attempt_grades_saved_bytes_without_agent_and_preserves_accounting(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    saved = b"saved first-attempt module"
+    artifact = publish_module_artifact(output_dir, saved)
+    pending = _attempt(artifact=artifact, verdict="ERROR")
+    pending.update(
+        {
+            "module_grading_pending": 0,
+            "agent_exit": 0,
+            "input_tokens": 123,
+            "output_tokens": 456,
+            "time_secs": 3.25,
+            "equivalent_cost_usd": 0.012,
+            "usage": {"input_tokens": 123, "output_tokens": 456, "model_requests": 1},
+        }
+    )
+    identity = _identity()
+    write_module_checkpoint(output_dir, identity, pending)
+
+    item = _resume_item(tmp_path, pending, saved, checkpoint_sequence=1)
+    agent_calls: list[object] = []
+    graded_bytes: list[bytes] = []
+
+    def unexpected_agent(*args, **kwargs):
+        agent_calls.append((args, kwargs))
+        raise AssertionError("a pending artifact must be graded before any new agent call")
+
+    def grade(item, workspace, basename, grading_dir, check_result_path, result, canonical_dir=None):
+        graded_bytes.append(Path(workspace, basename).read_bytes())
+        _complete_grading(result)
+
+    monkeypatch.setattr(runner, "_run_backend_local", unexpected_agent)
+    monkeypatch.setattr(runner, "_run_grader_local", grade)
+
+    recovered = runner.run_single_benchmark(item)
+
+    assert agent_calls == []
+    assert graded_bytes == [saved]
+    assert recovered["check_verdict"] == "PASS"
+    assert recovered["input_tokens"] == 123
+    assert recovered["output_tokens"] == 456
+    assert recovered["time_secs"] == 3.25
+    assert recovered["equivalent_cost_usd"] == 0.012
+    assert recovered["usage"] == {"input_tokens": 123, "output_tokens": 456, "model_requests": 1}
+
+
+def test_failed_regrade_keeps_pending_artifact_until_the_same_bytes_are_graded(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    saved = b"saved module awaiting a working checker"
+    artifact = publish_module_artifact(output_dir, saved)
+    pending = _attempt(artifact=artifact, verdict="ERROR")
+    pending["module_grading_pending"] = 0
+    identity = _identity()
+    write_module_checkpoint(output_dir, identity, pending)
+    grader_calls = 0
+    agent_calls: list[object] = []
+
+    def no_agent(*args, **kwargs):
+        agent_calls.append((args, kwargs))
+        raise AssertionError("pending grading must not launch the agent")
+
+    def grade(_item, workspace, basename, _grading_dir, _check_path, result, _canonical_dir=None):
+        nonlocal grader_calls
+        grader_calls += 1
+        assert Path(workspace, basename).read_bytes() == saved
+        if grader_calls == 1:
+            result["check_verdict"] = "ERROR"
+            result["error"] = "checker unavailable"
+        else:
+            _complete_grading(result)
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", no_agent)
+    monkeypatch.setattr(runner, "_run_grader_local", grade)
+
+    first_item = _resume_item(
+        tmp_path,
+        pending,
+        saved,
+        checkpoint_sequence=1,
+        max_continuations=1,
+    )
+    first = runner.run_single_benchmark(first_item)
+
+    assert first["module_grading_pending"] == 0
+    assert first["module_artifact"] == artifact
+    assert runner._module_resume_action(first, max_continuations=1) == runner.MODULE_RESUME_GRADE_SAVED
+    checkpoint = load_module_checkpoint(output_dir, identity)
+    assert checkpoint.result["module_grading_pending"] == 0
+
+    second_item = _resume_item(
+        tmp_path,
+        checkpoint.result,
+        saved,
+        checkpoint_sequence=checkpoint.sequence,
+        max_continuations=1,
+    )
+    second = runner.run_single_benchmark(second_item)
+
+    assert agent_calls == []
+    assert grader_calls == 2
+    assert second["check_verdict"] == "PASS"
+    assert "module_grading_pending" not in second
+    assert second["module_artifact"] == artifact
+
+
+def test_zero_work_quota_does_not_grade_canonical_input_or_consume_pass_at_one(tmp_path, monkeypatch):
+    benchmark_root = tmp_path / "benchmark"
+    task = benchmark_root / TASK_ID
+    task.parent.mkdir(parents=True)
+    task.write_bytes(b"canonical omitted module")
+    output_dir = tmp_path / "results"
+    canonical_inputs = runner.CanonicalInputs.capture(str(task), task.name, [])
+    backend = _ResumeBackend()
+    mode = _ResumeMode(benchmark_root, task)
+    item = runner.WorkItem(
+        benchmark_path=str(task),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=backend,
+        mode=mode,
+        tlapm_path="/opt/tlapm",
+        tlapm_lib="/opt/tlapm/lib",
+        infra_retries=0,
+        canonical_inputs=canonical_inputs,
+        module_checkpoint_identity=_identity(),
+    )
+    grader_calls: list[object] = []
+    prompts: list[str] = []
+
+    def zero_work_quota(item, prompt, *_args, **_kwargs):
+        prompts.append(prompt)
+        attempt = len(prompts)
+        workspace = tmp_path / f"zero-workspace-{attempt}"
+        canonical = tmp_path / f"zero-canonical-{attempt}"
+        workspace.mkdir()
+        canonical.mkdir()
+        canonical_inputs.materialize(str(workspace))
+        canonical_inputs.materialize(str(canonical))
+        result = _args[3]
+        usage = UsageSummary(available=False, warnings=("no model request",))
+        result.update(
+            {
+                "agent_exit": -1,
+                "termination_reason": "OK",
+                "time_secs": None,
+                "equivalent_cost_usd": None,
+                "usage": usage.to_dict(),
+                "input_tokens": 0,
+                "output_tokens": 0,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical),
+            "",
+            True,
+            False,
+            False,
+            False,
+            [],
+            usage,
+        )
+
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(runner, "_run_backend_with_retries", zero_work_quota)
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args, **kwargs: grader_calls.append((args, kwargs)))
+
+    result = runner.run_single_benchmark(item)
+
+    assert grader_calls == []
+    assert result["check_verdict"] == "ERROR"
+    assert result["termination_reason"] == "QUOTA_EXHAUSTED"
+    assert "module_artifact" not in result
+    assert "module_result" not in result
+    assert "graded_after_interruption" not in result
+    assert runner._module_resume_action(result, max_continuations=0) == runner.MODULE_RESUME_RETRY_FIRST
+
+    checkpoint = load_module_checkpoint(output_dir, _identity())
+    _recovered, resumes, completed = runner._recover_module_resume(
+        str(output_dir),
+        [result],
+        {TASK_ID: _identity()},
+        {TASK_ID: checkpoint},
+        max_continuations=0,
+    )
+    assert completed == set()
+    resume = resumes[TASK_ID]
+    assert resume.action == runner.MODULE_RESUME_RETRY_FIRST
+    assert resume.submission is None
+
+    resumed_item = runner.WorkItem(
+        benchmark_path=str(task),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=backend,
+        mode=mode,
+        tlapm_path="/opt/tlapm",
+        tlapm_lib="/opt/tlapm/lib",
+        infra_retries=0,
+        canonical_inputs=canonical_inputs,
+        module_resume=resume,
+        module_checkpoint_identity=_identity(),
+    )
+    runner.run_single_benchmark(resumed_item)
+
+    assert prompts == ["prove the module", "prove the module"]
+
+
+def test_zero_work_nonretryable_infra_first_attempt_does_not_materialize_or_grade(tmp_path, monkeypatch):
+    benchmark_root = tmp_path / "benchmark"
+    task = benchmark_root / TASK_ID
+    task.parent.mkdir(parents=True)
+    task.write_bytes(b"canonical omitted module")
+    output_dir = tmp_path / "results"
+    canonical_inputs = runner.CanonicalInputs.capture(str(task), task.name, [])
+    backend = _ResumeBackend()
+    item = runner.WorkItem(
+        benchmark_path=str(task),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=backend,
+        mode=_ResumeMode(benchmark_root, task),
+        tlapm_path="/opt/tlapm",
+        tlapm_lib="/opt/tlapm/lib",
+        infra_retries=0,
+        canonical_inputs=canonical_inputs,
+        module_checkpoint_identity=_identity(),
+    )
+    materialization_permissions: list[bool] = []
+    original_prepare = backend.prepare_submission
+
+    def zero_work_infra(*args, **_kwargs):
+        workspace = tmp_path / "infra-workspace"
+        canonical = tmp_path / "infra-canonical"
+        workspace.mkdir()
+        canonical.mkdir()
+        canonical_inputs.materialize(str(workspace))
+        canonical_inputs.materialize(str(canonical))
+        result = args[5]
+        usage = UsageSummary(available=False, warnings=("malformed stream without a model request",))
+        result.update(
+            {
+                "agent_exit": 1,
+                "termination_reason": "INFRA_ERROR",
+                "error": "invalid terminal event stream",
+                "time_secs": None,
+                "equivalent_cost_usd": None,
+                "usage": usage.to_dict(),
+                "input_tokens": 0,
+                "output_tokens": 0,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical),
+            "invalid event stream",
+            False,
+            False,
+            False,
+            False,
+            [],
+            usage,
+        )
+
+    def record_prepare(*args, **kwargs):
+        materialization_permissions.append(kwargs["allow_materialization"])
+        return original_prepare(*args, **kwargs)
+
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(runner, "_run_backend_with_retries", zero_work_infra)
+    monkeypatch.setattr(backend, "prepare_submission", record_prepare)
+    monkeypatch.setattr(
+        runner,
+        "_preserve_module_submission",
+        lambda *_args, **_kwargs: pytest.fail("zero-work interruption must not publish canonical bytes"),
+    )
+    monkeypatch.setattr(
+        runner,
+        "_run_grader_local",
+        lambda *_args, **_kwargs: pytest.fail("zero-work interruption must not run the grader"),
+    )
+
+    result = runner.run_single_benchmark(item)
+
+    assert materialization_permissions == [False]
+    assert result["check_verdict"] == "ERROR"
+    assert result["termination_reason"] == "INFRA_ERROR"
+    assert "module_artifact" not in result
+    assert "module_result" not in result
+    assert runner._module_resume_action(result, max_continuations=0) == runner.MODULE_RESUME_RETRY_FIRST
+
+
+def test_quota_after_model_work_grades_and_preserves_the_formal_first_attempt(tmp_path, monkeypatch):
+    benchmark_root = tmp_path / "benchmark"
+    task = benchmark_root / TASK_ID
+    task.parent.mkdir(parents=True)
+    task.write_bytes(b"canonical omitted module")
+    output_dir = tmp_path / "results"
+    canonical_inputs = runner.CanonicalInputs.capture(str(task), task.name, [])
+    item = runner.WorkItem(
+        benchmark_path=str(task),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=_ResumeBackend(),
+        mode=_ResumeMode(benchmark_root, task),
+        tlapm_path="/opt/tlapm",
+        tlapm_lib="/opt/tlapm/lib",
+        infra_retries=0,
+        canonical_inputs=canonical_inputs,
+        module_checkpoint_identity=_identity(),
+    )
+    submitted = b"partially proved module after model work"
+    usage = UsageSummary(input_tokens=25, output_tokens=50, model_requests=1, available=True, complete=True)
+    graded_bytes: list[bytes] = []
+
+    def interrupted_after_work(item, _prompt, *_args, **_kwargs):
+        workspace = tmp_path / "worked-workspace"
+        canonical = tmp_path / "worked-canonical"
+        workspace.mkdir()
+        canonical.mkdir()
+        canonical_inputs.materialize(str(workspace))
+        canonical_inputs.materialize(str(canonical))
+        (workspace / "Task.tla").write_bytes(submitted)
+        result = _args[3]
+        result.update(
+            {
+                "agent_exit": -1,
+                "termination_reason": "OK",
+                "time_secs": 4.5,
+                "equivalent_cost_usd": 0.02,
+                "usage": usage.to_dict(),
+                "input_tokens": 25,
+                "output_tokens": 50,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical),
+            "partial work",
+            True,
+            True,
+            False,
+            True,
+            [],
+            usage,
+        )
+
+    def grade(_item, workspace, basename, _grading_dir, _check_path, result, _canonical_dir=None):
+        graded_bytes.append(Path(workspace, basename).read_bytes())
+        module_result = _module_result(complete=False)
+        result.update(
+            {
+                "check_verdict": "FAIL",
+                "module_result": module_result,
+                "proof_unit_count": 1,
+                "trusted_proof_unit_count": 0,
+                "trusted_proof_unit_ids": [],
+            }
+        )
+
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(runner, "_run_backend_with_retries", interrupted_after_work)
+    monkeypatch.setattr(runner, "_run_grader_local", grade)
+
+    result = runner.run_single_benchmark(item)
+
+    assert graded_bytes == [submitted]
+    assert result["check_verdict"] == "FAIL"
+    assert result["termination_reason"] == "QUOTA_EXHAUSTED"
+    assert result["graded_after_interruption"] is True
+    assert result["input_tokens"] == 25
+    assert result["output_tokens"] == 50
+    assert result["time_secs"] == 4.5
+    assert result["equivalent_cost_usd"] == 0.02
+    assert result["module_artifact"]["sha256"] == hashlib.sha256(submitted).hexdigest()
+    assert runner._module_resume_action(result, max_continuations=0) == runner.MODULE_RESUME_COMPLETE
+
+
+@pytest.mark.parametrize(
+    ("submission_state", "quota_exhausted", "expected_termination", "expected_error"),
+    [
+        ("missing", True, "QUOTA_EXHAUSTED", "module submission is missing"),
+        ("empty", False, "INFRA_ERROR", "module submission is empty"),
+    ],
+)
+def test_interrupted_model_work_with_invalid_submission_consumes_pass_at_one(
+    tmp_path,
+    monkeypatch,
+    submission_state,
+    quota_exhausted,
+    expected_termination,
+    expected_error,
+):
+    benchmark_root = tmp_path / "benchmark"
+    task = benchmark_root / TASK_ID
+    task.parent.mkdir(parents=True)
+    task.write_bytes(b"canonical omitted module")
+    output_dir = tmp_path / "results"
+    canonical_inputs = runner.CanonicalInputs.capture(str(task), task.name, [])
+    item = runner.WorkItem(
+        benchmark_path=str(task),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=_ResumeBackend(),
+        mode=_ResumeMode(benchmark_root, task),
+        tlapm_path="/opt/tlapm",
+        tlapm_lib="/opt/tlapm/lib",
+        infra_retries=0,
+        canonical_inputs=canonical_inputs,
+        module_checkpoint_identity=_identity(),
+    )
+    usage = UsageSummary(input_tokens=100, output_tokens=50, model_requests=1, available=True, complete=True)
+
+    def interrupted_invalid_submission(_item, _prompt, *_args, **_kwargs):
+        workspace = tmp_path / "worked-workspace"
+        canonical = tmp_path / "worked-canonical"
+        workspace.mkdir()
+        canonical.mkdir()
+        canonical_inputs.materialize(str(workspace))
+        canonical_inputs.materialize(str(canonical))
+        destination = workspace / "Task.tla"
+        if submission_state == "missing":
+            destination.unlink()
+        else:
+            destination.write_bytes(b"")
+        result = _args[3]
+        result.update(
+            {
+                "agent_exit": -1,
+                "termination_reason": "OK" if quota_exhausted else "INFRA_ERROR",
+                "time_secs": 4.5,
+                "equivalent_cost_usd": 0.25,
+                "usage": usage.to_dict(),
+                "input_tokens": 100,
+                "output_tokens": 50,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical),
+            "paid model work",
+            quota_exhausted,
+            quota_exhausted,
+            False,
+            True,
+            [],
+            usage,
+        )
+
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(runner, "_run_backend_with_retries", interrupted_invalid_submission)
+    monkeypatch.setattr(
+        runner,
+        "_run_grader_local",
+        lambda *_args, **_kwargs: pytest.fail("a missing or empty module is a direct submission failure"),
+    )
+
+    result = runner.run_single_benchmark(item)
+
+    assert result["check_verdict"] == "FAIL"
+    assert result["termination_reason"] == expected_termination
+    assert result["error"] == expected_error
+    assert result["invalid_submission_after_interruption"] is True
+    assert "graded_after_interruption" not in result
+    assert "module_artifact" not in result
+    assert "module_result" not in result
+    assert (result["input_tokens"], result["output_tokens"]) == (100, 50)
+    assert result["equivalent_cost_usd"] == 0.25
+    assert not runner.is_non_genuine(result)
+    assert runner._module_resume_action(result, max_continuations=0) == runner.MODULE_RESUME_COMPLETE
+    checkpoint = load_module_checkpoint(output_dir, _identity())
+    assert checkpoint.result["invalid_submission_after_interruption"] is True
+
+
+@pytest.mark.parametrize("submission_state", ["missing", "empty"])
+def test_invalid_first_submission_uses_the_same_continuation_bytes_before_and_after_resume(
+    tmp_path,
+    monkeypatch,
+    submission_state,
+):
+    benchmark_root = tmp_path / "benchmark"
+    task = benchmark_root / TASK_ID
+    task.parent.mkdir(parents=True)
+    canonical_bytes = b"canonical task module"
+    task.write_bytes(canonical_bytes)
+    output_dir = tmp_path / "results"
+    canonical_inputs = runner.CanonicalInputs.capture(str(task), task.name, [])
+    identity = _identity()
+    backend = _ResumeBackend()
+    mode = _ResumeMode(benchmark_root, task)
+    item = runner.WorkItem(
+        benchmark_path=str(task),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=backend,
+        mode=mode,
+        tlapm_path="/opt/tlapm",
+        tlapm_lib="/opt/tlapm/lib",
+        infra_retries=0,
+        max_continuations=1,
+        canonical_inputs=canonical_inputs,
+        module_checkpoint_identity=identity,
+    )
+    usage = UsageSummary(input_tokens=5, output_tokens=6, model_requests=1, available=True, complete=True)
+
+    def interrupted_invalid_submission(_item, _prompt, *_args, **_kwargs):
+        workspace = tmp_path / "worked-workspace"
+        canonical = tmp_path / "worked-canonical"
+        workspace.mkdir()
+        canonical.mkdir()
+        canonical_inputs.materialize(str(workspace))
+        canonical_inputs.materialize(str(canonical))
+        destination = workspace / "Task.tla"
+        if submission_state == "missing":
+            destination.unlink()
+        else:
+            destination.write_bytes(b"")
+        result = _args[3]
+        result.update(
+            {
+                "agent_exit": -1,
+                "termination_reason": "INFRA_ERROR",
+                "time_secs": 1.0,
+                "equivalent_cost_usd": 0.01,
+                "usage": usage.to_dict(),
+                "input_tokens": 5,
+                "output_tokens": 6,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical),
+            "paid model work",
+            False,
+            False,
+            False,
+            True,
+            [],
+            usage,
+        )
+
+    continuation_inputs: list[bytes] = []
+
+    def capture_continuation(_item, workspace, *_args, **_kwargs):
+        continuation_inputs.append(Path(workspace, "Task.tla").read_bytes())
+
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(runner, "_run_backend_with_retries", interrupted_invalid_submission)
+    monkeypatch.setattr(runner, "_run_continuations", capture_continuation)
+    monkeypatch.setattr(
+        runner,
+        "_run_grader_local",
+        lambda *_args, **_kwargs: pytest.fail("an invalid module must not reach the grader"),
+    )
+
+    result = runner.run_single_benchmark(item)
+    checkpoint = load_module_checkpoint(output_dir, identity)
+    recovered, resumes, completed = runner._recover_module_resume(
+        str(output_dir),
+        [result],
+        {TASK_ID: identity},
+        {TASK_ID: checkpoint},
+        max_continuations=1,
+    )
+
+    assert completed == set()
+    assert recovered[0]["check_verdict"] == "FAIL"
+    resume = resumes[TASK_ID]
+    assert resume.action == runner.MODULE_RESUME_CONTINUE
+    assert resume.submission is None
+
+    resumed_item = runner.WorkItem(
+        benchmark_path=str(task),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=backend,
+        mode=mode,
+        tlapm_path="/opt/tlapm",
+        tlapm_lib="/opt/tlapm/lib",
+        infra_retries=0,
+        max_continuations=1,
+        canonical_inputs=canonical_inputs,
+        module_resume=resume,
+        module_checkpoint_identity=identity,
+    )
+    runner.run_single_benchmark(resumed_item)
+
+    assert continuation_inputs == [canonical_bytes, canonical_bytes]
+
+
+def test_first_attempt_checker_failure_keeps_artifact_pending_and_stops_continuations(tmp_path, monkeypatch):
+    benchmark_root = tmp_path / "benchmark"
+    task = benchmark_root / TASK_ID
+    task.parent.mkdir(parents=True)
+    task.write_bytes(b"canonical omitted module")
+    output_dir = tmp_path / "results"
+    canonical_inputs = runner.CanonicalInputs.capture(str(task), task.name, [])
+    item = runner.WorkItem(
+        benchmark_path=str(task),
+        output_dir=str(output_dir),
+        timeout=10,
+        check_timeout=10,
+        backend=_ResumeBackend(),
+        mode=_ResumeMode(benchmark_root, task),
+        tlapm_path="/opt/tlapm",
+        tlapm_lib="/opt/tlapm/lib",
+        infra_retries=0,
+        max_continuations=1,
+        canonical_inputs=canonical_inputs,
+        module_checkpoint_identity=_identity(),
+    )
+    submitted = b"model-produced partial module"
+    usage = UsageSummary(input_tokens=5, output_tokens=7, model_requests=1, available=True, complete=True)
+
+    def model_work(item, _prompt, *_args, **_kwargs):
+        workspace = tmp_path / "worked-workspace"
+        canonical = tmp_path / "worked-canonical"
+        workspace.mkdir()
+        canonical.mkdir()
+        canonical_inputs.materialize(str(workspace))
+        canonical_inputs.materialize(str(canonical))
+        (workspace / "Task.tla").write_bytes(submitted)
+        result = _args[3]
+        result.update(
+            {
+                "agent_exit": 0,
+                "termination_reason": "OK",
+                "time_secs": 1.0,
+                "equivalent_cost_usd": 0.01,
+                "usage": usage.to_dict(),
+                "input_tokens": 5,
+                "output_tokens": 7,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical),
+            "model work",
+            False,
+            False,
+            False,
+            True,
+            [],
+            usage,
+        )
+
+    def checker_unavailable(_item, _workspace, _basename, _grading_dir, _check_path, result, _canonical=None):
+        result["check_verdict"] = "ERROR"
+        result["error"] = "checker unavailable"
+
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(runner, "_run_backend_with_retries", model_work)
+    monkeypatch.setattr(runner, "_run_grader_local", checker_unavailable)
+    monkeypatch.setattr(
+        runner,
+        "_run_continuations",
+        lambda *_args, **_kwargs: pytest.fail("ungraded saved bytes must stop before a continuation"),
+    )
+
+    result = runner.run_single_benchmark(item)
+
+    assert result["check_verdict"] == "ERROR"
+    assert result["module_grading_pending"] == 0
+    assert result["module_artifact"]["sha256"] == hashlib.sha256(submitted).hexdigest()
+    assert runner._module_resume_action(result, max_continuations=1) == runner.MODULE_RESUME_GRADE_SAVED
+    assert load_module_checkpoint(output_dir, _identity()).result["module_grading_pending"] == 0
+
+
+def test_pending_continuation_grades_as_continuation_and_keeps_pass_at_one(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    first = publish_module_artifact(output_dir, b"first failed module")
+    continuation = publish_module_artifact(output_dir, b"saved continuation module")
+    first_result = _attempt(artifact=first, module_result=_module_result(complete=False), verdict="FAIL")
+    pending_round = _attempt(artifact=continuation, verdict="ERROR", round=1)
+    pending_round.update({"agent_exit": 0, "input_tokens": 7, "output_tokens": 8})
+    result = {
+        **first_result,
+        "input_tokens": 100,
+        "output_tokens": 200,
+        "time_secs": 4.0,
+        "equivalent_cost_usd": 0.02,
+        "continuations": [pending_round],
+        "module_grading_pending": 1,
+        "max_continuations": 2,
+    }
+    identity = _identity()
+    write_module_checkpoint(output_dir, identity, result)
+
+    item = _resume_item(
+        tmp_path,
+        result,
+        b"saved continuation module",
+        checkpoint_sequence=3,
+        max_continuations=2,
+    )
+    agent_calls: list[object] = []
+    graded_bytes: list[bytes] = []
+
+    def unexpected_agent(*args, **kwargs):
+        agent_calls.append((args, kwargs))
+        raise AssertionError("a pending continuation must be graded before a new continuation agent call")
+
+    def grade(item, workspace, basename, grading_dir, check_result_path, attempt, canonical_dir=None):
+        graded_bytes.append(Path(workspace, basename).read_bytes())
+        _complete_grading(attempt)
+
+    monkeypatch.setattr(runner, "_run_backend_local", unexpected_agent)
+    monkeypatch.setattr(runner, "_run_grader_local", grade)
+
+    recovered = runner.run_single_benchmark(item)
+
+    assert agent_calls == []
+    assert graded_bytes == [b"saved continuation module"]
+    assert recovered["check_verdict"] == "FAIL"
+    assert recovered["continuations"][0]["check_verdict"] == "PASS"
+    assert recovered["input_tokens"] == 100
+    assert recovered["output_tokens"] == 200
+    assert recovered["time_secs"] == 4.0
+    assert recovered["equivalent_cost_usd"] == 0.02
+
+
+def test_recover_marks_spent_continuation_budget_complete(tmp_path):
+    identity, result = _checkpoint_result(
+        tmp_path,
+        continuation_contents=(b"continuation module",),
+        continuation_verdicts=("FAIL",),
+    )
+
+    recovered, resumes, completed = runner._recover_module_resume(
+        str(tmp_path),
+        [result],
+        {TASK_ID: identity},
+        {TASK_ID: load_module_checkpoint(tmp_path, identity)},
+        max_continuations=1,
+    )
+
+    assert completed == {TASK_ID}
+    assert resumes == {}
+    assert recovered[0]["check_verdict"] == "FAIL"
+
+
+def test_recover_retries_interrupted_continuation_at_same_round_without_losing_history(tmp_path):
+    identity, result = _checkpoint_result(
+        tmp_path,
+        continuation_contents=(b"interrupted continuation module",),
+        continuation_verdicts=("ERROR",),
+        continuation_termination_reasons=("INFRA_ERROR",),
+    )
+    result["input_tokens"] = 100
+    result["output_tokens"] = 200
+    result["time_secs"] = 5.0
+    result["equivalent_cost_usd"] = 0.03
+    # Rewrite the checkpoint with the accounting fields included.
+    write_module_checkpoint(tmp_path, identity, result)
+    checkpoint = load_module_checkpoint(tmp_path, identity)
+
+    recovered, resumes, completed = runner._recover_module_resume(
+        str(tmp_path),
+        [result],
+        {TASK_ID: identity},
+        {TASK_ID: checkpoint},
+        max_continuations=2,
+    )
+
+    assert completed == set()
+    assert resumes[TASK_ID].action == runner.MODULE_RESUME_CONTINUE
+    assert recovered[0]["check_verdict"] == "FAIL"
+    assert recovered[0]["continuations"][0]["round"] == 1
+    assert recovered[0]["continuations"][0]["termination_reason"] == "INFRA_ERROR"
+    assert recovered[0]["input_tokens"] == 100
+    assert recovered[0]["output_tokens"] == 200
+    assert recovered[0]["time_secs"] == 5.0
+    assert recovered[0]["equivalent_cost_usd"] == 0.03
+
+
+def test_recover_keeps_graded_interrupted_model_work_as_first_attempt_and_continues(tmp_path):
+    identity, result = _checkpoint_result(tmp_path, max_continuations=1)
+    result.update(
+        {
+            "termination_reason": "QUOTA_EXHAUSTED",
+            "graded_after_interruption": True,
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "time_secs": 5.0,
+            "equivalent_cost_usd": 0.03,
+        }
+    )
+    write_module_checkpoint(tmp_path, identity, result)
+
+    recovered, resumes, completed = runner._recover_module_resume(
+        str(tmp_path),
+        [result],
+        {TASK_ID: identity},
+        {TASK_ID: load_module_checkpoint(tmp_path, identity)},
+        max_continuations=1,
+    )
+
+    assert completed == set()
+    assert resumes[TASK_ID].action == runner.MODULE_RESUME_CONTINUE
+    assert recovered[0]["check_verdict"] == "FAIL"
+    assert recovered[0]["graded_after_interruption"] is True
+    assert recovered[0]["input_tokens"] == 100
+    assert recovered[0]["output_tokens"] == 200
+    assert recovered[0]["time_secs"] == 5.0
+    assert recovered[0]["equivalent_cost_usd"] == 0.03
+
+
+def test_interrupted_continuation_is_archived_when_same_formal_round_restarts(tmp_path, monkeypatch):
+    identity, result = _checkpoint_result(
+        tmp_path,
+        continuation_contents=(b"interrupted continuation module",),
+        continuation_verdicts=("ERROR",),
+        continuation_termination_reasons=("INFRA_ERROR",),
+        max_continuations=2,
+    )
+    item = _resume_item(
+        tmp_path,
+        result,
+        b"interrupted continuation module",
+        action=runner.MODULE_RESUME_CONTINUE,
+        max_continuations=2,
+    )
+    item.mode.build_continuation_prompt = lambda *_args: "continue"  # type: ignore[attr-defined,method-assign]
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "Task.tla").write_bytes(b"interrupted continuation module")
+    observed_rounds: list[int] = []
+
+    def stop_after_round_is_selected(*args, **_kwargs):
+        observed_rounds.append(args[5]["round"])
+        raise RuntimeError("stop after selecting retry round")
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", stop_after_round_is_selected)
+
+    with pytest.raises(RuntimeError, match="selecting retry round"):
+        runner._run_continuations(
+            item,
+            str(workspace),
+            result,
+            str(tmp_path / "task-result"),
+            "Task.tla",
+            "Task",
+            item.canonical_inputs,
+            "/checker",
+        )
+
+    assert observed_rounds == [1]
+    assert result["continuations"] == []
+    assert result["interrupted_continuations"][0]["round"] == 1
+    assert result["interrupted_continuations"][0]["termination_reason"] == "INFRA_ERROR"
+    write_module_checkpoint(tmp_path, identity, result)
+
+
+def test_zero_work_quota_continuation_does_not_publish_or_consume_the_round(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    prior_submission = b"existing partial module"
+    identity, result = _checkpoint_result(
+        output_dir,
+        first_content=prior_submission,
+        max_continuations=2,
+    )
+    result["max_continuations"] = 2
+    write_module_checkpoint(output_dir, identity, result)
+    item = _resume_item(
+        tmp_path,
+        result,
+        prior_submission,
+        action=runner.MODULE_RESUME_CONTINUE,
+        max_continuations=2,
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "Task.tla").write_bytes(prior_submission)
+    canonical_dir = tmp_path / "canonical"
+    canonical_dir.mkdir()
+    usage = UsageSummary(available=False, warnings=("no model request",))
+    grader_calls: list[object] = []
+
+    def zero_work_quota(*args, **_kwargs):
+        round_result = args[5]
+        round_result.update(
+            {
+                "agent_exit": -1,
+                "termination_reason": "OK",
+                "time_secs": None,
+                "equivalent_cost_usd": None,
+                "usage": usage.to_dict(),
+                "input_tokens": 0,
+                "output_tokens": 0,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical_dir),
+            "",
+            True,
+            False,
+            False,
+            False,
+            [],
+            usage,
+        )
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", zero_work_quota)
+    monkeypatch.setattr(
+        runner,
+        "_preserve_module_submission",
+        lambda *_args, **_kwargs: pytest.fail("zero-work quota must not publish the prior workspace again"),
+    )
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args, **kwargs: grader_calls.append((args, kwargs)))
+
+    runner._run_continuations(
+        item,
+        str(workspace),
+        result,
+        str(tmp_path / "task-result"),
+        "Task.tla",
+        "Task",
+        item.canonical_inputs,
+        "/checker",
+    )
+
+    assert grader_calls == []
+    assert (workspace / "Task.tla").read_bytes() == prior_submission
+    assert result["continuations"][0]["round"] == 1
+    assert result["continuations"][0]["termination_reason"] == "QUOTA_EXHAUSTED"
+    assert "module_artifact" not in result["continuations"][0]
+    assert "module_grading_pending" not in result
+    assert result.get("input_tokens", 0) == 0
+    assert result.get("output_tokens", 0) == 0
+    assert runner._module_resume_action(result, max_continuations=2) == runner.MODULE_RESUME_CONTINUE
+    checkpoint = load_module_checkpoint(output_dir, identity)
+    assert checkpoint.result["continuations"][0]["round"] == 1
+
+
+def test_zero_work_nonretryable_infra_continuation_does_not_publish_grade_or_consume_round(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    prior_submission = b"existing partial module"
+    identity, result = _checkpoint_result(
+        output_dir,
+        first_content=prior_submission,
+        max_continuations=2,
+    )
+    result["max_continuations"] = 2
+    write_module_checkpoint(output_dir, identity, result)
+    item = _resume_item(
+        tmp_path,
+        result,
+        prior_submission,
+        action=runner.MODULE_RESUME_CONTINUE,
+        max_continuations=2,
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "Task.tla").write_bytes(prior_submission)
+    canonical_dir = tmp_path / "canonical"
+    canonical_dir.mkdir()
+    usage = UsageSummary(available=False, warnings=("malformed stream without a model request",))
+
+    def zero_work_infra(*args, **_kwargs):
+        round_result = args[5]
+        round_result.update(
+            {
+                "agent_exit": 1,
+                "termination_reason": "INFRA_ERROR",
+                "error": "invalid terminal event stream",
+                "time_secs": None,
+                "equivalent_cost_usd": None,
+                "usage": usage.to_dict(),
+                "input_tokens": 0,
+                "output_tokens": 0,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical_dir),
+            "invalid event stream",
+            False,
+            False,
+            False,
+            False,
+            [],
+            usage,
+        )
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", zero_work_infra)
+    monkeypatch.setattr(
+        runner,
+        "_preserve_module_submission",
+        lambda *_args, **_kwargs: pytest.fail("zero-work interruption must not republish the prior workspace"),
+    )
+    monkeypatch.setattr(
+        runner,
+        "_run_grader_local",
+        lambda *_args, **_kwargs: pytest.fail("zero-work interruption must not run the grader"),
+    )
+
+    runner._run_continuations(
+        item,
+        str(workspace),
+        result,
+        str(tmp_path / "task-result"),
+        "Task.tla",
+        "Task",
+        item.canonical_inputs,
+        "/checker",
+    )
+
+    interrupted_round = result["continuations"][0]
+    assert interrupted_round["round"] == 1
+    assert interrupted_round["termination_reason"] == "INFRA_ERROR"
+    assert "module_artifact" not in interrupted_round
+    assert "module_grading_pending" not in result
+    assert runner.is_non_genuine(interrupted_round)
+    assert runner._module_resume_action(result, max_continuations=2) == runner.MODULE_RESUME_CONTINUE
+
+    selected_rounds: list[int] = []
+
+    def stop_after_round_selection(*args, **_kwargs):
+        selected_rounds.append(args[5]["round"])
+        raise RuntimeError("stop after selecting retry round")
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", stop_after_round_selection)
+    with pytest.raises(RuntimeError, match="selecting retry round"):
+        runner._run_continuations(
+            item,
+            str(workspace),
+            result,
+            str(tmp_path / "task-result"),
+            "Task.tla",
+            "Task",
+            item.canonical_inputs,
+            "/checker",
+        )
+
+    assert selected_rounds == [1]
+    assert result["continuations"] == []
+    assert result["interrupted_continuations"][0]["round"] == 1
+
+
+def test_continuation_checker_failure_keeps_round_pending_and_stops_the_chain(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    prior_submission = b"first partial module"
+    identity, result = _checkpoint_result(
+        output_dir,
+        first_content=prior_submission,
+        max_continuations=2,
+    )
+    result["max_continuations"] = 2
+    write_module_checkpoint(output_dir, identity, result)
+    item = _resume_item(
+        tmp_path,
+        result,
+        prior_submission,
+        action=runner.MODULE_RESUME_CONTINUE,
+        max_continuations=2,
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    submitted = b"continuation partial module"
+    (workspace / "Task.tla").write_bytes(submitted)
+    usage = UsageSummary(input_tokens=3, output_tokens=4, model_requests=1, available=True, complete=True)
+    backend_calls = 0
+
+    def model_work(*args, **_kwargs):
+        nonlocal backend_calls
+        backend_calls += 1
+        canonical_dir = tmp_path / f"canonical-{backend_calls}"
+        canonical_dir.mkdir()
+        round_result = args[5]
+        round_result.update(
+            {
+                "agent_exit": 0,
+                "termination_reason": "OK",
+                "time_secs": 1.0,
+                "equivalent_cost_usd": 0.01,
+                "usage": usage.to_dict(),
+                "input_tokens": 3,
+                "output_tokens": 4,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical_dir),
+            "model work",
+            False,
+            False,
+            False,
+            True,
+            [],
+            usage,
+        )
+
+    def checker_unavailable(_item, _workspace, _basename, _round_dir, _check_path, round_result, _canonical=None):
+        round_result["check_verdict"] = "ERROR"
+        round_result["error"] = "checker unavailable"
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", model_work)
+    monkeypatch.setattr(runner, "_run_grader_local", checker_unavailable)
+
+    runner._run_continuations(
+        item,
+        str(workspace),
+        result,
+        str(tmp_path / "task-result"),
+        "Task.tla",
+        "Task",
+        item.canonical_inputs,
+        "/checker",
+    )
+
+    assert backend_calls == 1
+    assert result["module_grading_pending"] == 1
+    assert result["continuations"][0]["module_artifact"]["sha256"] == hashlib.sha256(submitted).hexdigest()
+    assert runner._module_resume_action(result, max_continuations=2) == runner.MODULE_RESUME_GRADE_SAVED
+    checkpoint = load_module_checkpoint(output_dir, identity)
+    assert checkpoint.result["module_grading_pending"] == 1
+
+
+def test_interrupted_worked_continuation_regrade_consumes_the_same_round(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    first_submission = b"first partial module"
+    identity, result = _checkpoint_result(
+        output_dir,
+        first_content=first_submission,
+        max_continuations=2,
+    )
+    result["max_continuations"] = 2
+    write_module_checkpoint(output_dir, identity, result)
+    item = _resume_item(
+        tmp_path,
+        result,
+        first_submission,
+        action=runner.MODULE_RESUME_CONTINUE,
+        max_continuations=2,
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    interrupted_submission = b"partial module produced before interruption"
+    (workspace / "Task.tla").write_bytes(interrupted_submission)
+    canonical_dir = tmp_path / "canonical"
+    canonical_dir.mkdir()
+    usage = UsageSummary(input_tokens=3, output_tokens=4, model_requests=1, available=True, complete=True)
+
+    def interrupted_model_work(*args, **_kwargs):
+        round_result = args[5]
+        round_result.update(
+            {
+                "agent_exit": -1,
+                "termination_reason": "OK",
+                "time_secs": 1.0,
+                "equivalent_cost_usd": 0.01,
+                "usage": usage.to_dict(),
+                "input_tokens": 3,
+                "output_tokens": 4,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical_dir),
+            "model work before interruption",
+            True,
+            True,
+            False,
+            True,
+            [],
+            usage,
+        )
+
+    def checker_unavailable(_item, _workspace, _basename, _round_dir, _check_path, round_result, _canonical=None):
+        round_result["check_verdict"] = "ERROR"
+        round_result["error"] = "checker unavailable"
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", interrupted_model_work)
+    monkeypatch.setattr(runner, "_run_grader_local", checker_unavailable)
+
+    runner._run_continuations(
+        item,
+        str(workspace),
+        result,
+        str(tmp_path / "task-result"),
+        "Task.tla",
+        "Task",
+        item.canonical_inputs,
+        "/checker",
+    )
+
+    pending_round = result["continuations"][0]
+    assert result["module_grading_pending"] == 1
+    assert pending_round["termination_reason"] == "QUOTA_EXHAUSTED"
+    assert pending_round["graded_after_interruption"] is True
+    assert "module_result" not in pending_round
+    assert runner.is_non_genuine(pending_round)
+
+    resumed_workspace = tmp_path / "resumed-workspace"
+    resumed_workspace.mkdir()
+    (resumed_workspace / "Task.tla").write_bytes(interrupted_submission)
+
+    def partial_grade(_item, _workspace, _basename, _round_dir, _check_path, round_result, _canonical=None):
+        module_result = _module_result(complete=False)
+        round_result.update(
+            {
+                "check_verdict": "FAIL",
+                "module_result": module_result,
+                "proof_unit_count": 1,
+                "trusted_proof_unit_count": 0,
+                "trusted_proof_unit_ids": [],
+            }
+        )
+
+    monkeypatch.setattr(runner, "_run_grader_local", partial_grade)
+    runner._grade_resumed_module_submission(
+        item,
+        str(resumed_workspace),
+        result,
+        str(tmp_path / "task-result"),
+        str(tmp_path / "task-result" / "grading"),
+        "Task.tla",
+        "Task",
+        item.canonical_inputs,
+    )
+
+    assert "module_grading_pending" not in result
+    assert not runner.is_non_genuine(result["continuations"][0])
+    assert runner._module_resume_action(result, max_continuations=2) == runner.MODULE_RESUME_CONTINUE
+
+    selected_rounds: list[int] = []
+
+    def stop_after_round_selection(*args, **_kwargs):
+        selected_rounds.append(args[5]["round"])
+        raise RuntimeError("stop after selecting continuation round")
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", stop_after_round_selection)
+    with pytest.raises(RuntimeError, match="selecting continuation round"):
+        runner._run_continuations(
+            item,
+            str(resumed_workspace),
+            result,
+            str(tmp_path / "task-result"),
+            "Task.tla",
+            "Task",
+            item.canonical_inputs,
+            "/checker",
+        )
+
+    assert selected_rounds == [2]
+    assert "interrupted_continuations" not in result
+
+
+def test_interrupted_worked_continuation_with_missing_submission_consumes_the_round(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    prior_submission = b"first partial module"
+    identity, result = _checkpoint_result(
+        output_dir,
+        first_content=prior_submission,
+        max_continuations=2,
+    )
+    result.update(
+        {
+            "max_continuations": 2,
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "time_secs": 2.0,
+            "equivalent_cost_usd": 0.1,
+            "usage": UsageSummary(
+                input_tokens=10,
+                output_tokens=20,
+                model_requests=1,
+                available=True,
+                complete=True,
+            ).to_dict(),
+        }
+    )
+    write_module_checkpoint(output_dir, identity, result)
+    item = _resume_item(
+        tmp_path,
+        result,
+        prior_submission,
+        action=runner.MODULE_RESUME_CONTINUE,
+        max_continuations=2,
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "Task.tla").write_bytes(prior_submission)
+    canonical_dir = tmp_path / "canonical"
+    canonical_dir.mkdir()
+    usage = UsageSummary(input_tokens=3, output_tokens=4, model_requests=1, available=True, complete=True)
+
+    def interrupted_after_deletion(*args, **_kwargs):
+        (workspace / "Task.tla").unlink()
+        round_result = args[5]
+        round_result.update(
+            {
+                "agent_exit": -1,
+                "termination_reason": "OK",
+                "time_secs": 1.0,
+                "equivalent_cost_usd": 0.01,
+                "usage": usage.to_dict(),
+                "input_tokens": 3,
+                "output_tokens": 4,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical_dir),
+            "paid model work before deletion",
+            True,
+            True,
+            False,
+            True,
+            [],
+            usage,
+        )
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", interrupted_after_deletion)
+    monkeypatch.setattr(
+        runner,
+        "_run_grader_local",
+        lambda *_args, **_kwargs: pytest.fail("a missing module is a direct submission failure"),
+    )
+
+    runner._run_continuations(
+        item,
+        str(workspace),
+        result,
+        str(tmp_path / "task-result"),
+        "Task.tla",
+        "Task",
+        item.canonical_inputs,
+        "/checker",
+    )
+
+    failed_round = result["continuations"][0]
+    assert failed_round["round"] == 1
+    assert failed_round["check_verdict"] == "FAIL"
+    assert failed_round["termination_reason"] == "QUOTA_EXHAUSTED"
+    assert failed_round["error"] == "module submission is missing"
+    assert failed_round["invalid_submission_after_interruption"] is True
+    assert "module_artifact" not in failed_round
+    assert "module_result" not in failed_round
+    assert not runner.is_non_genuine(failed_round)
+    assert (workspace / "Task.tla").read_bytes() == prior_submission
+    assert (result["input_tokens"], result["output_tokens"]) == (13, 24)
+    assert result["equivalent_cost_usd"] == pytest.approx(0.11)
+    assert runner._module_resume_action(result, max_continuations=2) == runner.MODULE_RESUME_CONTINUE
+
+    resumed_workspace = tmp_path / "resumed-workspace"
+    resumed_workspace.mkdir()
+    (resumed_workspace / "Task.tla").write_bytes(prior_submission)
+    selected_rounds: list[int] = []
+
+    def stop_after_round_selection(*args, **_kwargs):
+        selected_rounds.append(args[5]["round"])
+        raise RuntimeError("stop after selecting next round")
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", stop_after_round_selection)
+    with pytest.raises(RuntimeError, match="selecting next round"):
+        runner._run_continuations(
+            item,
+            str(resumed_workspace),
+            result,
+            str(tmp_path / "task-result"),
+            "Task.tla",
+            "Task",
+            item.canonical_inputs,
+            "/checker",
+        )
+
+    assert selected_rounds == [2]
+    assert "interrupted_continuations" not in result
+
+
+def test_checkpoint_rejects_graded_result_without_artifact(tmp_path):
+    identity = _identity()
+    result = _attempt(module_result=_module_result(complete=False), verdict="FAIL")
+
+    with pytest.raises(ModuleCheckpointError, match="checker result without an artifact"):
+        write_module_checkpoint(tmp_path, identity, result)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda result: result.update(invalid_submission_after_interruption=False),
+        lambda result: result.update(
+            invalid_submission_after_interruption=True,
+            termination_reason="OK",
+        ),
+        lambda result: result.update(
+            invalid_submission_after_interruption=True,
+            check_verdict="ERROR",
+        ),
+        lambda result: result.update(
+            invalid_submission_after_interruption=True,
+            graded_after_interruption=True,
+        ),
+    ],
+)
+def test_checkpoint_rejects_inconsistent_interrupted_submission_failure(tmp_path, mutate):
+    result = _attempt(verdict="FAIL", termination_reason="INFRA_ERROR")
+    mutate(result)
+
+    with pytest.raises(ModuleCheckpointError, match="interrupted-submission"):
+        write_module_checkpoint(tmp_path, _identity(), result)
+
+
+def test_checkpoint_rejects_noncontiguous_continuation_round(tmp_path):
+    identity, _result = _checkpoint_result(
+        tmp_path,
+        continuation_contents=(b"continuation module",),
+        continuation_verdicts=("FAIL",),
+    )
+    path = checkpoint_path(tmp_path, TASK_ID)
+    payload = json.loads(path.read_text())
+    payload["result"]["continuations"][0]["round"] = 2
+    path.write_text(json.dumps(payload))
+
+    with pytest.raises(ModuleCheckpointError, match="consecutive"):
+        load_module_checkpoint(tmp_path, identity)
+
+
+def test_checkpoint_rejects_round_after_passing_continuation(tmp_path):
+    identity, _result = _checkpoint_result(
+        tmp_path,
+        continuation_contents=(b"passing continuation module",),
+        continuation_verdicts=("PASS",),
+    )
+    second_receipt = publish_module_artifact(tmp_path, b"post-pass continuation module")
+    path = checkpoint_path(tmp_path, TASK_ID)
+    payload = json.loads(path.read_text())
+    payload["result"]["max_continuations"] = 2
+    payload["result"]["continuations"].append(
+        _attempt(
+            artifact=second_receipt,
+            module_result=_module_result(complete=False),
+            verdict="FAIL",
+            round=2,
+        )
+    )
+    path.write_text(json.dumps(payload))
+
+    with pytest.raises(ModuleCheckpointError, match="after a passing continuation"):
+        load_module_checkpoint(tmp_path, identity)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda result: result.update(module_grading_pending=-1), "non-negative integer"),
+        (lambda result: result.update(module_grading_pending=True), "non-negative integer"),
+        (lambda result: result.update(module_grading_pending=1), "latest continuation"),
+        (
+            lambda result: (result.pop("module_artifact"), result.update(module_grading_pending=0)),
+            "requires a preserved module artifact",
+        ),
+        (
+            lambda result: result.update(
+                module_result=_module_result(complete=False),
+                proof_unit_count=1,
+                trusted_proof_unit_count=0,
+                trusted_proof_unit_ids=[],
+                module_grading_pending=0,
+            ),
+            "already graded",
+        ),
+    ],
+)
+def test_checkpoint_rejects_invalid_pending_marker(tmp_path, mutate, message):
+    identity = _identity()
+    artifact = publish_module_artifact(tmp_path, b"pending module")
+    result = _attempt(artifact=artifact, verdict="ERROR")
+    mutate(result)
+
+    with pytest.raises(ModuleCheckpointError, match=message):
+        write_module_checkpoint(tmp_path, identity, result)
+
+
+def test_prepare_ignores_writer_owned_stale_temp_but_rejects_arbitrary_entry(tmp_path):
+    directory = tmp_path / MODULE_CHECKPOINT_DIRECTORY
+    directory.mkdir()
+    stale = directory / f".{checkpoint_filename(TASK_ID)}.orphan.tmp"
+    stale.write_text("incomplete writer output")
+    identity = _identity()
+
+    assert prepare_module_checkpoints(tmp_path, {TASK_ID: identity}, resume=False) == {}
+
+    (directory / "unexpected.json").write_text("{}")
+    with pytest.raises(ModuleCheckpointError, match="unexpected entries"):
+        prepare_module_checkpoints(tmp_path, {TASK_ID: identity}, resume=False)
+
+
+def test_resume_archives_all_prior_owned_evidence(tmp_path):
+    output_dir = tmp_path / "results"
+    result_dir = output_dir / "Suite" / "Task"
+    result_dir.mkdir(parents=True)
+    owned = ("input", "agent", "grading", "continuations", "result.json")
+    for name in owned:
+        path = result_dir / name
+        if name == "result.json":
+            path.write_text("old result")
+        else:
+            path.mkdir()
+            (path / "evidence.txt").write_text(name)
+    (result_dir / "operator-note.txt").write_text("keep this unrelated evidence")
+
+    runner._reset_benchmark_artifacts(
+        str(output_dir),
+        str(result_dir),
+        resume_checkpoint_sequence=7,
+    )
+
+    history = result_dir / "resume-history" / "checkpoint-7"
+    assert sorted(path.name for path in history.iterdir()) == sorted(owned)
+    assert all(not (result_dir / name).exists() for name in owned)
+    assert (result_dir / "operator-note.txt").read_text() == "keep this unrelated evidence"

--- a/tests/evaluator/test_proof_unit_scoring.py
+++ b/tests/evaluator/test_proof_unit_scoring.py
@@ -1,0 +1,295 @@
+"""Focused proof-unit scoring and summary coverage for module tasks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from evaluator import runner
+from evaluator.score import (
+    SCORERS,
+    SPECIFICATION_EQUAL,
+    comparison_md,
+    proof_unit_rate_line,
+    proof_unit_score,
+    scorecard_md,
+)
+
+UNIT_A = "Suite/Module/A"
+UNIT_B = "Suite/Module/B"
+
+
+def _module_result(unit_ids: tuple[str, ...], trusted_ids: tuple[str, ...]) -> dict[str, object]:
+    trusted = set(trusted_ids)
+    units = []
+    for index, unit_id in enumerate(unit_ids, start=1):
+        is_trusted = unit_id in trusted
+        units.append(
+            {
+                "unit_id": unit_id,
+                "kind": "target",
+                "theorem_name": unit_id.rsplit("/", 1)[-1],
+                "line_start": index,
+                "line_end": index + 1,
+                "dependencies": [],
+                "raw_verdict": "PASS" if is_trusted else "FAIL",
+                "tlapm_exit": 0 if is_trusted else 1,
+                "missing_proofs": 0 if is_trusted else 1,
+                "obligation_failed": False,
+                "trusted": is_trusted,
+            }
+        )
+    return {
+        "schema_version": 1,
+        "sany_status": "valid",
+        "proof_unit_ids": list(unit_ids),
+        "units": units,
+        "trusted_unit_ids": list(trusted_ids),
+        "trusted_proof_unit_ids": list(trusted_ids),
+        "complete": len(trusted_ids) == len(unit_ids),
+    }
+
+
+def _result(
+    benchmark: str,
+    unit_ids: tuple[str, ...],
+    *,
+    verdict: str = "FAIL",
+    trusted_ids: tuple[str, ...] = (),
+    termination_reason: str = "OK",
+    module_result: dict[str, object] | None = None,
+    continuations: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    result: dict[str, object] = {
+        "benchmark": benchmark,
+        "module": benchmark.split("/", 1)[0],
+        "mode": "proof-from-scratch",
+        "check_verdict": verdict,
+        "termination_reason": termination_reason,
+        "time_secs": 0.0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "proof_unit_ids": list(unit_ids),
+        "proof_unit_count": len(unit_ids),
+        "trusted_proof_unit_count": len(trusted_ids),
+        "trusted_proof_unit_ids": list(trusted_ids),
+    }
+    if module_result is not None:
+        result["module_result"] = module_result
+    if continuations is not None:
+        result["continuations"] = continuations
+    return result
+
+
+def test_first_attempt_uses_validated_module_report_not_persisted_trust_counts() -> None:
+    result = _result(
+        "Suite/Module.tla",
+        (UNIT_A, UNIT_B),
+        module_result=_module_result((UNIT_A, UNIT_B), (UNIT_A,)),
+        trusted_ids=(UNIT_A, UNIT_B),
+    )
+
+    score = proof_unit_score([result])
+
+    assert (score.trusted_units, score.total_units) == (1, 2)
+
+
+def test_with_continuations_uses_latest_available_report_without_a_pass() -> None:
+    result = _result(
+        "Suite/Module.tla",
+        (UNIT_A, UNIT_B),
+        module_result=_module_result((UNIT_A, UNIT_B), (UNIT_A,)),
+        continuations=[
+            {
+                "check_verdict": "FAIL",
+                "module_result": _module_result((UNIT_A, UNIT_B), (UNIT_A,)),
+            },
+            {
+                "check_verdict": "FAIL",
+                "module_result": _module_result((UNIT_A, UNIT_B), (UNIT_B,)),
+            },
+        ],
+    )
+
+    score = proof_unit_score([result], with_continuations=True)
+
+    assert (score.trusted_units, score.total_units) == (1, 2)
+
+
+def test_with_continuations_keeps_the_first_passing_report() -> None:
+    result = _result(
+        "Suite/Module.tla",
+        (UNIT_A, UNIT_B),
+        module_result=_module_result((UNIT_A, UNIT_B), (UNIT_A,)),
+        continuations=[
+            {
+                "round": 1,
+                "check_verdict": "PASS",
+                "module_result": _module_result((UNIT_A, UNIT_B), (UNIT_A, UNIT_B)),
+            },
+            {
+                "round": 2,
+                "check_verdict": "FAIL",
+                "module_result": _module_result((UNIT_A, UNIT_B), (UNIT_A,)),
+            },
+        ],
+    )
+
+    score = proof_unit_score([result], with_continuations=True)
+
+    assert (score.trusted_units, score.total_units) == (2, 2)
+
+
+def test_skipped_and_non_genuine_modules_are_excluded_but_genuine_errors_keep_the_denominator() -> None:
+    results = [
+        _result(
+            "Suite/Good.tla",
+            (UNIT_A, UNIT_B),
+            trusted_ids=(UNIT_A,),
+            module_result=_module_result((UNIT_A, UNIT_B), (UNIT_A,)),
+        ),
+        _result("Suite/Error.tla", (UNIT_A, UNIT_B), verdict="ERROR"),
+        _result(
+            "Suite/Skipped.tla",
+            (UNIT_A, UNIT_B),
+            verdict="SKIP",
+            trusted_ids=(UNIT_A, UNIT_B),
+            module_result=_module_result((UNIT_A, UNIT_B), (UNIT_A, UNIT_B)),
+        ),
+        _result(
+            "Suite/Infra.tla",
+            (UNIT_A, UNIT_B),
+            verdict="PASS",
+            termination_reason="INFRA_ERROR",
+            trusted_ids=(UNIT_A, UNIT_B),
+            module_result=_module_result((UNIT_A, UNIT_B), (UNIT_A, UNIT_B)),
+        ),
+        {"benchmark": "ordinary.tla", "check_verdict": "PASS"},
+    ]
+
+    score = proof_unit_score(results)
+
+    assert (score.trusted_units, score.total_units) == (1, 4)
+    continuation_score = proof_unit_score(results, with_continuations=True)
+    assert (continuation_score.trusted_units, continuation_score.total_units) == (1, 4)
+
+
+def test_non_module_results_do_not_contribute_to_proof_unit_score() -> None:
+    result = {
+        "benchmark": "ordinary.tla",
+        "check_verdict": "PASS",
+        "module_result": _module_result((UNIT_A, UNIT_B), (UNIT_A, UNIT_B)),
+        "trusted_proof_unit_count": 2,
+    }
+
+    score = proof_unit_score([result])
+
+    assert (score.trusted_units, score.total_units, score.represented_modules) == (0, 0, 0)
+    assert proof_unit_rate_line([result]) is None
+
+
+def test_summary_reports_proof_unit_totals_and_per_module_trust(tmp_path: Path) -> None:
+    results = [
+        _result(
+            "Suite/First.tla",
+            (UNIT_A, UNIT_B),
+            trusted_ids=(UNIT_A,),
+            module_result=_module_result((UNIT_A, UNIT_B), (UNIT_A,)),
+        ),
+        _result(
+            "Suite/Second.tla",
+            (UNIT_A,),
+            verdict="PASS",
+            trusted_ids=(UNIT_A,),
+            module_result=_module_result((UNIT_A,), (UNIT_A,)),
+        ),
+        {"benchmark": "ordinary.tla", "check_verdict": "PASS", "time_secs": 0.0},
+    ]
+
+    runner.update_summary(
+        results,
+        str(tmp_path),
+        total_benchmarks=3,
+        backend_name="copilot",
+        mode_name="proof-from-scratch",
+        specification_ids={
+            ("proof-from-scratch", "Suite/First.tla"): "Suite/First.tla",
+            ("proof-from-scratch", "Suite/Second.tla"): "Suite/Second.tla",
+        },
+    )
+
+    summary = (tmp_path / "summary.md").read_text()
+    unit_score = "**Proof-unit score (k/n, pass@1)**: 2/3 (66.7%)"
+    strict_completion = "**Specification pass rate (all leaves complete)**"
+    assert unit_score in summary
+    assert summary.index(unit_score) < summary.index(strict_completion)
+    assert "pass@1 trusted 1/2 proof units" in summary
+    assert "pass@1 trusted 1/1 proof units" in summary
+    assert "ordinary.tla` | ✅ PASS" in summary
+    assert "ordinary.tla` | ✅ PASS | 0.0s |  | 0/0 |" not in summary
+
+
+def test_summary_reports_latest_continuation_proof_unit_trust(tmp_path: Path) -> None:
+    results = [
+        _result(
+            "Suite/Module.tla",
+            (UNIT_A, UNIT_B),
+            trusted_ids=(UNIT_A,),
+            module_result=_module_result((UNIT_A, UNIT_B), (UNIT_A,)),
+            continuations=[
+                {
+                    "round": 1,
+                    "check_verdict": "FAIL",
+                    "trusted_proof_unit_count": 1,
+                    "module_result": _module_result((UNIT_A, UNIT_B), (UNIT_A,)),
+                },
+                {
+                    "round": 2,
+                    "check_verdict": "PASS",
+                    "trusted_proof_unit_count": 2,
+                    "module_result": _module_result((UNIT_A, UNIT_B), (UNIT_A, UNIT_B)),
+                },
+            ],
+        )
+    ]
+
+    runner.update_summary(
+        results,
+        str(tmp_path),
+        total_benchmarks=1,
+        backend_name="copilot",
+        mode_name="proof-from-scratch",
+    )
+
+    summary = (tmp_path / "summary.md").read_text()
+    assert "**Proof-unit score (k/n, pass@1)**: 1/2 (50.0%)" in summary
+    assert "**Proof-unit score (k/n, with continuations)**: 2/2 (100.0%)" in summary
+    assert "pass@1 trusted 1/2 proof units; latest continuation trusted 2/2" in summary
+
+
+def test_scorecard_and_comparison_use_k_over_n_as_the_module_primary() -> None:
+    results = [
+        _result(
+            "Suite/Module.tla",
+            (UNIT_A, UNIT_B),
+            trusted_ids=(UNIT_A,),
+            module_result=_module_result((UNIT_A, UNIT_B), (UNIT_A,)),
+        )
+    ]
+    run = {
+        "path": "results.json",
+        "id": "run-one",
+        "backend": "codex",
+        "mode": "proof-from-scratch",
+        "results": results,
+    }
+    specification_ids = {
+        ("proof-from-scratch", "Suite/Module.tla"): "Suite/Module.tla",
+    }
+
+    scorecard = scorecard_md(run, SCORERS["equal"], SPECIFICATION_EQUAL, specification_ids)
+    unit_score = "**Proof-unit score (k/n, pass@1)**: 1/2 (50.0%)"
+    assert scorecard.index(unit_score) < scorecard.index("**Specification pass rate")
+
+    comparison = comparison_md([run], SCORERS["equal"], SPECIFICATION_EQUAL, specification_ids)
+    assert "| Proof-unit score (k/n) | Specification pass rate |" in comparison
+    assert "| run-one | codex | proof-from-scratch | 1/2 (50.0%) | 0/1 (0.0%) |" in comparison

--- a/tests/evaluator/test_run_identity.py
+++ b/tests/evaluator/test_run_identity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -12,6 +13,18 @@ from evaluator.modes.base import Mode
 
 class _Mode(Mode):
     name = "proof-from-scratch"
+
+
+def _backend(**changes):
+    values = {
+        "name": "codex",
+        "approach": "agentic",
+        "model": "gpt-test",
+        "reasoning_effort": "high",
+        "max_output_tokens": 4096,
+    }
+    values.update(changes)
+    return SimpleNamespace(**values)
 
 
 def test_canonical_inputs_materialize_frozen_library_catalog(tmp_path):
@@ -79,6 +92,20 @@ def test_resume_rejects_changed_execution_sources(tmp_path):
         runner._validate_resume_run_manifest(str(tmp_path), expected)
 
 
+def test_resume_rejects_changed_agent_skill_snapshot(tmp_path):
+    recorded = {
+        "schema_version": 4,
+        "benchmark_revision": "same-revision",
+        "agent_skills_digest": "old-skills",
+        "agent_skills": ["tlaps-proof-hints"],
+    }
+    expected = {**recorded, "agent_skills_digest": "new-skills"}
+    (tmp_path / runner.RUN_MANIFEST_RECORD).write_text(json.dumps(recorded))
+
+    with pytest.raises(ValueError, match="different benchmark, execution"):
+        runner._validate_resume_run_manifest(str(tmp_path), expected)
+
+
 def test_resume_rejects_changed_verification_toolchain(tmp_path):
     recorded = {
         "schema_version": 2,
@@ -90,6 +117,38 @@ def test_resume_rejects_changed_verification_toolchain(tmp_path):
 
     with pytest.raises(ValueError, match="verification-toolchain inputs"):
         runner._validate_resume_run_manifest(str(tmp_path), expected)
+
+
+def test_resume_rejects_changed_agent_or_budget_policy(tmp_path):
+    policy = runner._execution_policy_identity(
+        _backend(),
+        use_container=True,
+        timeout=100,
+        check_timeout=20,
+        infra_retries=3,
+        max_continuations=1,
+        session_dir="/tmp/tlaps-sessions",
+    )
+    recorded = {"schema_version": 3, "execution_policy": policy}
+    (tmp_path / runner.RUN_MANIFEST_RECORD).write_text(json.dumps(recorded))
+
+    for changed in (
+        {**policy, "model": "different-model"},
+        {**policy, "reasoning_effort": "low"},
+        {**policy, "timeout": 101},
+        {**policy, "check_timeout": 21},
+        {**policy, "infra_retries": 0},
+        {**policy, "max_continuations": 2},
+        {**policy, "environment": "local"},
+        {**policy, "session": {**policy["session"], "persistence": False}},
+        {**policy, "session": {**policy["session"], "root": "/tmp/other-sessions"}},
+        {**policy, "session": {**policy["session"], "key_scheme": "different"}},
+    ):
+        with pytest.raises(ValueError, match="different benchmark, execution"):
+            runner._validate_resume_run_manifest(
+                str(tmp_path),
+                {**recorded, "execution_policy": changed},
+            )
 
 
 def test_resume_rejects_legacy_results_without_run_manifest(tmp_path):

--- a/tests/evaluator/test_score.py
+++ b/tests/evaluator/test_score.py
@@ -21,6 +21,7 @@ from evaluator.score import (
     continuation_budget,
     continuation_interrupted,
     continuation_passed,
+    is_non_genuine,
     is_pass,
     is_pass_with_continuations,
     is_skipped,
@@ -536,6 +537,28 @@ def test_continuation_interrupted_only_for_unresolved_cut_chains():
     # A recovered chain resolved, however its stream ended.
     assert not continuation_interrupted(_r("FAIL", continuations=_cont("FAIL", "PASS")))
     assert not continuation_interrupted(_r("FAIL"))  # no rounds recorded
+
+
+def test_graded_module_progress_after_interruption_remains_a_genuine_result():
+    result = _r(
+        "FAIL",
+        termination_reason="QUOTA_EXHAUSTED",
+        graded_after_interruption=True,
+        module_result={"complete": False},
+    )
+
+    assert not is_non_genuine(result)
+
+
+def test_invalid_module_submission_after_model_work_remains_a_genuine_failure():
+    result = _r(
+        "FAIL",
+        termination_reason="INFRA_ERROR",
+        invalid_submission_after_interruption=True,
+    )
+
+    assert not is_non_genuine(result)
+    assert not continuation_interrupted(_r("FAIL", continuations=[{"round": 1, **result}]))
 
 
 def test_continuation_budget_uniform_or_none():

--- a/tests/evaluator/test_task_list.py
+++ b/tests/evaluator/test_task_list.py
@@ -95,12 +95,15 @@ def test_select_exact_tasks_uses_mode_relative_ids_and_list_order(tmp_path):
 
 @pytest.mark.parametrize("mode_name", ["proof-completion", "proof-from-scratch"])
 def test_current_manifest_modes_support_exact_task_ids(mode_name):
-    manifest = json.loads((REPO_ROOT / "benchmark" / mode_name / "manifest.json").read_text(encoding="utf-8"))
-    task_id = sorted(manifest)[0]
+    suite_name = "proof-from-scratch-module" if mode_name == "proof-from-scratch" else mode_name
+    manifest = json.loads((REPO_ROOT / "benchmark" / suite_name / "manifest.json").read_text(encoding="utf-8"))
+    task_id = (
+        manifest["module_tasks"][0]["spec"]["task_id"] if mode_name == "proof-from-scratch" else sorted(manifest)[0]
+    )
     mode = get_mode(mode_name, str(REPO_ROOT / "benchmark"), "/checker")
 
     assert runner._select_exact_tasks(mode, [task_id]) == [
-        str((REPO_ROOT / "benchmark" / mode_name / task_id).resolve())
+        str((REPO_ROOT / "benchmark" / suite_name / task_id).resolve())
     ]
 
 

--- a/tests/integration/test_proof_module_boundary.py
+++ b/tests/integration/test_proof_module_boundary.py
@@ -1,0 +1,97 @@
+"""End-to-end soundness checks for module-level proof-from-scratch tasks."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from common.proof_from_scratch_module import begin_agent_proof, end_agent_proof
+from common.proof_libraries import CATALOG_FILENAME, scan_official_libraries
+from common.task_contract import BEGIN_AGENT_HELPERS, END_AGENT_HELPERS
+
+REPO = Path(__file__).resolve().parents[2]
+CHECKER = REPO / "src" / "common" / "check_proof.py"
+SANY_RUN_SH = REPO / "src" / "dataset" / "sany-dump" / "run.sh"
+UNIT_ID = "Suite/Task_B.tla"
+
+
+def _tlapm() -> str:
+    configured = os.environ.get("TLAPM")
+    candidates = [Path(configured)] if configured else []
+    candidates.extend((Path("/opt/tlapm/bin/tlapm"), Path.home() / ".tlapm" / "bin" / "tlapm"))
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    pytest.skip("tlapm is not installed")
+
+
+def _task(proof: str) -> str:
+    return "\n".join(
+        (
+            "---- MODULE Task ----",
+            BEGIN_AGENT_HELPERS,
+            END_AGENT_HELPERS,
+            "",
+            "THEOREM B == FALSE",
+            begin_agent_proof(UNIT_ID),
+            proof,
+            end_agent_proof(UNIT_ID),
+            "====",
+            "",
+        )
+    )
+
+
+def _run_checker(tmp_path: Path, submitted: str) -> subprocess.CompletedProcess[str]:
+    canonical = tmp_path / "canonical"
+    workspace = tmp_path / "workspace"
+    canonical.mkdir(parents=True)
+    workspace.mkdir()
+    (canonical / "Task.tla").write_text(_task("PROOF OMITTED"))
+    (canonical / CATALOG_FILENAME).write_bytes(scan_official_libraries().to_bytes())
+    (workspace / "Task.tla").write_text(submitted)
+
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(REPO / "src"),
+        "SANY_RUN_SH": str(SANY_RUN_SH),
+        "TLAPS_LIB": str(REPO / "lib" / "tlapm"),
+        "COMMUNITY_LIB": str(REPO / "lib" / "community"),
+    }
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            str(workspace / "Task.tla"),
+            "--mode",
+            "proof-from-scratch",
+            "--no-container",
+            "--no-git-track",
+            "--no-cache",
+            "--canonical-replay-required",
+            "--benchmark-dir",
+            str(canonical),
+            "--tlapm",
+            _tlapm(),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+
+
+def test_nested_proof_omitted_cannot_admit_a_false_target(tmp_path):
+    result = _run_checker(
+        tmp_path,
+        _task("PROOF\n<1>1. FALSE\n  PROOF OMITTED\n<1> QED BY <1>1"),
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "PROOF_OMITTED_ADDED" in result.stdout
+    assert '"trusted_proof_unit_ids":[]' in result.stdout
+    assert "PASS — 1/1" not in result.stdout


### PR DESCRIPTION
Built on the merged #133 and #137.

## What changed

- Run each proof-from-scratch module in one agent session and score its original theorem targets as separate proof units.
- Grade every target and referenced helper against canonical inputs, count a result only when its local dependencies are trusted, and preserve the latest module artifact and checkpoint across timeout, continuation, interruption, and resume.
- Report proof-unit `k/n` and specification aggregates, and reject theorem-level results when resuming a module run.

## Testing

- `uv run ruff check`, `uv run ruff format --check`, and `uv run pytest tests` (2,019 passed, 2 skipped locally; 2,013 passed, 8 skipped in exact-head CI)
- Generated `FindHighest` as one four-unit module, then ran four fresh `gpt-5.6-sol` max-reasoning attempts with no continuation. All four passed 4/4 and persisted their artifacts, checkpoints, results, and reports.
- Ran four different modules with the same setup. `Allocator` passed 4/4, `SimpleMutex` passed 2/2, `AddTwo` passed 2/2, and `BubbleSort` reached 2/3 before the 30-minute timeout. Its partial result was preserved and graded.
- Regenerated and verified all 109 module tasks, then graded every canonical unresolved module through the evaluator. All 109 returned valid structured results with correct proof-unit mappings and 0 errors.
- GitHub `native` CI passed.
