### PR TITLE
Route proof-from-scratch generate to the module-task suite.

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -354,7 +354,7 @@ uv run tlaps-bench generate --mode proof-from-scratch
 uv run tlaps-bench generate --mode proof-from-scratch --verify
 ```
 
-Proof-from-scratch generation emits the module suite under `benchmark/proof-from-scratch-module/`: one task per source `spec_id`, with the existing 245 theorem IDs as proof units. It reads `benchmark/proof-from-scratch/` and will not write into that tree. `--verify` regenerates into a scratch directory and compares the shipped suite. To rebuild the frozen 245-task selection corpus itself, invoke `python -m dataset.proof_from_scratch.generate --layered` directly.
+Proof-from-scratch generation emits the module suite under `benchmark/proof-from-scratch-module/`: one task per source `spec_id`, with the existing 245 theorem IDs as proof units. It reads `benchmark/proof-from-scratch/` and will not write into that tree. `--verify` regenerates into a scratch directory and compares the shipped suite. To rebuild the frozen 245-task selection corpus itself, invoke `uv run python -m dataset.proof_from_scratch.generate --layered` directly.
 
 Proof-completion generation emits the layered suite described in [Layered-task trust boundary](#layered-task-trust-boundary): one read-only `<base>Model.tla` per source, one read-only `<task>Scaffold.tla` per target, an editable `<task>.tla` holding the fixed theorem statement and the marked proof region, and a `manifest.json` naming every task's source specification and exact context. Use `--legacy` only for the old generators.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -227,7 +227,7 @@ uv run tlaps-bench run --backend codex --model gpt-5.5 --mode proof-completion
 uv run tlaps-bench run --backend codex --model gpt-5.5 --mode proof-from-scratch
 ```
 
-Benchmark files live in `benchmark/proof-completion/` and `benchmark/proof-from-scratch/` respectively.
+Benchmark files live in `benchmark/proof-completion/` and `benchmark/proof-from-scratch-module/` respectively. The 245-task tree under `benchmark/proof-from-scratch/` is the module generator's read-only target-selection source, not the suite `run` loads.
 
 ### Layered-task trust boundary
 
@@ -351,7 +351,10 @@ Regenerate benchmark files from annotated source specs.
 ```bash
 uv run tlaps-bench generate
 uv run tlaps-bench generate --mode proof-from-scratch
+uv run tlaps-bench generate --mode proof-from-scratch --verify
 ```
