### PR TITLE
Fix proof-from-scratch newline handling and CI verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ jobs:
           TLAPS_BENCH_REQUIRE_PI_CLI: "1"
         run: uv run pytest tests
 
+      - name: Verify generated proof-from-scratch module suite
+        env:
+          PYTHONPATH: src
+        run: uv run python -m dataset.proof_from_scratch.module_tasks --verify
+
       - name: Check tlaps-bench CLI help
         run: |
           set -euo pipefail

--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -95,6 +95,8 @@ from common.proof_libraries import (
 )
 from common.task_contract import (
     EditableRegionError,
+    FixedSegmentStatus,
+    compare_fixed_segments,
     contains_marker_text,
     parse_editable_regions,
     parse_proof_region,
@@ -680,29 +682,16 @@ def check_editable_region_integrity(filepath, benchmark_dir, *, proof_only=False
     except EditableRegionError as exc:
         return [(0, f"editable-region markers were modified: {exc}", "SCAFFOLD_MODIFIED")]
 
-    if submitted_regions.fixed_segments != canonical_regions.fixed_segments:
-        canonical_fixed = canonical_regions.fixed_segments
-        submitted_fixed = submitted_regions.fixed_segments
-        canonical_suffix = canonical_fixed[-1]
-        submitted_suffix = submitted_fixed[-1]
-        extra_suffix = (
-            submitted_suffix[len(canonical_suffix) :] if submitted_suffix.startswith(canonical_suffix) else None
-        )
-        if submitted_fixed[:-1] == canonical_fixed[:-1] and extra_suffix and not extra_suffix.strip("\r\n"):
-            return []
-
-        def normalize_format(regions):
-            normalized = tuple(re.sub(r"\r\n|\r|\n", "\n", segment) for segment in regions.fixed_segments)
-            return (*normalized[:-1], normalized[-1].rstrip("\n"))
-
-        if normalize_format(submitted_regions) == normalize_format(canonical_regions):
-            return [
-                (
-                    0,
-                    "fixed task scaffold differs only in line endings or the final newline",
-                    "SCAFFOLD_FORMAT_MODIFIED",
-                )
-            ]
+    fixed_segment_status = compare_fixed_segments(canonical_regions.fixed_segments, submitted_regions.fixed_segments)
+    if fixed_segment_status is FixedSegmentStatus.FORMAT_MODIFIED:
+        return [
+            (
+                0,
+                "fixed task scaffold differs only in line endings or the final newline",
+                "SCAFFOLD_FORMAT_MODIFIED",
+            )
+        ]
+    if fixed_segment_status is FixedSegmentStatus.MODIFIED:
         return [(0, "fixed task scaffold outside editable regions was modified", "SCAFFOLD_MODIFIED")]
     return []
 
@@ -1085,6 +1074,7 @@ def parse_strict_status(tlapm_exit, tlapm_output):
 
 
 MODULE_RESULT_PREFIX = "MODULE-RESULT: "
+_NON_CHEAT_MODULE_INTEGRITY_CODES = frozenset({"SCAFFOLD_FORMAT_MODIFIED"})
 
 
 def authoritative_module_unit_ids(filepath: str, benchmark_dir: str | None) -> tuple[str, ...] | None:
@@ -1377,7 +1367,11 @@ def run_module_task_check(
             for code, message in integrity_issues:
                 emit(f"FAIL {code}: {message}")
             emit("GATES-FAILED: module_integrity")
-            emit("CHEAT-DETECTED: " + ",".join(sorted({code for code, _message in integrity_issues})))
+            cheat_codes = sorted(
+                {code for code, _message in integrity_issues if code not in _NON_CHEAT_MODULE_INTEGRITY_CODES}
+            )
+            if cheat_codes:
+                emit("CHEAT-DETECTED: " + ",".join(cheat_codes))
             return 1
 
         unit_results: list[dict[str, object]] = []

--- a/src/common/proof_from_scratch_grading.py
+++ b/src/common/proof_from_scratch_grading.py
@@ -11,6 +11,7 @@ from common.proof_from_scratch_module import (
     ModuleTaskRegions,
     parse_module_task_regions,
 )
+from common.task_contract import FixedSegmentStatus, compare_fixed_segments
 from common.tla_modules import mask_comments_and_strings
 from tlacore.model import Module, Theorem
 
@@ -297,7 +298,13 @@ def analyze_module_submission(
     expected = tuple(expected_unit_ids)
     canonical_regions = _parse_regions(canonical_source, expected, label="canonical")
     submitted_regions = _parse_regions(submitted_source, expected, label="submitted")
-    if submitted_regions.fixed_segments != canonical_regions.fixed_segments:
+    fixed_segment_status = compare_fixed_segments(canonical_regions.fixed_segments, submitted_regions.fixed_segments)
+    if fixed_segment_status is FixedSegmentStatus.FORMAT_MODIFIED:
+        raise ModuleSubmissionError(
+            "SCAFFOLD_FORMAT_MODIFIED",
+            "fixed module task scaffold differs only in line endings or the final newline",
+        )
+    if fixed_segment_status is FixedSegmentStatus.MODIFIED:
         raise ModuleSubmissionError(
             "SCAFFOLD_MODIFIED",
             "fixed module task scaffold outside editable regions was modified",

--- a/src/common/task_contract.py
+++ b/src/common/task_contract.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from types import MappingProxyType
 from typing import Any
@@ -52,6 +53,14 @@ class ManifestError(TaskContractError):
 
 class EditableRegionError(TaskContractError):
     """A task does not contain the exact editable-region marker structure."""
+
+
+class FixedSegmentStatus(StrEnum):
+    """How submitted immutable task segments differ from the canonical task."""
+
+    MATCH = "match"
+    FORMAT_MODIFIED = "format-modified"
+    MODIFIED = "modified"
 
 
 @dataclass(frozen=True)
@@ -121,6 +130,36 @@ class ProofRegion:
         """Rebuild the source, optionally replacing the editable proof."""
 
         return "".join((self.fixed_prefix, self.proof if proof is None else proof, self.fixed_suffix))
+
+
+def compare_fixed_segments(canonical: Sequence[str], submitted: Sequence[str]) -> FixedSegmentStatus:
+    """Compare immutable task bytes under the documented newline policy.
+
+    Extra CR/LF newlines at EOF are harmless and count as a match. Differences
+    consisting only of line-ending style or a missing final newline are format
+    failures, while every other difference changes the canonical scaffold.
+    """
+
+    canonical_segments = tuple(canonical)
+    submitted_segments = tuple(submitted)
+    if submitted_segments == canonical_segments:
+        return FixedSegmentStatus.MATCH
+    if len(submitted_segments) != len(canonical_segments):
+        return FixedSegmentStatus.MODIFIED
+
+    canonical_suffix = canonical_segments[-1]
+    submitted_suffix = submitted_segments[-1]
+    extra_suffix = submitted_suffix[len(canonical_suffix) :] if submitted_suffix.startswith(canonical_suffix) else None
+    if submitted_segments[:-1] == canonical_segments[:-1] and extra_suffix and not extra_suffix.strip("\r\n"):
+        return FixedSegmentStatus.MATCH
+
+    def normalize_format(segments: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(_SOURCE_NEWLINE.sub("\n", segment) for segment in segments)
+        return (*normalized[:-1], normalized[-1].rstrip("\n"))
+
+    if normalize_format(submitted_segments) == normalize_format(canonical_segments):
+        return FixedSegmentStatus.FORMAT_MODIFIED
+    return FixedSegmentStatus.MODIFIED
 
 
 def _json_object_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:

--- a/tests/common/test_check_proof_module_task.py
+++ b/tests/common/test_check_proof_module_task.py
@@ -244,6 +244,92 @@ def test_unchanged_proof_omitted_is_unresolved_and_not_trusted(tmp_path, monkeyp
     validate_module_result(report, (unit_id,))
 
 
+def test_extra_eof_newlines_do_not_fail_module_integrity(tmp_path, monkeypatch):
+    unit_id = UNIT_A
+    canonical_source = _marked_source(unit_id)
+    submitted_source = canonical_source + "\r\n\n"
+    filepath, benchmark = _write_inputs(
+        tmp_path,
+        canonical_source=canonical_source,
+        submitted_source=submitted_source,
+    )
+    module = _module_for_marked_source(submitted_source, unit_id)
+    monkeypatch.setattr(check_proof, "run_normalized", lambda *_args, **_kwargs: _valid_sany())
+    monkeypatch.setattr(check_proof.Module, "parse", lambda _raw: module)
+    monkeypatch.setattr(check_proof, "find_community_lib", lambda _filepath: None)
+    monkeypatch.setattr(
+        check_proof,
+        "run_killgroup",
+        lambda *_args, **_kwargs: pytest.fail("an admitted PROOF OMITTED unit must not invoke TLAPM"),
+    )
+    lines: list[str] = []
+
+    exit_code = check_proof.run_module_task_check(
+        filepath=str(filepath),
+        benchmark_dir=str(benchmark),
+        expected_unit_ids=(unit_id,),
+        tlapm_path="tlapm",
+        tlapm_lib="/tlaps/lib",
+        timeout=30,
+        output_path=str(tmp_path / "check.result"),
+        import_violations=[],
+        emit=lines.append,
+    )
+
+    assert exit_code == 1
+    report = _report(lines)
+    assert "integrity_issues" not in report
+    assert report["units"][0]["raw_verdict"] == "UNRESOLVED"
+    assert not any(line.startswith("CHEAT-DETECTED:") for line in lines)
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        lambda source: source.replace("\n", "\r\n"),
+        lambda source: source.removesuffix("\n"),
+    ],
+    ids=("line-ending-style", "missing-final-newline"),
+)
+def test_newline_only_module_integrity_failure_is_not_cheating(tmp_path, monkeypatch, transform):
+    unit_id = UNIT_A
+    canonical_source = _marked_source(unit_id)
+    submitted_source = transform(canonical_source)
+    filepath, benchmark = _write_inputs(
+        tmp_path,
+        canonical_source=canonical_source,
+        submitted_source=submitted_source,
+    )
+    module = _module_for_marked_source(submitted_source, unit_id)
+    monkeypatch.setattr(check_proof, "run_normalized", lambda *_args, **_kwargs: _valid_sany())
+    monkeypatch.setattr(check_proof.Module, "parse", lambda _raw: module)
+    monkeypatch.setattr(
+        check_proof,
+        "run_killgroup",
+        lambda *_args, **_kwargs: pytest.fail("an integrity failure must stop TLAPM"),
+    )
+    lines: list[str] = []
+
+    exit_code = check_proof.run_module_task_check(
+        filepath=str(filepath),
+        benchmark_dir=str(benchmark),
+        expected_unit_ids=(unit_id,),
+        tlapm_path="tlapm",
+        tlapm_lib="/tlaps/lib",
+        timeout=30,
+        output_path=str(tmp_path / "check.result"),
+        import_violations=[],
+        emit=lines.append,
+    )
+
+    assert exit_code == 1
+    report = _report(lines)
+    assert [issue["code"] for issue in report["integrity_issues"]] == ["SCAFFOLD_FORMAT_MODIFIED"]
+    assert any(line.startswith("FAIL SCAFFOLD_FORMAT_MODIFIED:") for line in lines)
+    assert "GATES-FAILED: module_integrity" in lines
+    assert not any(line.startswith("CHEAT-DETECTED:") for line in lines)
+
+
 def test_raw_pass_with_untrusted_dependency_is_blocked(tmp_path, monkeypatch):
     admitted = _unit(UNIT_A, theorem_name="A", line_start=10, admitted=True)
     dependent = _unit(UNIT_B, theorem_name="B", line_start=50, line_end=60, dependencies=(UNIT_A,))
@@ -324,6 +410,7 @@ def test_context_integrity_failure_emits_machine_report_and_exit_one(tmp_path, m
     assert report["trusted_proof_unit_ids"] == []
     assert report["complete"] is False
     assert [issue["code"] for issue in report["integrity_issues"]] == ["CONTEXT_MODIFIED"]
+    assert "CHEAT-DETECTED: CONTEXT_MODIFIED" in lines
     validate_module_result(report, (UNIT_A,))
 
 

--- a/tests/common/test_proof_from_scratch_grading.py
+++ b/tests/common/test_proof_from_scratch_grading.py
@@ -430,6 +430,45 @@ def test_scaffold_and_statement_modification_are_rejected(mutated: str, statemen
     assert caught.value.code == "SCAFFOLD_MODIFIED"
 
 
+def test_extra_eof_newlines_are_allowed():
+    canonical, submitted, module = _submission(
+        proof_bodies={UNIT_A: "PROOF BY TRUE", UNIT_B: "PROOF BY TRUE"},
+    )
+
+    analysis = analyze_module_submission(
+        canonical_source=canonical,
+        submitted_source=submitted + "\r\n\n",
+        expected_unit_ids=UNITS,
+        module=module,
+    )
+
+    assert tuple(unit.unit_id for unit in analysis.target_units) == UNITS
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        lambda source: source.replace("\n", "\r\n"),
+        lambda source: source.removesuffix("\n"),
+    ],
+    ids=("line-ending-style", "missing-final-newline"),
+)
+def test_newline_only_scaffold_changes_are_format_failures(transform):
+    canonical, submitted, module = _submission(
+        proof_bodies={UNIT_A: "PROOF BY TRUE", UNIT_B: "PROOF BY TRUE"},
+    )
+
+    with pytest.raises(ModuleSubmissionError) as caught:
+        analyze_module_submission(
+            canonical_source=canonical,
+            submitted_source=transform(submitted),
+            expected_unit_ids=UNITS,
+            module=module,
+        )
+
+    assert caught.value.code == "SCAFFOLD_FORMAT_MODIFIED"
+
+
 def test_proof_region_cannot_lexically_extend_the_fixed_target_statement():
     canonical, submitted, module = _submission(
         proof_bodies={UNIT_A: "=> TRUE\nPROOF OBVIOUS", UNIT_B: "PROOF BY TRUE"},


### PR DESCRIPTION
## What changed

I found and fixed two small issues in the proof-from-scratch pipeline.

- Extra EOF newlines were being rejected as scaffold changes and reported as cheating. They are now accepted, while other newline-only changes still fail without being marked as cheating.
- The generated module verifier already existed, but CI was not running it. CI now runs it on every PR.

## Testing

- The verifier regenerated and SANY-checked all 109 modules and 245 proof units with zero errors.
- A deliberately changed generated module was rejected with exit code 1.
- Added newline regression coverage and ran 114 focused tests. Ruff also passes.
