### PR TITLE
Grade proof modules from clean artifacts

### DIFF
--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -1095,7 +1095,12 @@ def authoritative_module_unit_ids(filepath: str, benchmark_dir: str | None) -> t
 
 
 def _module_context_issues(filepath: str, benchmark_dir: str) -> list[tuple[str, str]]:
-    """Compare every workspace TLA+ dependency with the frozen canonical copy."""
+    """Compare supplied TLA+ dependencies with the frozen canonical copy.
+
+    Extra workspace modules are development artifacts, not submitted context.
+    Canonical replay never stages them, and the module contract independently
+    rejects a final task that imports an unapproved module.
+    """
 
     target_name = os.path.basename(filepath)
     workspace = os.path.dirname(filepath)
@@ -1112,8 +1117,6 @@ def _module_context_issues(filepath: str, benchmark_dir: str) -> list[tuple[str,
     actual_context = set(workspace_paths) - {target_name}
     for missing in sorted(expected_context - actual_context):
         issues.append(("CONTEXT_MISSING", f"canonical context file {missing!r} is missing from the submission"))
-    for extra in sorted(actual_context - expected_context):
-        issues.append(("CONTEXT_ADDED", f"undeclared TLA+ file {extra!r} was added to the submission"))
     for name in sorted(expected_context & actual_context):
         submitted = workspace_paths[name]
         if os.path.islink(submitted):

--- a/src/evaluator/prompts/proof-from-scratch.txt
+++ b/src/evaluator/prompts/proof-from-scratch.txt
@@ -1,6 +1,8 @@
 # Task
 
-Prove every target theorem in {benchmark_basename}. This is the only editable file and represents one complete module task. Every other TLA+ file in the workspace is read-only context supplied for this module.
+Prove every target theorem in {benchmark_basename}. This is the only submitted file and represents one complete module task. Every supplied TLA+ context file in the workspace is read-only.
+
+You may create temporary wrappers, configs, traces, and other scratch files for local TLC or Apalache exploration. They are not submitted. Grading reconstructs a clean workspace from {benchmark_basename} and the canonical read-only context, so the final task must not import or depend on scratch files.
 
 Only edit inside the `\* BEGIN AGENT HELPERS` ... `\* END AGENT HELPERS` region and each identified AGENT PROOF region (`\* BEGIN AGENT PROOF <proof-unit-id>` ... `\* END AGENT PROOF <proof-unit-id>`). Do not change the proof-unit IDs on the marker lines. You may choose the proof strategy and reuse any earlier sibling theorem once it is proved.
 
@@ -35,7 +37,7 @@ If you must stop early, leave your best partial proofs in the module. Independen
 # Constraints
 
 - Do not change the module header, imports, marker lines, theorem statements, theorem order, or any text outside the editable regions.
-- Do not modify, replace, or add dependency modules.
+- Do not modify or replace supplied dependency modules, and do not make the final task depend on scratch modules.
 - Do not add EXTENDS, nested modules, CONSTANT, VARIABLE, ASSUME, ASSUMPTION, or AXIOM declarations. INSTANCE is allowed only in the official-library form described above.
 - Every helper `LEMMA` or `THEOREM` must be named and fully proved.
 - Never use PROOF OMITTED or bare OMITTED, and never create a circular helper.

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -749,6 +749,53 @@ def _make_canonical_dir(name_no_ext: str, canonical_inputs: CanonicalInputs) -> 
         raise
 
 
+@contextlib.contextmanager
+def _module_grading_inputs(
+    item: WorkItem,
+    attempt: dict[str, object],
+    canonical_inputs: CanonicalInputs,
+    basename: str,
+    name_no_ext: str,
+):
+    """Yield an artifact-only submission workspace and independent canonical copy."""
+
+    if canonical_inputs.target_name != basename:
+        raise ModuleArtifactError("module artifact target name does not match its canonical input")
+    submission = read_module_artifact(item.output_dir, attempt.get("module_artifact"))
+    grading_workspace = _make_canonical_dir(f"{name_no_ext}_grading", canonical_inputs)
+    canonical_dir = None
+    try:
+        _write_bytes(os.path.join(grading_workspace, basename), submission)
+        canonical_dir = _make_canonical_dir(name_no_ext, canonical_inputs)
+        yield grading_workspace, canonical_dir
+    finally:
+        shutil.rmtree(grading_workspace, ignore_errors=True)
+        if canonical_dir is not None:
+            shutil.rmtree(canonical_dir, ignore_errors=True)
+
+
+@contextlib.contextmanager
+def _standard_grading_inputs(
+    item: WorkItem,
+    workspace: str,
+    canonical_inputs: CanonicalInputs,
+    name_no_ext: str,
+    canonical_dir: str | None,
+):
+    """Yield the existing workspace and an independent canonical copy when required."""
+
+    grading_canonical_dir = canonical_dir
+    created_canonical_dir = False
+    if getattr(item.mode, "canonical_replay_required", False):
+        grading_canonical_dir = _make_canonical_dir(name_no_ext, canonical_inputs)
+        created_canonical_dir = True
+    try:
+        yield workspace, grading_canonical_dir
+    finally:
+        if created_canonical_dir:
+            shutil.rmtree(grading_canonical_dir, ignore_errors=True)
+
+
 def _make_workspace(
     backend_name: str,
     name_no_ext: str,
@@ -1916,33 +1963,19 @@ def _grade_resumed_module_submission(
     if not os.path.isfile(solution_path):
         raise ModuleArtifactError("resumed module artifact did not materialize as a regular task file")
     shutil.copy2(solution_path, os.path.join(attempt_dir, "solution.tla"))
-    canonical_dir = _make_canonical_dir(name_no_ext, canonical_inputs)
-    try:
-        check_result_path = os.path.join(attempt_dir, "check.result")
-        if item.use_container:
-            _run_grader_container(
-                item,
-                workspace,
-                basename,
-                attempt_dir,
-                check_result_path,
-                attempt,
-                canonical_dir,
-            )
-        else:
-            _run_grader_local(
-                item,
-                workspace,
-                basename,
-                attempt_dir,
-                check_result_path,
-                attempt,
-                canonical_dir,
-            )
-    finally:
-        if isinstance(attempt.get("module_result"), dict):
-            result.pop("module_grading_pending", None)
-        shutil.rmtree(canonical_dir, ignore_errors=True)
+    _grade_submission(
+        item,
+        attempt,
+        workspace,
+        attempt_dir,
+        os.path.join(attempt_dir, "check.result"),
+        basename,
+        name_no_ext,
+        canonical_inputs,
+        None,
+    )
+    if isinstance(attempt.get("module_result"), dict):
+        result.pop("module_grading_pending", None)
 
 
 def run_single_benchmark(item: WorkItem):
@@ -2064,7 +2097,6 @@ def run_single_benchmark(item: WorkItem):
 
     workspace = None
     canonical_dir = None
-    grading_canonical_dir = None
     try:
         canonical_inputs = item.canonical_inputs
         if canonical_inputs is None:
@@ -2288,35 +2320,21 @@ def run_single_benchmark(item: WorkItem):
 
         # Run grader
         check_result_path = os.path.join(grading_dir, "check.result")
-        grading_canonical_dir = canonical_dir
-        if getattr(mode, "canonical_replay_required", False):
-            grading_canonical_dir = _make_canonical_dir(name_no_ext, canonical_inputs)
-        try:
-            if item.use_container:
-                _run_grader_container(
-                    item,
-                    workspace,
-                    basename,
-                    grading_dir,
-                    check_result_path,
-                    result,
-                    grading_canonical_dir,
-                )
-            else:
-                _run_grader_local(
-                    item,
-                    workspace,
-                    basename,
-                    grading_dir,
-                    check_result_path,
-                    result,
-                    grading_canonical_dir,
-                )
-            if interrupted_after_model_work and result.get("module_result") is not None:
-                result["graded_after_interruption"] = True
-        finally:
-            if isinstance(result.get("module_result"), dict):
-                result.pop("module_grading_pending", None)
+        _grade_submission(
+            item,
+            result,
+            workspace,
+            grading_dir,
+            check_result_path,
+            basename,
+            name_no_ext,
+            canonical_inputs,
+            canonical_dir,
+        )
+        if interrupted_after_model_work and result.get("module_result") is not None:
+            result["graded_after_interruption"] = True
+        if isinstance(result.get("module_result"), dict):
+            result.pop("module_grading_pending", None)
         if item.module_checkpoint_identity is not None and not _persist_work_item_result(item, result_dir, result):
             return result
         if result.get("module_grading_pending") is not None:
@@ -2340,8 +2358,6 @@ def run_single_benchmark(item: WorkItem):
     finally:
         if workspace:
             shutil.rmtree(workspace, ignore_errors=True)
-        if grading_canonical_dir and grading_canonical_dir != canonical_dir:
-            shutil.rmtree(grading_canonical_dir, ignore_errors=True)
         if canonical_dir:
             shutil.rmtree(canonical_dir, ignore_errors=True)
         _persist_work_item_result(item, result_dir, result)
@@ -2531,7 +2547,6 @@ def _run_continuations(
             name_no_ext,
             fixed_workspace=workspace,
         )
-        grading_canonical_dir = None
         try:
             round_usage = run.usage.with_context(continuation_round=rnd)
             round_result["usage"] = round_usage.to_dict()
@@ -2632,37 +2647,23 @@ def _run_continuations(
                 if not _persist_work_item_result(item, result_dir, result):
                     cut_short = True
             if module_submission_failure is None and (not cut_short or grade_interrupted_module):
-                grading_canonical_dir = run.canonical_dir
-                if getattr(mode, "canonical_replay_required", False):
-                    grading_canonical_dir = _make_canonical_dir(name_no_ext, canonical_inputs)
                 check_result_path = os.path.join(round_dir, "check.result")
-                if item.use_container:
-                    _run_grader_container(
-                        item,
-                        workspace,
-                        basename,
-                        round_dir,
-                        check_result_path,
-                        round_result,
-                        grading_canonical_dir,
-                    )
-                else:
-                    _run_grader_local(
-                        item,
-                        workspace,
-                        basename,
-                        round_dir,
-                        check_result_path,
-                        round_result,
-                        grading_canonical_dir,
-                    )
+                _grade_submission(
+                    item,
+                    round_result,
+                    workspace,
+                    round_dir,
+                    check_result_path,
+                    basename,
+                    name_no_ext,
+                    canonical_inputs,
+                    run.canonical_dir,
+                )
                 if isinstance(round_result.get("module_result"), dict):
                     result.pop("module_grading_pending", None)
                 elif result.get("module_grading_pending") == rnd:
                     cut_short = True
         finally:
-            if grading_canonical_dir and grading_canonical_dir != run.canonical_dir:
-                shutil.rmtree(grading_canonical_dir, ignore_errors=True)
             shutil.rmtree(run.canonical_dir, ignore_errors=True)
 
         if item.module_checkpoint_identity is not None:
@@ -3131,6 +3132,50 @@ def _run_grader_local(
     except Exception as e:
         result["check_verdict"] = "ERROR"
         result["error"] = str(e)
+
+
+def _grade_submission(
+    item: WorkItem,
+    attempt: dict[str, object],
+    workspace: str,
+    grading_dir: str,
+    check_result_path: str,
+    basename: str,
+    name_no_ext: str,
+    canonical_inputs: CanonicalInputs,
+    canonical_dir: str | None,
+) -> None:
+    """Grade a submission, isolating preserved module artifacts from scratch files."""
+
+    try:
+        if item.module_checkpoint_identity is not None:
+            inputs = _module_grading_inputs(item, attempt, canonical_inputs, basename, name_no_ext)
+        else:
+            inputs = _standard_grading_inputs(item, workspace, canonical_inputs, name_no_ext, canonical_dir)
+        with inputs as (grading_workspace, grading_canonical_dir):
+            if item.use_container:
+                _run_grader_container(
+                    item,
+                    grading_workspace,
+                    basename,
+                    grading_dir,
+                    check_result_path,
+                    attempt,
+                    grading_canonical_dir,
+                )
+            else:
+                _run_grader_local(
+                    item,
+                    grading_workspace,
+                    basename,
+                    grading_dir,
+                    check_result_path,
+                    attempt,
+                    grading_canonical_dir,
+                )
+    except (OSError, ModuleArtifactError) as exc:
+        attempt["check_verdict"] = "ERROR"
+        attempt["error"] = f"cannot materialize grading inputs: {exc}"
 
 
 def _parse_grader_result(

--- a/tests/common/test_check_proof_module_task.py
+++ b/tests/common/test_check_proof_module_task.py
@@ -426,6 +426,15 @@ def test_context_hardlink_alias_is_rejected(tmp_path):
     ]
 
 
+def test_unreferenced_scratch_tla_is_not_submitted_context(tmp_path):
+    context_source = "---- MODULE Model ----\n====\n"
+    filepath, benchmark = _write_inputs(tmp_path, context=(("Model.tla", context_source),))
+    (filepath.parent / "MCTask.tla").write_text("---- MODULE MCTask ----\nEXTENDS Task\n====\n")
+    (filepath.parent / "Task_TTrace_1.tla").write_text("---- MODULE Task_TTrace_1 ----\n====\n")
+
+    assert check_proof._module_context_issues(str(filepath), str(benchmark)) == []
+
+
 def test_unit_checker_error_emits_machine_report_and_exit_three(tmp_path, monkeypatch):
     unit = _unit(UNIT_A, line_start=10)
     analysis = _analysis((unit,))

--- a/tests/evaluator/test_agent_skills.py
+++ b/tests/evaluator/test_agent_skills.py
@@ -596,4 +596,6 @@ def test_agentic_prompt_drops_inline_model_checker_guide_without_skill_pointer(t
     assert "check_proof_bin Target.tla --mode proof-from-scratch" in prompt
     assert "Every helper `LEMMA` or `THEOREM` must be named and fully proved" in prompt
     assert 'SMTT("rN")' in prompt
-    assert "Do not modify, replace, or add dependency modules" in prompt
+    assert "temporary wrappers, configs, traces, and other scratch files" in prompt
+    assert "the final task must not import or depend on scratch files" in prompt
+    assert "Do not modify or replace supplied dependency modules" in prompt

--- a/tests/evaluator/test_oneshot_prompt.py
+++ b/tests/evaluator/test_oneshot_prompt.py
@@ -107,7 +107,9 @@ def test_proof_from_scratch_agentic_prompt_enforces_same_boundary(tmp_path):
 
     prompt = mode.build_prompt("Target_Goal.tla", "/opt/tlapm", "/opt/tlapm/lib")
 
-    assert "This is the only editable file" in prompt
+    assert "This is the only submitted file" in prompt
+    assert "temporary wrappers, configs, traces, and other scratch files" in prompt
+    assert "the final task must not import or depend on scratch files" in prompt
     assert r"\* BEGIN AGENT HELPERS" in prompt
     assert r"\* BEGIN AGENT PROOF" in prompt
     assert "Do not change the module header, imports, marker lines" in prompt

--- a/tests/evaluator/test_proof_from_scratch_runner.py
+++ b/tests/evaluator/test_proof_from_scratch_runner.py
@@ -152,6 +152,8 @@ def test_runner_grades_from_pre_agent_canonical_bytes(tmp_path, monkeypatch):
     backend = _Backend()
     agent_canonical_dirs = []
     grader_canonical_dirs = []
+    agent_workspaces = []
+    submitted_task = task_source.replace("PROOF OMITTED", "PROOF BY TRUE")
 
     def fake_prompt(mode_, benchmark_path, dependencies, basename, tlapm_path, tlapm_lib):
         assert Path(benchmark_path).read_text() == task_source
@@ -177,7 +179,11 @@ def test_runner_grades_from_pre_agent_canonical_bytes(tmp_path, monkeypatch):
             "Model.tla",
             "Task.tla",
         ]
+        agent_workspaces.append(workspace)
         agent_canonical_dirs.append(canonical_dir)
+        Path(workspace, "Task.tla").write_text(submitted_task)
+        Path(workspace, "MCTask.tla").write_text(_module("MCTask", "EXTENDS Task\n"))
+        Path(workspace, "Task_TTrace_1.tla").write_text(_module("Task_TTrace_1"))
         task.write_text(task_source.replace("THEOREM Target == TRUE", "THEOREM Target == FALSE"))
         model.write_text(_module("Model", "Value == FALSE\n"))
         (Path(canonical_dir) / "Model.tla").write_text("TAINTED SELF-CHECK SNAPSHOT")
@@ -186,15 +192,52 @@ def test_runner_grades_from_pre_agent_canonical_bytes(tmp_path, monkeypatch):
         result["agent_exit"] = 0
 
     def fake_grader(item, workspace, basename, grading_dir, check_result_path, result, canonical_dir=None):
+        assert workspace != agent_workspaces[0]
+        assert sorted(name for name in os.listdir(workspace) if name.endswith(".tla")) == ["Model.tla", "Task.tla"]
+        assert Path(workspace, "Task.tla").read_text() == submitted_task
+        assert Path(workspace, "Model.tla").read_text() == model_source
         assert (Path(canonical_dir) / "Task.tla").read_text() == task_source
         assert (Path(canonical_dir) / "Model.tla").read_text() == model_source
         grader_canonical_dirs.append(canonical_dir)
-        result["check_verdict"] = "FAIL"
+        result.update(
+            {
+                "check_verdict": "PASS",
+                "sany_status": "valid",
+                "sany_valid": True,
+                "trusted_proof_unit_count": 1,
+                "trusted_proof_unit_ids": [PROOF_UNIT_ID],
+                "module_result": {
+                    "schema_version": 1,
+                    "sany_status": "valid",
+                    "proof_unit_ids": [PROOF_UNIT_ID],
+                    "units": [
+                        {
+                            "unit_id": PROOF_UNIT_ID,
+                            "kind": "target",
+                            "theorem_name": "Target",
+                            "line_start": 1,
+                            "line_end": 1,
+                            "dependencies": [],
+                            "raw_verdict": "PASS",
+                            "tlapm_exit": 0,
+                            "missing_proofs": 0,
+                            "obligation_failed": False,
+                            "trusted": True,
+                        }
+                    ],
+                    "trusted_unit_ids": [PROOF_UNIT_ID],
+                    "trusted_proof_unit_ids": [PROOF_UNIT_ID],
+                    "unused_helper_names": [],
+                    "complete": True,
+                },
+            }
+        )
 
     monkeypatch.setattr(backend, "build_prompt", fake_prompt)
     monkeypatch.setattr(runner, "_run_backend_local", fake_agent)
     monkeypatch.setattr(runner, "_run_grader_local", fake_grader)
 
+    canonical_inputs = runner.CanonicalInputs.capture(str(task), task.name, [str(model)])
     item = runner.WorkItem(
         benchmark_path=str(task),
         output_dir=str(tmp_path / "results"),
@@ -205,7 +248,13 @@ def test_runner_grades_from_pre_agent_canonical_bytes(tmp_path, monkeypatch):
         tlapm_path="/opt/tlapm",
         tlapm_lib="/opt/tlapm/lib",
         infra_retries=0,
-        canonical_inputs=runner.CanonicalInputs.capture(str(task), task.name, [str(model)]),
+        canonical_inputs=canonical_inputs,
+        module_checkpoint_identity=runner.ModuleCheckpointIdentity(
+            task_id=MODULE_TASK_ID,
+            proof_unit_ids=(PROOF_UNIT_ID,),
+            canonical_input_sha256=canonical_inputs.digest(),
+            run_identity_sha256="0" * 64,
+        ),
     )
     task.write_text("TAINTED BEFORE THIS WORKER STARTED")
     model.write_text("TAINTED BEFORE THIS WORKER STARTED")


### PR DESCRIPTION
## Summary

- grade proof-from-scratch modules from their preserved task artifact plus canonical context
- allow unsubmitted TLC/Apalache scratch files without weakening context or import checks
- document the clean grading boundary and cover wrapper/trace regressions