+
+Proof-from-scratch generation emits the module suite under `benchmark/proof-from-scratch-module/`: one task per source `spec_id`, with the existing 245 theorem IDs as proof units. It reads `benchmark/proof-from-scratch/` and will not write into that tree. `--verify` regenerates into a scratch directory and compares the shipped suite. To rebuild the frozen 245-task selection corpus itself, invoke `python -m dataset.proof_from_scratch.generate --layered` directly.
 
 Proof-completion generation emits the layered suite described in [Layered-task trust boundary](#layered-task-trust-boundary): one read-only `<base>Model.tla` per source, one read-only `<task>Scaffold.tla` per target, an editable `<task>.tla` holding the fixed theorem statement and the marked proof region, and a `manifest.json` naming every task's source specification and exact context. Use `--legacy` only for the old generators.
 

--- a/src/dataset/proof_from_scratch/design.md
+++ b/src/dataset/proof_from_scratch/design.md
@@ -241,7 +241,7 @@ scratch. (Exception: when the target property *is* an invariant, as in
 
 - **Input**: `source/<Module>/<File>.tla`
 - **Output**: `benchmark/proof-from-scratch/<Module>/<File>_<TheoremName>.tla` (one file per top-level theorem, plus copied INSTANCE dependency `.tla` files)
-- **CLI**: `python3 -m dataset.proof_from_scratch.generate [--filter <pattern>] [--source-dir source/] [--output-dir benchmark/proof-from-scratch/]` rebuilds the frozen 245-task selection corpus. `tlaps-bench generate --mode proof-from-scratch` emits the module suite under `benchmark/proof-from-scratch-module/` and does not write the 245-task tree.
+- **CLI**: `uv run python -m dataset.proof_from_scratch.generate [--filter <pattern>] [--source-dir source/] [--output-dir benchmark/proof-from-scratch/]` rebuilds the frozen 245-task selection corpus. `tlaps-bench generate --mode proof-from-scratch` emits the module suite under `benchmark/proof-from-scratch-module/` and does not write the 245-task tree.
 
 ## Module tasks (Issue #132)
 

--- a/src/dataset/proof_from_scratch/design.md
+++ b/src/dataset/proof_from_scratch/design.md
@@ -241,7 +241,7 @@ scratch. (Exception: when the target property *is* an invariant, as in
 
 - **Input**: `source/<Module>/<File>.tla`
 - **Output**: `benchmark/proof-from-scratch/<Module>/<File>_<TheoremName>.tla` (one file per top-level theorem, plus copied INSTANCE dependency `.tla` files)
-- **CLI**: `python3 src/dataset/proof_from_scratch/generate.py [--filter <pattern>] [--source-dir source/] [--output-dir benchmark/proof-from-scratch/]`
+- **CLI**: `python3 -m dataset.proof_from_scratch.generate [--filter <pattern>] [--source-dir source/] [--output-dir benchmark/proof-from-scratch/]` rebuilds the frozen 245-task selection corpus. `tlaps-bench generate --mode proof-from-scratch` emits the module suite under `benchmark/proof-from-scratch-module/` and does not write the 245-task tree.
 
 ## Module tasks (Issue #132)
 

--- a/src/dataset/proof_from_scratch/design.md
+++ b/src/dataset/proof_from_scratch/design.md
@@ -241,7 +241,7 @@ scratch. (Exception: when the target property *is* an invariant, as in
 
 - **Input**: `source/<Module>/<File>.tla`
 - **Output**: `benchmark/proof-from-scratch/<Module>/<File>_<TheoremName>.tla` (one file per top-level theorem, plus copied INSTANCE dependency `.tla` files)
-- **CLI**: `uv run python -m dataset.proof_from_scratch.generate [--filter <pattern>] [--source-dir source/] [--output-dir benchmark/proof-from-scratch/]` rebuilds the frozen 245-task selection corpus. `tlaps-bench generate --mode proof-from-scratch` emits the module suite under `benchmark/proof-from-scratch-module/` and does not write the 245-task tree.
+- **CLI**: `uv run python -m dataset.proof_from_scratch.generate --layered [--filter <pattern>] [--source-dir source/] [--output-dir benchmark/proof-from-scratch/]` rebuilds the frozen 245-task selection corpus. `tlaps-bench generate --mode proof-from-scratch` emits the module suite under `benchmark/proof-from-scratch-module/` and does not write the 245-task tree.
 
 ## Module tasks (Issue #132)
 

--- a/src/tlaps_bench/cli.py
+++ b/src/tlaps_bench/cli.py
@@ -83,6 +83,41 @@ def _extract_mode(args: list[str]) -> tuple[str, list[str]]:
     return mode, rest
 
 
+_PROOF_FROM_SCRATCH_GENERATE_DIR_ALIASES = {
+    "--output-dir": "--output-root",
+    "--source-dir": "--source-root",
+}
+
+
+def _proof_from_scratch_generate_args(args: list[str]) -> list[str]:
+    """Map the shared generate directory flags onto the module-task CLI.
+
+    ``tlaps-bench generate`` documents ``--output-dir`` / ``--source-dir``.
+    Module-task generation uses ``--output-root`` / ``--source-root`` so it
+    cannot be aimed at the frozen 245-task corpus by accident.
+    """
+
+    rewritten: list[str] = []
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token in _PROOF_FROM_SCRATCH_GENERATE_DIR_ALIASES:
+            rewritten.append(_PROOF_FROM_SCRATCH_GENERATE_DIR_ALIASES[token])
+            index += 1
+            continue
+        mapped = False
+        for old, new in _PROOF_FROM_SCRATCH_GENERATE_DIR_ALIASES.items():
+            prefix = f"{old}="
+            if token.startswith(prefix):
+                rewritten.append(f"{new}={token[len(prefix) :]}")
+                mapped = True
+                break
+        if not mapped:
+            rewritten.append(token)
+        index += 1
+    return rewritten
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:]) if argv is None else list(argv)
 
@@ -113,10 +148,19 @@ def main(argv: list[str] | None = None) -> int:
         # --help before --mode: show which modes exist plus the proof-completion flags
         # (the default) — the mode-specific flags then come from that module.
         mode, gen_args = _extract_mode(rest)
-        module = (
-            "dataset.proof_completion.generate" if mode == "proof-completion" else "dataset.proof_from_scratch.generate"
+        if mode == "proof-completion":
+            return _dispatch(
+                f"{PROG} generate --mode {mode}",
+                "dataset.proof_completion.generate",
+                "main",
+                gen_args,
+            )
+        return _dispatch(
+            f"{PROG} generate --mode {mode}",
+            "dataset.proof_from_scratch.module_tasks",
+            "main",
+            _proof_from_scratch_generate_args(gen_args),
         )
-        return _dispatch(f"{PROG} generate --mode {mode}", module, "main", gen_args)
     if sub == "score":
         return _dispatch(f"{PROG} score", "evaluator.score", "main", rest)
 

--- a/tests/common/test_cli.py
+++ b/tests/common/test_cli.py
@@ -65,3 +65,62 @@ def test_generate_routes_legacy_shared_model_arguments(monkeypatch, tmp_path):
         "passthrough": ["--legacy", "--shared-model", "--output-dir", str(output_dir)],
         "entry_kwargs": None,
     }
+
+
+def test_generate_proof_from_scratch_routes_to_module_tasks(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_dispatch(prog, module_name, attr, passthrough, *, entry_kwargs=None):
+        captured.update(
+            prog=prog,
+            module_name=module_name,
+            attr=attr,
+            passthrough=passthrough,
+            entry_kwargs=entry_kwargs,
+        )
+        return 0
+
+    monkeypatch.setattr(cli, "_dispatch", fake_dispatch)
+    output_dir = tmp_path / "module-suite"
+    source_dir = tmp_path / "source"
+
+    assert (
+        cli.main(
+            [
+                "generate",
+                "--mode",
+                "proof-from-scratch",
+                "--output-dir",
+                str(output_dir),
+                "--source-dir",
+                str(source_dir),
+                "--verify",
+            ]
+        )
+        == 0
+    )
+    assert captured == {
+        "prog": "tlaps-bench generate --mode proof-from-scratch",
+        "module_name": "dataset.proof_from_scratch.module_tasks",
+        "attr": "main",
+        "passthrough": [
+            "--output-root",
+            str(output_dir),
+            "--source-root",
+            str(source_dir),
+            "--verify",
+        ],
+        "entry_kwargs": None,
+    }
+
+    assert (
+        cli.main(
+            [
+                "generate",
+                "--mode=proof-from-scratch",
+                f"--output-dir={output_dir}",
+            ]
+        )
+        == 0
+    )
+    assert captured["passthrough"] == [f"--output-root={output_dir}"]


### PR DESCRIPTION
### What changed
I found and fixed a leftover in the public generate command. After the module-task suite landed, tlaps-bench generate --mode proof-from-scratch was still generating the old per-theorem corpus under benchmark/proof-from-scratch/, while run uses benchmark/proof-from-scratch-module/.

So the documented command could overwrite the frozen 245-task source and wouldn’t generate the suite the evaluator uses. It now generates module tasks, with --output-dir / --source-dir mapped to the module-task flags. Rebuilding the 245 task corpus still uses uv run python -m dataset.proof_from_scratch.generate --layered.

### Testing
- Public CLI generated FindHighest as one module with 4 proof units, plus its Model/Defs files.
- tlaps-bench generate --mode proof-from-scratch --verify regenerated and verified all 109 modules / 245 proof units with 0 errors.
- Confirmed the existing 245-task tree is unchanged.
- Added CLI routing tests, Ruff passes.