### PR TITLE
Fix benchmark result accounting

### DIFF
--- a/src/common/check_proof.py
+++ b/src/common/check_proof.py
@@ -1074,7 +1074,24 @@ def parse_strict_status(tlapm_exit, tlapm_output):
 
 
 MODULE_RESULT_PREFIX = "MODULE-RESULT: "
+MODULE_RESULT_SCHEMA_VERSION = 2
 _NON_CHEAT_MODULE_INTEGRITY_CODES = frozenset({"SCAFFOLD_FORMAT_MODIFIED"})
+
+
+def _module_obligation_count(output: str) -> int | None:
+    """Read the obligation total from one proof-unit TLAPM invocation."""
+
+    machine_counts = re.findall(
+        r"@!!type:obligationsnumber\s*\n@!!count:(\d+)",
+        output,
+    )
+    if machine_counts:
+        return int(machine_counts[-1])
+    proved = re.findall(r"All (\d+) obligations? proved\.", output)
+    if proved:
+        return int(proved[-1])
+    failed = re.findall(r"\d+/(\d+) obligations? failed\.", output)
+    return int(failed[-1]) if failed else None
 
 
 def authoritative_module_unit_ids(filepath: str, benchmark_dir: str | None) -> tuple[str, ...] | None:
@@ -1169,6 +1186,7 @@ def _module_unit_result(
                 "tlapm_exit": None,
                 "missing_proofs": 1,
                 "obligation_failed": False,
+                "obligations": 0,
             },
             "proof is omitted or missing",
         )
@@ -1180,6 +1198,7 @@ def _module_unit_result(
                 "tlapm_exit": None,
                 "missing_proofs": None,
                 "obligation_failed": None,
+                "obligations": None,
             },
             "SANY did not provide a valid theorem location",
         )
@@ -1193,6 +1212,7 @@ def _module_unit_result(
                 "tlapm_exit": None,
                 "missing_proofs": None,
                 "obligation_failed": None,
+                "obligations": None,
             },
             "module checker timeout exhausted before this proof unit",
         )
@@ -1223,6 +1243,7 @@ def _module_unit_result(
                 "tlapm_exit": None,
                 "missing_proofs": None,
                 "obligation_failed": None,
+                "obligations": None,
             },
             "TLAPM timed out",
         )
@@ -1234,6 +1255,7 @@ def _module_unit_result(
                 "tlapm_exit": None,
                 "missing_proofs": None,
                 "obligation_failed": None,
+                "obligations": None,
             },
             f"TLAPM could not run: {exc}",
         )
@@ -1251,6 +1273,7 @@ def _module_unit_result(
             "tlapm_exit": returncode,
             "missing_proofs": missing,
             "obligation_failed": obligation_failed,
+            "obligations": _module_obligation_count(output),
         },
         output,
     )
@@ -1301,6 +1324,7 @@ def run_module_task_check(
         remaining = None if deadline is None else deadline - time.monotonic()
         if remaining is not None and remaining <= 0:
             emit("SANY-STATUS: unavailable")
+            emit("CHECK-TIMEOUT: module checker budget exhausted before SANY validation")
             emit("ERROR: module checker timeout exhausted before SANY validation")
             return 3
         sany_timeout = 180 if remaining is None else max(1, min(180, math.ceil(remaining)))
@@ -1313,11 +1337,13 @@ def run_module_task_check(
             return 3
         emit(f"SANY-STATUS: {sany_run.status.value}")
         if sany_run.status is SanyStatus.UNAVAILABLE:
+            if sany_run.returncode is None and "timed out" in sany_run.detail:
+                emit(f"CHECK-TIMEOUT: {sany_run.detail[:300]}")
             emit(f"ERROR: SANY validation unavailable: {sany_run.detail[:300]}")
             return 3
         if sany_run.status is SanyStatus.INVALID:
             report = {
-                "schema_version": 1,
+                "schema_version": MODULE_RESULT_SCHEMA_VERSION,
                 "sany_status": "invalid",
                 "proof_unit_ids": list(expected_unit_ids),
                 "units": [],
@@ -1332,6 +1358,7 @@ def run_module_task_check(
         assert sany_run.raw is not None
         remaining = None if deadline is None else deadline - time.monotonic()
         if remaining is not None and remaining <= 0:
+            emit("CHECK-TIMEOUT: module checker budget exhausted before canonical SANY validation")
             emit("ERROR: module checker timeout exhausted before canonical SANY validation")
             return 3
         canonical_sany_timeout = 180 if remaining is None else max(1, min(180, math.ceil(remaining)))
@@ -1341,6 +1368,8 @@ def run_module_task_check(
             timeout=canonical_sany_timeout,
         )
         if canonical_sany_run.status is not SanyStatus.VALID or canonical_sany_run.raw is None:
+            if canonical_sany_run.returncode is None and "timed out" in canonical_sany_run.detail:
+                emit(f"CHECK-TIMEOUT: {canonical_sany_run.detail[:300]}")
             emit(f"ERROR: canonical module SANY validation unavailable: {canonical_sany_run.detail[:300]}")
             return 3
         canonical_module = Module.parse(canonical_sany_run.raw)
@@ -1357,7 +1386,7 @@ def run_module_task_check(
 
         if integrity_issues:
             report = {
-                "schema_version": 1,
+                "schema_version": MODULE_RESULT_SCHEMA_VERSION,
                 "sany_status": "valid",
                 "proof_unit_ids": list(expected_unit_ids),
                 "units": [],
@@ -1403,7 +1432,7 @@ def run_module_task_check(
             result["trusted"] = result["unit_id"] in trusted
         complete = len(trusted_targets) == len(expected_unit_ids)
         report = {
-            "schema_version": 1,
+            "schema_version": MODULE_RESULT_SCHEMA_VERSION,
             "sany_status": "valid",
             "proof_unit_ids": list(expected_unit_ids),
             "units": unit_results,

--- a/src/evaluator/proof_module_checkpoint.py
+++ b/src/evaluator/proof_module_checkpoint.py
@@ -154,13 +154,16 @@ def _validate_result(
         module_result = attempt.get("module_result")
         invalid_after_interruption = attempt.get("invalid_submission_after_interruption")
         if invalid_after_interruption is not None:
+            # A resumed segment may fail to materialize new bytes while the
+            # attempt still retains its previous durable artifact as the next
+            # resume point. The marker describes this segment's submission;
+            # module_artifact remains the latest successfully published bytes.
             if invalid_after_interruption is not True:
                 raise ModuleCheckpointError(f"module checkpoint {label} has an invalid interrupted-submission marker")
             if (
                 attempt.get("termination_reason") not in {"INFRA_ERROR", "QUOTA_EXHAUSTED"}
                 or verdict != "FAIL"
                 or module_result is not None
-                or attempt.get("module_artifact") is not None
                 or attempt.get("graded_after_interruption") is not None
             ):
                 raise ModuleCheckpointError(

--- a/src/evaluator/proof_module_checkpoint.py
+++ b/src/evaluator/proof_module_checkpoint.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import json
+import math
 import os
 import re
 import tempfile
@@ -130,6 +131,26 @@ def _validate_result(
         verdict = attempt.get("check_verdict")
         if type(verdict) is not str or verdict not in {"PASS", "FAIL", "TIMEOUT", "ERROR", "CHEATING"}:
             raise ModuleCheckpointError(f"module checkpoint {label} has an invalid checker verdict")
+        for field in ("logical_timeout_secs", "logical_timeout_used_secs"):
+            value = attempt.get(field)
+            if value is not None and (
+                not isinstance(value, (int, float))
+                or isinstance(value, bool)
+                or value < 0
+                or not math.isfinite(float(value))
+            ):
+                raise ModuleCheckpointError(f"module checkpoint {label} has an invalid {field}")
+        remaining = attempt.get("logical_timeout_remaining_secs")
+        if remaining is not None and (
+            not isinstance(remaining, (int, float))
+            or isinstance(remaining, bool)
+            or remaining < 0
+            or not math.isfinite(float(remaining))
+        ):
+            raise ModuleCheckpointError(f"module checkpoint {label} has an invalid logical timeout remainder")
+        resume_count = attempt.get("logical_resume_count")
+        if resume_count is not None and (type(resume_count) is not int or resume_count < 0):
+            raise ModuleCheckpointError(f"module checkpoint {label} has an invalid logical resume count")
         module_result = attempt.get("module_result")
         invalid_after_interruption = attempt.get("invalid_submission_after_interruption")
         if invalid_after_interruption is not None:

--- a/src/evaluator/proof_module_checkpoint.py
+++ b/src/evaluator/proof_module_checkpoint.py
@@ -170,7 +170,7 @@ def _validate_result(
             raise ModuleCheckpointError(f"module checkpoint {label} has inconsistent trusted proof-unit IDs")
         if verdict == "PASS" and not validated["complete"]:
             raise ModuleCheckpointError(f"module checkpoint {label} records PASS for an incomplete module")
-        if validated["complete"] and verdict != "PASS":
+        if validated["complete"] and verdict not in {"PASS", "ERROR"}:
             raise ModuleCheckpointError(f"module checkpoint {label} does not record PASS for a complete module")
 
     validate_attempt(result, label="first attempt")
@@ -220,8 +220,8 @@ def _validate_result(
             raise ModuleCheckpointError("module checkpoint pending grading must identify the latest continuation")
         else:
             pending_attempt = continuations[-1]
-        if pending_attempt.get("module_result") is not None:
-            raise ModuleCheckpointError("module checkpoint cannot mark an already graded attempt as pending")
+        if pending_attempt.get("module_result") is not None and pending_attempt.get("check_verdict") != "ERROR":
+            raise ModuleCheckpointError("module checkpoint cannot mark a successfully graded attempt as pending")
         if pending_attempt.get("module_artifact") is None:
             raise ModuleCheckpointError("module checkpoint pending grading requires a preserved module artifact")
 

--- a/src/evaluator/proof_module_result.py
+++ b/src/evaluator/proof_module_result.py
@@ -8,7 +8,8 @@ from typing import Any
 
 from common.proof_from_scratch_module import ModuleTaskContractError, compute_trusted_units
 
-MODULE_RESULT_SCHEMA_VERSION = 1
+MODULE_RESULT_SCHEMA_VERSION = 2
+SUPPORTED_MODULE_RESULT_SCHEMA_VERSIONS = frozenset({1, MODULE_RESULT_SCHEMA_VERSION})
 MODULE_RESULT_PREFIX = "MODULE-RESULT: "
 RAW_VERDICTS = frozenset({"PASS", "FAIL", "UNRESOLVED", "TIMEOUT", "ERROR"})
 
@@ -58,8 +59,9 @@ def validate_module_result(raw: object, expected_unit_ids: Iterable[str]) -> dic
     allowed = required | {"unused_helper_names", "integrity_issues"}
     if not required <= set(raw) or set(raw) - allowed:
         raise ModuleResultError("module result has missing or unknown fields")
-    if type(raw["schema_version"]) is not int or raw["schema_version"] != MODULE_RESULT_SCHEMA_VERSION:
+    if type(raw["schema_version"]) is not int or raw["schema_version"] not in SUPPORTED_MODULE_RESULT_SCHEMA_VERSIONS:
         raise ModuleResultError(f"unsupported module result schema_version {raw['schema_version']!r}")
+    schema_version = raw["schema_version"]
     if type(raw["sany_status"]) is not str or raw["sany_status"] not in {"valid", "invalid"}:
         raise ModuleResultError("module result sany_status must be valid or invalid")
     if tuple(_string_list(raw["proof_unit_ids"], label="proof_unit_ids")) != expected:
@@ -93,6 +95,8 @@ def validate_module_result(raw: object, expected_unit_ids: Iterable[str]) -> dic
         "obligation_failed",
         "trusted",
     }
+    if schema_version >= 2:
+        unit_keys.add("obligations")
     for index, value in enumerate(units):
         if type(value) is not dict or set(value) != unit_keys:
             raise ModuleResultError(f"module result unit {index} has an invalid shape")
@@ -140,6 +144,14 @@ def validate_module_result(raw: object, expected_unit_ids: Iterable[str]) -> dic
             tlapm_exit is not None or missing_proofs is not None or obligation_failed is not None
         ):
             raise ModuleResultError(f"module result unit {unit_id!r} has inconsistent {verdict} evidence")
+        if schema_version >= 2:
+            obligations = value["obligations"]
+            if obligations is not None and (type(obligations) is not int or obligations < 0):
+                raise ModuleResultError(f"module result unit {unit_id!r} has invalid obligations")
+            if verdict == "UNRESOLVED" and obligations != 0:
+                raise ModuleResultError(f"module result unit {unit_id!r} has inconsistent UNRESOLVED obligations")
+            if verdict in {"TIMEOUT", "ERROR"} and obligations is not None:
+                raise ModuleResultError(f"module result unit {unit_id!r} has inconsistent {verdict} obligations")
         if verdict == "PASS":
             raw_pass.add(unit_id)
         if type(value["trusted"]) is not bool:
@@ -216,6 +228,7 @@ __all__ = [
     "MODULE_RESULT_SCHEMA_VERSION",
     "MODULE_RESULT_PREFIX",
     "RAW_VERDICTS",
+    "SUPPORTED_MODULE_RESULT_SCHEMA_VERSIONS",
     "ModuleResultError",
     "module_result_from_result",
     "parse_module_result_json",

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -1305,11 +1305,15 @@ def _validate_resume_result_accounting(results: list[dict], *, supports_cost_tim
             if value is None or isinstance(result.get(field), bool):
                 raise ValueError(f"prior result {benchmark!r} has invalid {field}")
             split_times[field] = value
-        if len(split_times) == 2 and time_secs is not None and not math.isclose(
-            split_times["agent_time_secs"] + split_times["grading_time_secs"],
-            float(time_secs),
-            rel_tol=1e-9,
-            abs_tol=1e-9,
+        if (
+            len(split_times) == 2
+            and time_secs is not None
+            and not math.isclose(
+                split_times["agent_time_secs"] + split_times["grading_time_secs"],
+                float(time_secs),
+                rel_tol=1e-9,
+                abs_tol=1e-9,
+            )
         ):
             raise ValueError(f"prior result {benchmark!r} has inconsistent split and total time")
         grader_error_time = result.get("grader_error_time_secs")
@@ -2776,10 +2780,7 @@ def _run_continuations(
                 grading_after = nonnegative_float(round_result.get("grading_time_secs"))
                 if grading_after is not None:
                     _add_child_grading_time(result, grading_after - grading_before)
-                if (
-                    isinstance(round_result.get("module_result"), dict)
-                    and round_result.get("check_verdict") != "ERROR"
-                ):
+                if isinstance(round_result.get("module_result"), dict) and round_result.get("check_verdict") != "ERROR":
                     result.pop("module_grading_pending", None)
                 elif result.get("module_grading_pending") == rnd:
                     cut_short = True

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -101,7 +101,13 @@ from evaluator.score import (
     weighted_score,
 )
 from evaluator.termination import TerminationContext, TerminationReason, classify, startup_error_snippet
-from evaluator.usage import UsageSummary, nonnegative_float
+from evaluator.usage import (
+    UsageSummary,
+    aggregate_token_usage,
+    format_token_usage,
+    nonnegative_float,
+    result_token_usage,
+)
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # File at <repo>/src/evaluator/runner.py — ascend two levels for repo root.
@@ -142,7 +148,16 @@ _COST_TIME_BACKENDS = frozenset(
     }
 )
 _RUNNER_OWNED_ACCOUNTING_KEYS = frozenset(
-    {"usage", "input_tokens", "output_tokens", "time_secs", "equivalent_cost_usd"}
+    {
+        "usage",
+        "input_tokens",
+        "output_tokens",
+        "agent_time_secs",
+        "grading_time_secs",
+        "grader_error_time_secs",
+        "time_secs",
+        "equivalent_cost_usd",
+    }
 )
 
 
@@ -252,6 +267,53 @@ def _sum_accounting_values(left: object, right: object) -> float | None:
     if left_value is None or right_value is None:
         return None
     return left_value + right_value
+
+
+def _recompute_task_time(result: dict[str, object]) -> None:
+    """Keep total task time equal to agent plus grading time."""
+
+    result["time_secs"] = _sum_accounting_values(
+        result.get("agent_time_secs"),
+        result.get("grading_time_secs"),
+    )
+
+
+def _ensure_time_breakdown(result: dict[str, object]) -> None:
+    """Adapt a legacy total-only result before adding new accounting."""
+
+    total = nonnegative_float(result.get("time_secs"))
+    grading = nonnegative_float(result.get("grading_time_secs")) or 0.0
+    agent = nonnegative_float(result.get("agent_time_secs"))
+    if agent is not None and "grading_time_secs" in result:
+        return
+    result["grading_time_secs"] = grading
+    result["agent_time_secs"] = total - grading if total is not None and total >= grading else None
+
+
+def _set_agent_time(result: dict[str, object], value: object) -> None:
+    result["agent_time_secs"] = nonnegative_float(value)
+    result.setdefault("grading_time_secs", 0.0)
+    _recompute_task_time(result)
+
+
+def _add_grading_time(result: dict[str, object], elapsed: float) -> float:
+    """Accumulate one grading attempt and return the amount added."""
+
+    _ensure_time_breakdown(result)
+    prior_grading = nonnegative_float(result.get("grading_time_secs"))
+    if prior_grading is None:
+        prior_grading = 0.0
+    result["grading_time_secs"] = prior_grading + elapsed
+    _recompute_task_time(result)
+    return elapsed
+
+
+def _add_child_grading_time(result: dict[str, object], elapsed: float) -> None:
+    """Add a continuation grader's time to the run-level aggregate."""
+
+    prior = nonnegative_float(result.get("grading_time_secs"))
+    result["grading_time_secs"] = None if prior is None else prior + elapsed
+    _recompute_task_time(result)
 
 
 def _retry_may_duplicate_model_work(
@@ -892,12 +954,13 @@ def _run_backend_with_retries(
     continuation round passes its existing workspace instead — the partial
     proof in it IS the input, and a no-work startup death can't have touched it.
 
-    Fills result's time_secs / usage / input_tokens / output_tokens / agent_exit /
+    Fills result's agent_time_secs / time_secs / usage / input_tokens / output_tokens / agent_exit /
     error / termination_reason (plus infra_retries / infra_retry_reasons after
     any retries); the caller owns quota/infra exhaustion verdicts and messages.
-    time_secs records only the final experiment attempt. Infra/quota launches
-    are saved separately beside their raw artifacts and never enter the formal
-    result. Returns the final attempt's workspace + canonical snapshot, which
+    agent_time_secs records only the final experiment attempt and time_secs is
+    recomputed as agent plus grading time. Infra/quota launches are saved
+    separately beside their raw artifacts and never enter the formal result.
+    Returns the final attempt's workspace + canonical snapshot, which
     the caller must clean up (earlier attempts' dirs are cleaned here, including
     when an attempt raises).
     """
@@ -1033,7 +1096,7 @@ def _run_backend_with_retries(
                 log_prefix=f"[{name_no_ext}] ",
                 prepare_retry=_prepare_quota_retry,
             )
-            result["time_secs"] = attempt_secs if _supports_cost_time(backend) else active_secs
+            _set_agent_time(result, attempt_secs if _supports_cost_time(backend) else active_secs)
 
             # Parse agent output on every path — including quota exhaustion — so
             # the result records any tokens the agent did emit (rather than
@@ -1158,6 +1221,7 @@ def _run_backend_with_retries(
             available=False,
             warnings=("infra/quota accounting is stored separately under agent artifacts",),
         )
+        result["agent_time_secs"] = None
         result["time_secs"] = None
         result["equivalent_cost_usd"] = None
         result["usage"] = attempt_usage.to_dict()
@@ -1231,6 +1295,28 @@ def _validate_resume_result_accounting(results: list[dict], *, supports_cost_tim
             raise ValueError(f"prior result {benchmark!r} has invalid time_secs: expected a finite non-negative number")
         else:
             totals["time_secs"].append(float(time_secs))
+        split_times: dict[str, float] = {}
+        for field in ("agent_time_secs", "grading_time_secs"):
+            if field not in result:
+                continue
+            if result.get(field) is None and supports_cost_time and time_secs is None:
+                continue
+            value = nonnegative_float(result.get(field))
+            if value is None or isinstance(result.get(field), bool):
+                raise ValueError(f"prior result {benchmark!r} has invalid {field}")
+            split_times[field] = value
+        if len(split_times) == 2 and time_secs is not None and not math.isclose(
+            split_times["agent_time_secs"] + split_times["grading_time_secs"],
+            float(time_secs),
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        ):
+            raise ValueError(f"prior result {benchmark!r} has inconsistent split and total time")
+        grader_error_time = result.get("grader_error_time_secs")
+        if grader_error_time is not None and (
+            nonnegative_float(grader_error_time) is None or isinstance(grader_error_time, bool)
+        ):
+            raise ValueError(f"prior result {benchmark!r} has invalid grader_error_time_secs")
         equivalent_cost = result.get("equivalent_cost_usd")
         if equivalent_cost is not None:
             if nonnegative_float(equivalent_cost) is None or isinstance(equivalent_cost, bool):
@@ -1687,10 +1773,11 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
             v = r["check_verdict"]
             verdicts[v] = verdicts.get(v, 0) + 1
 
-        total_input = sum(r.get("input_tokens", 0) for r in results)
-        total_output = sum(r.get("output_tokens", 0) for r in results)
-        formal_results = _formal_results(results) if supports_cost_time else []
-        total_task_time = _sum_required_metric(formal_results, "time_secs") if supports_cost_time else None
+        total_tokens = aggregate_token_usage(results)
+        formal_results = _formal_results(results)
+        total_agent_time = _sum_required_metric(formal_results, "agent_time_secs")
+        total_grading_time = _sum_required_metric(formal_results, "grading_time_secs")
+        total_task_time = _sum_required_metric(formal_results, "time_secs")
         total_equivalent_cost = (
             _sum_required_metric(formal_results, "equivalent_cost_usd") if supports_cost_time else None
         )
@@ -1717,7 +1804,7 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
             if n_skip:
                 pass_line += f" · {n_skip} skipped"
             if non_genuine:
-                pass_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
+                pass_line += f" · {non_genuine} error/interrupted (excluded — re-run)"
             diagnostic_score_lines.append(pass_line)
             continuation_results = results
         else:
@@ -1743,12 +1830,14 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
         continuation_unit_line = proof_unit_rate_line(continuation_results, with_continuations=True)
         if continuation_unit_line and any(result.get("continuations") for result in continuation_results):
             lines.append(continuation_unit_line)
-        lines.append(
-            f"**Total tokens**: {total_input:,} input / {total_output:,} output" + ("" if supports_cost_time else "\n")
-        )
+        lines.append(f"**Total tokens**: {format_token_usage(total_tokens, verbose=True)}")
+        lines.append(f"**Total agent time**: {_format_task_time(total_agent_time)}")
+        lines.append(f"**Total grading time**: {_format_task_time(total_grading_time)}")
+        lines.append(f"**Total task time**: {_format_task_time(total_task_time)}")
         if supports_cost_time:
-            lines.append(f"**Total task time**: {_format_task_time(total_task_time)}")
             lines.append(f"**Equivalent cost**: {_format_equivalent_cost(total_equivalent_cost)}\n")
+        else:
+            lines.append("")
 
         lines.append("## Summary\n")
         lines.append("| Verdict | Count |")
@@ -1762,11 +1851,15 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
 
         lines.append("## Details\n")
         if supports_cost_time:
-            lines.append("| Benchmark | Verdict | Time | Equivalent cost | Obligations | Tokens (in/out) | Notes |")
-            lines.append("|-----------|---------|------|----------------:|-------------|-----------------|-------|")
+            lines.append(
+                "| Benchmark | Verdict | Agent | Grading | Total | Equivalent cost | Obligations | Tokens (in/out) | Notes |"
+            )
+            lines.append(
+                "|-----------|---------|------:|--------:|------:|----------------:|-------------|-----------------|-------|"
+            )
         else:
-            lines.append("| Benchmark | Verdict | Time | Obligations | Tokens (in/out) | Notes |")
-            lines.append("|-----------|---------|------|-------------|-----------------|-------|")
+            lines.append("| Benchmark | Verdict | Agent | Grading | Total | Obligations | Tokens (in/out) | Notes |")
+            lines.append("|-----------|---------|------:|--------:|------:|-------------|-----------------|-------|")
         for r in sorted(results, key=lambda x: x["benchmark"]):
             icon = VERDICT_ICONS.get(r["check_verdict"], "❓")
             notes = r.get("error", "")
@@ -1798,9 +1891,10 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
                     latest_count = graded_rounds[-1]["trusted_proof_unit_count"]
                     unit_note += f"; latest continuation trusted {latest_count}/{r['proof_unit_count']}"
                 notes = (unit_note + " " + notes).strip()
-            tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
+            tokens = format_token_usage(result_token_usage(r))
             if "obligations" in r:
-                obs = str(r["obligations"])
+                prefix = "≥" if r.get("obligations_complete") is False else ""
+                obs = f"{prefix}{r['obligations']}"
             elif "obligations_failed" in r:
                 obs = f"{r['obligations_failed']}/{r['obligations_total']} failed"
             else:
@@ -1808,13 +1902,17 @@ def update_summary(results, output_dir, total_benchmarks, backend_name, mode_nam
             if supports_cost_time:
                 lines.append(
                     f"| `{r['benchmark']}` | {icon} {r['check_verdict']} | "
+                    f"{_format_task_time(r.get('agent_time_secs'))} | "
+                    f"{_format_task_time(r.get('grading_time_secs'))} | "
                     f"{_format_task_time(r.get('time_secs'))} | "
                     f"{_format_equivalent_cost(r.get('equivalent_cost_usd'))} | {obs} | {tokens} | {notes} |"
                 )
             else:
                 lines.append(
                     f"| `{r['benchmark']}` | {icon} {r['check_verdict']} | "
-                    f"{r['time_secs']:.0f}s | {obs} | {tokens} | {notes} |"
+                    f"{_format_task_time(r.get('agent_time_secs'))} | "
+                    f"{_format_task_time(r.get('grading_time_secs'))} | "
+                    f"{_format_task_time(r.get('time_secs'))} | {obs} | {tokens} | {notes} |"
                 )
         lines.append("")
         cost_warnings = _equivalent_cost_warnings(results) if supports_cost_time else []
@@ -1963,6 +2061,7 @@ def _grade_resumed_module_submission(
     if not os.path.isfile(solution_path):
         raise ModuleArtifactError("resumed module artifact did not materialize as a regular task file")
     shutil.copy2(solution_path, os.path.join(attempt_dir, "solution.tla"))
+    grading_before = nonnegative_float(attempt.get("grading_time_secs")) or 0.0
     _grade_submission(
         item,
         attempt,
@@ -1974,7 +2073,13 @@ def _grade_resumed_module_submission(
         canonical_inputs,
         None,
     )
-    if isinstance(attempt.get("module_result"), dict):
+    if pending_round > 0:
+        _ensure_time_breakdown(result)
+        latest_grading = nonnegative_float(attempt.get("grading_time_secs"))
+        prior_grading = nonnegative_float(result.get("grading_time_secs"))
+        if latest_grading is not None and prior_grading is not None:
+            _add_child_grading_time(result, latest_grading - grading_before)
+    if isinstance(attempt.get("module_result"), dict) and attempt.get("check_verdict") != "ERROR":
         result.pop("module_grading_pending", None)
 
 
@@ -2013,6 +2118,8 @@ def run_single_benchmark(item: WorkItem):
         "mode": mode.name,
         "agent_exit": -1,
         "check_verdict": "ERROR",
+        "agent_time_secs": None if _supports_cost_time(backend) else 0,
+        "grading_time_secs": 0.0,
         "time_secs": None if _supports_cost_time(backend) else 0,
         "error": "",
         # Skill availability, not evidence that the client invoked a skill.
@@ -2218,12 +2325,10 @@ def run_single_benchmark(item: WorkItem):
 
         with open(os.path.join(agent_dir, "transcript.txt"), "w") as f:
             f.write(f"Benchmark: {rel_path}\n")
+            f.write(f"Agent time: {_format_task_time(result.get('agent_time_secs'))}\n")
             if _supports_cost_time(backend):
-                f.write(f"Time: {_format_task_time(result.get('time_secs'))}\n")
                 f.write(f"Equivalent cost: {_format_equivalent_cost(result.get('equivalent_cost_usd'))}\n")
-            else:
-                f.write(f"Time: {result['time_secs']:.0f}s\n")
-            f.write(f"Tokens: {result['input_tokens']:,} input / {result['output_tokens']:,} output\n")
+            f.write(f"Tokens: {format_token_usage(result_token_usage(result), verbose=True)}\n")
             f.write("=" * 60 + "\n\n")
             f.write(run.transcript)
 
@@ -2333,7 +2438,7 @@ def run_single_benchmark(item: WorkItem):
         )
         if interrupted_after_model_work and result.get("module_result") is not None:
             result["graded_after_interruption"] = True
-        if isinstance(result.get("module_result"), dict):
+        if isinstance(result.get("module_result"), dict) and result.get("check_verdict") != "ERROR":
             result.pop("module_grading_pending", None)
         if item.module_checkpoint_identity is not None and not _persist_work_item_result(item, result_dir, result):
             return result
@@ -2498,6 +2603,7 @@ def _run_continuations(
     <result_dir>/continuations/round-N/, shaped like the agent/ + grading/ dirs.
     """
     mode = item.mode
+    _ensure_time_breakdown(result)
     prompt = mode.build_continuation_prompt(basename, item.tlapm_path, item.tlapm_lib)
     agent_check_file = os.path.join(workspace, name_no_ext + ".result")
     rounds: list[dict] = result.setdefault("continuations", [])
@@ -2525,6 +2631,8 @@ def _run_continuations(
             "round": rnd,
             "agent_exit": -1,
             "check_verdict": "ERROR",
+            "agent_time_secs": 0,
+            "grading_time_secs": 0.0,
             "time_secs": 0,
             "error": "",
             "termination_reason": TerminationReason.OK,
@@ -2567,7 +2675,7 @@ def _run_continuations(
                 run.quota_exhausted or round_result.get("termination_reason") == TerminationReason.INFRA_ERROR
             )
 
-            formal_round = not is_non_genuine(round_result) or (
+            formal_round = not round_interrupted or (
                 item.module_checkpoint_identity is not None and run.model_work_observed
             )
             if formal_round or not _supports_cost_time(item.backend):
@@ -2579,10 +2687,15 @@ def _run_continuations(
                         .merge(toolcalls.ToolCallSummary.from_dict(round_result.get("tool_calls")))
                         .to_dict()
                     )
-                result["time_secs"] = _sum_accounting_values(
-                    result.get("time_secs"),
-                    round_result.get("time_secs"),
+                result["agent_time_secs"] = _sum_accounting_values(
+                    result.get("agent_time_secs"),
+                    round_result.get("agent_time_secs"),
                 )
+                result["grading_time_secs"] = _sum_accounting_values(
+                    result.get("grading_time_secs"),
+                    round_result.get("grading_time_secs"),
+                )
+                _recompute_task_time(result)
                 if _supports_cost_time(item.backend):
                     result["equivalent_cost_usd"] = _sum_accounting_values(
                         result.get("equivalent_cost_usd"),
@@ -2648,6 +2761,7 @@ def _run_continuations(
                     cut_short = True
             if module_submission_failure is None and (not cut_short or grade_interrupted_module):
                 check_result_path = os.path.join(round_dir, "check.result")
+                grading_before = nonnegative_float(round_result.get("grading_time_secs")) or 0.0
                 _grade_submission(
                     item,
                     round_result,
@@ -2659,9 +2773,17 @@ def _run_continuations(
                     canonical_inputs,
                     run.canonical_dir,
                 )
-                if isinstance(round_result.get("module_result"), dict):
+                grading_after = nonnegative_float(round_result.get("grading_time_secs"))
+                if grading_after is not None:
+                    _add_child_grading_time(result, grading_after - grading_before)
+                if (
+                    isinstance(round_result.get("module_result"), dict)
+                    and round_result.get("check_verdict") != "ERROR"
+                ):
                     result.pop("module_grading_pending", None)
                 elif result.get("module_grading_pending") == rnd:
+                    cut_short = True
+                if round_result.get("check_verdict") == "ERROR":
                     cut_short = True
         finally:
             shutil.rmtree(run.canonical_dir, ignore_errors=True)
@@ -3147,6 +3269,25 @@ def _grade_submission(
 ) -> None:
     """Grade a submission, isolating preserved module artifacts from scratch files."""
 
+    previous_grader_error = attempt.pop("grader_error", None)
+    if previous_grader_error and attempt.get("error") == previous_grader_error:
+        attempt["error"] = ""
+    for key in (
+        "module_result",
+        "trusted_proof_unit_ids",
+        "obligations",
+        "obligations_complete",
+        "obligations_failed",
+        "obligations_total",
+        "sany_status",
+        "sany_valid",
+        "failed_gates",
+        "cheat_checks",
+    ):
+        attempt.pop(key, None)
+    if "trusted_proof_unit_count" in attempt:
+        attempt["trusted_proof_unit_count"] = 0
+    started = time.monotonic()
     try:
         if item.module_checkpoint_identity is not None:
             inputs = _module_grading_inputs(item, attempt, canonical_inputs, basename, name_no_ext)
@@ -3176,6 +3317,16 @@ def _grade_submission(
     except (OSError, ModuleArtifactError) as exc:
         attempt["check_verdict"] = "ERROR"
         attempt["error"] = f"cannot materialize grading inputs: {exc}"
+    finally:
+        elapsed = time.monotonic() - started
+        if attempt.get("check_verdict") == "ERROR":
+            attempt["grader_error"] = str(attempt.get("error", ""))
+            prior = nonnegative_float(attempt.get("grader_error_time_secs")) or 0.0
+            attempt["grader_error_time_secs"] = prior + elapsed
+            _ensure_time_breakdown(attempt)
+            _recompute_task_time(attempt)
+        else:
+            _add_grading_time(attempt, elapsed)
 
 
 def _parse_grader_result(
@@ -3212,6 +3363,9 @@ def _parse_grader_result(
         result["check_verdict"] = "ERROR"
         result["error"] = f"grader reported an invalid SANY status marker: {sany_status!r}"
         return
+    result["sany_status"] = sany_status
+    result["sany_valid"] = sany_status == "valid"
+    declared_timeout = bool(re.search(r"^CHECK-TIMEOUT:", stdout or "", re.MULTILINE))
     module_matches = re.findall(
         rf"^{re.escape(MODULE_RESULT_PREFIX)}(.+)$",
         stdout or "",
@@ -3219,6 +3373,9 @@ def _parse_grader_result(
     )
     if expected_module_unit_ids is not None:
         if len(module_matches) != 1:
+            if len(module_matches) == 0 and exit_code not in (0, 1) and declared_timeout:
+                result["check_verdict"] = "TIMEOUT"
+                return
             result["check_verdict"] = "ERROR"
             result["error"] = "module grader did not report exactly one machine-readable module result"
             return
@@ -3233,6 +3390,11 @@ def _parse_grader_result(
         result["proof_unit_count"] = len(expected_module_unit_ids)
         result["trusted_proof_unit_count"] = len(trusted)
         result["trusted_proof_unit_ids"] = list(trusted)
+        units = module_result["units"]
+        if units and any("obligations" in unit for unit in units):
+            known_obligations = [unit["obligations"] for unit in units if isinstance(unit.get("obligations"), int)]
+            result["obligations"] = sum(known_obligations)
+            result["obligations_complete"] = len(known_obligations) == len(units)
         if exit_code == 0 and not module_result["complete"]:
             result["check_verdict"] = "ERROR"
             result["error"] = "module grader exited PASS without trusting every proof unit"
@@ -3249,8 +3411,6 @@ def _parse_grader_result(
             result["error"] = "module grader SANY status disagrees with SANY-STATUS marker"
             return
 
-    result["sany_status"] = sany_status
-    result["sany_valid"] = sany_status == "valid"
     # Which gate(s) failed (the grade is binary; this keeps the analysis signal).
     gm = re.search(r"GATES-FAILED:\s*([^\n]+)", stdout or "")
     if gm:
@@ -3731,7 +3891,7 @@ def main():
                 f"(first-attempt or continuation) + {n_skip} SKIP"
             )
             if non_genuine:
-                msg += f"; {non_genuine} infra/quota-cut result(s) eligible for rerun"
+                msg += f"; {non_genuine} error/interrupted result(s) eligible for rerun"
             print(msg)
         else:
             print(f"Resume: no prior results.json or module checkpoints in {output_dir} — running all")
@@ -3896,7 +4056,7 @@ def main():
             r = run_single_benchmark(item)
             _record_result(results, r)
             icon = VERDICT_ICONS.get(r["check_verdict"], "❓")
-            tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
+            tokens = format_token_usage(result_token_usage(r))
             cont = _continuation_note(r)
             metrics = (
                 f"{_format_task_time(r.get('time_secs'))}, {tokens} tok, "
@@ -3916,7 +4076,7 @@ def main():
                 r = future.result()
                 _record_result(results, r)
                 icon = VERDICT_ICONS.get(r["check_verdict"], "❓")
-                tokens = f"{r.get('input_tokens', 0):,}/{r.get('output_tokens', 0):,}"
+                tokens = format_token_usage(result_token_usage(r))
                 cont = _continuation_note(r)
                 metrics = (
                     f"{_format_task_time(r.get('time_secs'))}, {tokens} tok, "
@@ -3949,12 +4109,12 @@ def main():
     for v in ["PASS", "FAIL", "CHEATING", "TIMEOUT", "ERROR"]:
         if v in verdicts:
             print(f"  {VERDICT_ICONS.get(v, '❓')} {v}: {verdicts[v]}")
-    total_in = sum(r.get("input_tokens", 0) for r in results)
-    total_out = sum(r.get("output_tokens", 0) for r in results)
-    print(f"  Total tokens: {total_in:,} input / {total_out:,} output")
+    print(f"  Total tokens: {format_token_usage(aggregate_token_usage(results), verbose=True)}")
+    formal_results = _formal_results(results)
+    print(f"  Total agent time: {_format_task_time(_sum_required_metric(formal_results, 'agent_time_secs'))}")
+    print(f"  Total grading time: {_format_task_time(_sum_required_metric(formal_results, 'grading_time_secs'))}")
+    print(f"  Total task time: {_format_task_time(_sum_required_metric(formal_results, 'time_secs'))}")
     if _supports_cost_time(backend):
-        formal_results = _formal_results(results)
-        print(f"  Total task time: {_format_task_time(_sum_required_metric(formal_results, 'time_secs'))}")
         print(
             f"  Equivalent cost: {_format_equivalent_cost(_sum_required_metric(formal_results, 'equivalent_cost_usd'))}"
         )

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -3733,14 +3733,15 @@ def _parse_grader_result(
         if cm:
             result["check_verdict"] = "CHEATING"
             result["cheat_checks"] = [c.strip() for c in cm.group(1).split(",") if c.strip()]
-    ob_matches = re.findall(r"All (\d+) obligation", stdout)
-    if ob_matches:
-        result["obligations"] = int(ob_matches[-1])
-    else:
-        fail_match = re.search(r"(\d+)/(\d+) obligation", stdout)
-        if fail_match:
-            result["obligations_failed"] = int(fail_match.group(1))
-            result["obligations_total"] = int(fail_match.group(2))
+    if expected_module_unit_ids is None:
+        ob_matches = re.findall(r"All (\d+) obligation", stdout)
+        if ob_matches:
+            result["obligations"] = int(ob_matches[-1])
+        else:
+            fail_match = re.search(r"(\d+)/(\d+) obligation", stdout)
+            if fail_match:
+                result["obligations_failed"] = int(fail_match.group(1))
+                result["obligations_total"] = int(fail_match.group(2))
 
 
 # A one-word prompt that needs no tools and no workspace files — keeps the

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -106,6 +106,7 @@ from evaluator.usage import (
     aggregate_token_usage,
     format_token_usage,
     nonnegative_float,
+    nonnegative_int,
     result_token_usage,
 )
 
@@ -155,6 +156,7 @@ _RUNNER_OWNED_ACCOUNTING_KEYS = frozenset(
         "agent_time_secs",
         "grading_time_secs",
         "grader_error_time_secs",
+        "logical_timeout_used_secs",
         "time_secs",
         "equivalent_cost_usd",
     }
@@ -619,6 +621,213 @@ class WorkItem:
     module_checkpoint_identity: ModuleCheckpointIdentity | None = None
 
 
+_LOGICAL_PROOF_EVIDENCE_KEYS = (
+    "module_result",
+    "trusted_proof_unit_count",
+    "trusted_proof_unit_ids",
+    "obligations",
+    "obligations_complete",
+    "obligations_failed",
+    "obligations_total",
+    "sany_status",
+    "sany_valid",
+    "failed_gates",
+    "cheat_checks",
+)
+_LOGICAL_ATTEMPT_OUTCOME_KEYS = (
+    *_LOGICAL_PROOF_EVIDENCE_KEYS,
+    "graded_after_interruption",
+    "invalid_submission_after_interruption",
+    "grader_error",
+    "infra_retries",
+    "infra_retry_reasons",
+)
+
+
+def _result_usage_summary(result: dict[str, object]) -> UsageSummary:
+    usage = result.get("usage")
+    if isinstance(usage, dict):
+        return UsageSummary.from_dict(usage)
+    input_tokens = nonnegative_int(result.get("input_tokens", 0))
+    output_tokens = nonnegative_int(result.get("output_tokens", 0))
+    if input_tokens is None or output_tokens is None:
+        raise ModuleCheckpointError("logical attempt has invalid legacy token accounting")
+    return UsageSummary.from_legacy(input_tokens, output_tokens, source="runner.legacy_logical_attempt")
+
+
+def _logical_attempt_has_accounted_work(result: dict[str, object]) -> bool:
+    _ensure_time_breakdown(result)
+    if (nonnegative_float(result.get("logical_timeout_used_secs")) or 0.0) > 0:
+        return True
+    if (nonnegative_float(result.get("agent_time_secs")) or 0.0) > 0:
+        return True
+    if any(
+        result.get(field) is not None
+        for field in ("module_artifact", "graded_after_interruption", "invalid_submission_after_interruption")
+    ):
+        return True
+    usage = _result_usage_summary(result)
+    if (usage.model_requests or 0) > 0 or usage.requests:
+        return True
+    return any((getattr(usage, field) or 0) > 0 for field in _USAGE_TOKEN_FIELDS)
+
+
+def _logical_timeout_budget(result: dict[str, object], configured_timeout: float) -> float:
+    raw = result.get("logical_timeout_secs", configured_timeout)
+    budget = nonnegative_float(raw)
+    configured = nonnegative_float(configured_timeout)
+    if budget is None or configured is None:
+        raise ModuleCheckpointError("logical attempt timeout must be a finite non-negative number")
+    if not math.isclose(budget, configured, rel_tol=0, abs_tol=1e-9):
+        raise ModuleCheckpointError("logical attempt timeout differs from the recorded run configuration")
+    result["logical_timeout_secs"] = budget
+    return budget
+
+
+def _remaining_logical_timeout(result: dict[str, object], configured_timeout: float) -> float | None:
+    """Return None for unlimited, otherwise the unspent agent-time budget."""
+
+    budget = _logical_timeout_budget(result, configured_timeout)
+    if budget == 0:
+        result["logical_timeout_remaining_secs"] = None
+        return None
+    _ensure_time_breakdown(result)
+    spent = nonnegative_float(result.get("logical_timeout_used_secs"))
+    if spent is None:
+        spent = nonnegative_float(result.get("agent_time_secs"))
+    if spent is None:
+        if _logical_attempt_has_accounted_work(result):
+            raise ModuleCheckpointError("cannot resume a timed logical attempt with unavailable agent time")
+        spent = 0.0
+    remaining = max(0.0, budget - spent)
+    result["logical_timeout_remaining_secs"] = remaining
+    return remaining
+
+
+def _mark_logical_attempt_timeout(result: dict[str, object]) -> None:
+    result["agent_exit"] = -1
+    result["check_verdict"] = "TIMEOUT"
+    result["termination_reason"] = TerminationReason.TIMEOUT
+    result["error"] = "logical attempt timeout exhausted before resume"
+    result["logical_timeout_remaining_secs"] = 0.0
+    result.pop("graded_after_interruption", None)
+    result.pop("invalid_submission_after_interruption", None)
+
+
+def _refresh_logical_timeout_remaining(result: dict[str, object]) -> None:
+    budget = nonnegative_float(result.get("logical_timeout_secs"))
+    if budget is None:
+        return
+    if budget == 0:
+        result["logical_timeout_remaining_secs"] = None
+        return
+    spent = nonnegative_float(result.get("logical_timeout_used_secs"))
+    if spent is None:
+        spent = nonnegative_float(result.get("agent_time_secs"))
+    result["logical_timeout_remaining_secs"] = None if spent is None else max(0.0, budget - spent)
+
+
+def _reset_logical_attempt_segment(result: dict[str, object], backend: Backend) -> None:
+    """Clear one interrupted segment while retaining its durable task state."""
+
+    for key in _LOGICAL_ATTEMPT_OUTCOME_KEYS:
+        result.pop(key, None)
+    result["agent_exit"] = -1
+    result["check_verdict"] = "ERROR"
+    result["termination_reason"] = TerminationReason.OK
+    result["error"] = ""
+    result["agent_time_secs"] = None if _supports_cost_time(backend) else 0.0
+    result["grading_time_secs"] = 0.0
+    result["logical_timeout_used_secs"] = 0.0
+    result["time_secs"] = None if _supports_cost_time(backend) else 0.0
+    result["usage"] = UsageSummary(
+        input_tokens=0,
+        output_tokens=0,
+        model_requests=0,
+        sources=("runner.logical_attempt_segment",),
+        available=True,
+        complete=True,
+    ).to_dict()
+    result["input_tokens"] = 0
+    result["output_tokens"] = 0
+    result.pop("tool_calls", None)
+    result.pop("grader_error_time_secs", None)
+    if _supports_cost_time(backend):
+        result["equivalent_cost_usd"] = None
+
+
+def _merge_logical_attempt_accounting(
+    result: dict[str, object],
+    previous: dict[str, object],
+    segment_usage: UsageSummary,
+    *,
+    include_segment: bool,
+    backend: Backend,
+) -> None:
+    """Merge process segments without creating a new benchmark attempt."""
+
+    resume_count = previous.get("logical_resume_count", 0)
+    if type(resume_count) is not int or resume_count < 0:
+        raise ModuleCheckpointError("logical attempt has an invalid resume count")
+    result["logical_resume_count"] = resume_count + 1
+    if not include_segment:
+        for key in _RUNNER_OWNED_ACCOUNTING_KEYS:
+            if key in previous:
+                result[key] = copy.deepcopy(previous[key])
+            else:
+                result.pop(key, None)
+        for key in _LOGICAL_PROOF_EVIDENCE_KEYS:
+            if key in previous:
+                result[key] = copy.deepcopy(previous[key])
+        _refresh_logical_timeout_remaining(result)
+        return
+
+    previous_has_work = _logical_attempt_has_accounted_work(previous)
+    if not previous_has_work:
+        _refresh_logical_timeout_remaining(result)
+        return
+
+    _ensure_time_breakdown(previous)
+    aggregate_usage = _result_usage_summary(previous).merge(segment_usage)
+    result["usage"] = aggregate_usage.to_dict()
+    result["input_tokens"] = aggregate_usage.legacy_input_tokens
+    result["output_tokens"] = aggregate_usage.legacy_output_tokens
+    result["agent_time_secs"] = _sum_accounting_values(previous.get("agent_time_secs"), result.get("agent_time_secs"))
+    result["grading_time_secs"] = _sum_accounting_values(
+        previous.get("grading_time_secs"), result.get("grading_time_secs")
+    )
+    previous_timeout_used = nonnegative_float(previous.get("logical_timeout_used_secs"))
+    if previous_timeout_used is None:
+        previous_timeout_used = previous.get("agent_time_secs")
+    segment_timeout_used = nonnegative_float(result.get("logical_timeout_used_secs"))
+    if segment_timeout_used is None:
+        segment_timeout_used = result.get("agent_time_secs")
+    result["logical_timeout_used_secs"] = _sum_accounting_values(previous_timeout_used, segment_timeout_used)
+    _recompute_task_time(result)
+    if _supports_cost_time(backend):
+        result["equivalent_cost_usd"] = _sum_accounting_values(
+            previous.get("equivalent_cost_usd"), result.get("equivalent_cost_usd")
+        )
+    if "tool_calls" in previous or "tool_calls" in result:
+        result["tool_calls"] = (
+            toolcalls.ToolCallSummary.from_dict(previous.get("tool_calls"))
+            .merge(toolcalls.ToolCallSummary.from_dict(result.get("tool_calls")))
+            .to_dict()
+        )
+    previous_grader_error_time = nonnegative_float(previous.get("grader_error_time_secs")) or 0.0
+    segment_grader_error_time = nonnegative_float(result.get("grader_error_time_secs")) or 0.0
+    if previous_grader_error_time or segment_grader_error_time:
+        result["grader_error_time_secs"] = previous_grader_error_time + segment_grader_error_time
+    _refresh_logical_timeout_remaining(result)
+
+
+def _logical_attempt_execution_item(item: WorkItem, result: dict[str, object]) -> WorkItem | None:
+    remaining = _remaining_logical_timeout(result, item.timeout)
+    if remaining is not None and remaining <= 0:
+        return None
+    return item if remaining is None else replace(item, timeout=remaining)
+
+
 @dataclass(frozen=True)
 class CanonicalInputs:
     """Task and dependency bytes captured before an agent process can mutate them."""
@@ -971,6 +1180,7 @@ def _run_backend_with_retries(
     canonical_dir = None
     active_secs = 0.0
     attempt_secs: float | None = None
+    attempt_timeout_used_secs: float | None = None
     quota_exhausted = False
     quota_retry_suppressed = False
     infra_retriable = False
@@ -1006,7 +1216,7 @@ def _run_backend_with_retries(
 
             # Defaults keep the closure bound to this attempt.
             def _run_once(workspace=workspace, canonical_dir=canonical_dir):
-                nonlocal active_secs, attempt_secs
+                nonlocal active_secs, attempt_secs, attempt_timeout_used_secs
                 result["error"] = ""
                 # Establish a valid empty-stream marker before process/container
                 # startup. A launch exception is then distinguishable from a
@@ -1046,11 +1256,8 @@ def _run_backend_with_retries(
                         checker_bin,
                         canonical_dir,
                     )
-                elapsed = (
-                    container_agent_secs
-                    if item.use_container and _supports_cost_time(backend)
-                    else time.monotonic() - t0
-                )
+                wall_elapsed = time.monotonic() - t0
+                elapsed = container_agent_secs if item.use_container and _supports_cost_time(backend) else wall_elapsed
                 # Cooperative backends may spend a bounded grace period flushing
                 # audit events after the logical deadline. That is not extra model
                 # time and must not inflate the benchmark runtime metric.
@@ -1061,7 +1268,9 @@ def _run_backend_with_retries(
                     and "timeout after" in result.get("error", "")
                 ):
                     elapsed = min(elapsed, item.timeout)
+                    wall_elapsed = min(wall_elapsed, item.timeout)
                 attempt_secs = elapsed
+                attempt_timeout_used_secs = wall_elapsed
                 if elapsed is not None:
                     active_secs += elapsed
 
@@ -1097,6 +1306,7 @@ def _run_backend_with_retries(
                 prepare_retry=_prepare_quota_retry,
             )
             _set_agent_time(result, attempt_secs if _supports_cost_time(backend) else active_secs)
+            result["logical_timeout_used_secs"] = attempt_timeout_used_secs
 
             # Parse agent output on every path — including quota exhaustion — so
             # the result records any tokens the agent did emit (rather than
@@ -1222,11 +1432,14 @@ def _run_backend_with_retries(
             warnings=("infra/quota accounting is stored separately under agent artifacts",),
         )
         result["agent_time_secs"] = None
+        result["logical_timeout_used_secs"] = 0.0
         result["time_secs"] = None
         result["equivalent_cost_usd"] = None
         result["usage"] = attempt_usage.to_dict()
         result["input_tokens"] = 0
         result["output_tokens"] = 0
+    elif interrupted and not model_work_observed:
+        result["logical_timeout_used_secs"] = 0.0
     outcome_usage = attempt_usage if _supports_cost_time(backend) else (aggregate_usage or attempt_usage)
     return ExecutionOutcome(
         workspace,
@@ -1381,9 +1594,9 @@ def _module_resume_action(result: dict[str, object], *, max_continuations: int) 
 
     A pending-grading marker is written immediately after publishing an
     artifact, so a restart grades those saved bytes before any model call. A
-    completed first attempt is never rewritten as pass@1: remaining work is a
-    continuation, and a fully spent chain is terminal even when it did not
-    pass.
+    completed first attempt is never rewritten as pass@1. An interrupted
+    attempt resumes from its saved bytes with cumulative accounting and only
+    its remaining timeout; it does not gain another attempt or continuation.
     """
 
     if result.get("module_grading_pending") is not None:
@@ -1396,9 +1609,9 @@ def _module_resume_action(result: dict[str, object], *, max_continuations: int) 
     raw_rounds = result.get("continuations")
     rounds = raw_rounds if isinstance(raw_rounds, list) else []
     if rounds and isinstance(rounds[-1], dict) and is_non_genuine(rounds[-1]):
-        # This round did not count as an experiment. It remains visible until
-        # the retry starts, then _run_continuations archives it while reusing
-        # the same formal round number and continuation budget slot.
+        # Resume the same logical round and budget slot. Its prior process
+        # segment remains visible for diagnostics, while accounting and timeout
+        # stay cumulative on the active round.
         return MODULE_RESUME_CONTINUE
 
     if len(rounds) < max_continuations:
@@ -2124,7 +2337,9 @@ def run_single_benchmark(item: WorkItem):
         "check_verdict": "ERROR",
         "agent_time_secs": None if _supports_cost_time(backend) else 0,
         "grading_time_secs": 0.0,
+        "logical_timeout_used_secs": 0.0,
         "time_secs": None if _supports_cost_time(backend) else 0,
+        "logical_timeout_secs": item.timeout,
         "error": "",
         # Skill availability, not evidence that the client invoked a skill.
         "agent_skills": [],
@@ -2135,11 +2350,17 @@ def run_single_benchmark(item: WorkItem):
         **backend.initial_result_metadata(),
     }
     module_resume = item.module_resume
-    restored_result = module_resume is not None and module_resume.action in {
+    recovered_result = module_resume is not None and module_resume.action in {
+        MODULE_RESUME_RETRY_FIRST,
         MODULE_RESUME_GRADE_SAVED,
         MODULE_RESUME_CONTINUE,
     }
-    if restored_result:
+    control_flow_resume = module_resume is not None and module_resume.action in {
+        MODULE_RESUME_GRADE_SAVED,
+        MODULE_RESUME_CONTINUE,
+    }
+    retrying_first_attempt = module_resume is not None and module_resume.action == MODULE_RESUME_RETRY_FIRST
+    if recovered_result:
         result = copy.deepcopy(module_resume.result)
     module_spec_loader = getattr(mode, "module_task_spec", None)
     if module_spec_loader is not None:
@@ -2157,11 +2378,11 @@ def run_single_benchmark(item: WorkItem):
     if item.run_identity is not None:
         result["corpus_digest"] = item.run_identity["corpus_digest"]
         result["proof_library_digest"] = item.run_identity["proof_library_digest"]
-    if _supports_cost_time(backend) and not restored_result:
+    if _supports_cost_time(backend) and not recovered_result:
         result["equivalent_cost_usd"] = None
     # Usage is runner-owned structured evidence; backend metadata must not
     # accidentally replace it with a similarly named custom field.
-    if not restored_result:
+    if not recovered_result:
         result["usage"] = UsageSummary(
             input_tokens=0,
             output_tokens=0,
@@ -2170,7 +2391,7 @@ def run_single_benchmark(item: WorkItem):
             available=True,
             complete=True,
         ).to_dict()
-    if item.max_continuations > 0 and not restored_result:
+    if item.max_continuations > 0 and not recovered_result:
         # Run-level config, stamped on EVERY result — first-attempt PASSes and
         # non-genuine early exits included — so the continuation metric can
         # state its ≤N budget without guessing from the chains that happened to run.
@@ -2182,10 +2403,19 @@ def run_single_benchmark(item: WorkItem):
         skills_snapshot_dir,
         item.agent_skills_snapshot,
     )
-    if not restored_result:
+    if not recovered_result:
         result["agent_skills"] = current_agent_skills
 
-    grading_only_resume = restored_result and module_resume.action == MODULE_RESUME_GRADE_SAVED
+    logical_execution_item = item
+    if retrying_first_attempt:
+        maybe_item = _logical_attempt_execution_item(item, result)
+        if maybe_item is None:
+            _mark_logical_attempt_timeout(result)
+            _persist_work_item_result(item, result_dir, result)
+            return result
+        logical_execution_item = maybe_item
+
+    grading_only_resume = control_flow_resume and module_resume.action == MODULE_RESUME_GRADE_SAVED
     quota_available = grading_only_resume or quota.wait_for_quota(
         item.usage_script,
         item.quota_5h,
@@ -2194,7 +2424,7 @@ def run_single_benchmark(item: WorkItem):
         log_prefix=f"[{name_no_ext}] ",
     )
     if not quota_available:
-        if restored_result:
+        if recovered_result:
             _persist_work_item_result(item, result_dir, result)
             return result
         result["agent_exit"] = -3
@@ -2221,7 +2451,7 @@ def run_single_benchmark(item: WorkItem):
         if module_resume is not None and module_resume.submission is not None:
             _write_bytes(os.path.join(input_dir, "resume.tla"), module_resume.submission)
 
-        if restored_result:
+        if control_flow_resume:
             workspace = _make_workspace(
                 backend.name,
                 name_no_ext,
@@ -2293,8 +2523,11 @@ def run_single_benchmark(item: WorkItem):
         # Infra retry loop: a run cut short before the model did ANY work says
         # nothing about the model, so it is retried on a fresh workspace instead
         # of graded. Structured usage is authoritative when available.
+        previous_logical_attempt = copy.deepcopy(result) if retrying_first_attempt else None
+        if previous_logical_attempt is not None:
+            _reset_logical_attempt_segment(result, backend)
         run = _run_backend_with_retries(
-            item,
+            logical_execution_item,
             prompt,
             agent_dir,
             agent_jsonl,
@@ -2308,6 +2541,16 @@ def run_single_benchmark(item: WorkItem):
         )
         workspace, canonical_dir = run.workspace, run.canonical_dir
         attempt_interrupted = run.quota_exhausted or result.get("termination_reason") == TerminationReason.INFRA_ERROR
+        if previous_logical_attempt is not None:
+            _merge_logical_attempt_accounting(
+                result,
+                previous_logical_attempt,
+                run.usage,
+                include_segment=run.model_work_observed or not attempt_interrupted,
+                backend=backend,
+            )
+        else:
+            _refresh_logical_timeout_remaining(result)
         interrupted_after_model_work = run.model_work_observed and attempt_interrupted
         if interrupted_after_model_work:
             # The flag is checkpointed with a pending artifact. It only makes
@@ -2354,9 +2597,9 @@ def run_single_benchmark(item: WorkItem):
                     if not _persist_work_item_result(item, result_dir, result):
                         return result
                 elif module_submission_failure is not None and interrupted_after_model_work:
-                    # Missing/empty output after observed model work is a real,
-                    # paid invalid attempt. It has no bytes to grade, but resume
-                    # must consume it instead of replaying pass@1.
+                    # Missing/empty output after observed model work has no new
+                    # bytes to grade. Keep the marker so resume retains its
+                    # accounting while continuing the same logical pass@1.
                     result.pop("graded_after_interruption", None)
                     result["invalid_submission_after_interruption"] = True
             except (OSError, ModuleArtifactError) as exc:
@@ -2595,9 +2838,9 @@ def _run_continuations(
     the partial proof is still there — with a continuation prompt telling it to
     build on that prior work, then re-grades; rounds stop at the first PASS, at
     the --max-continuations budget, or when a round is cut short by infra/quota.
-    A chain cut short is interrupted, not failed: scoring excludes it from the
-    continuation rate (see score.continuation_interrupted) and --resume reruns
-    the benchmark.
+    A cut round is unresolved: scoring excludes it, and --resume continues that
+    same logical round with its saved proof, accumulated accounting, and
+    remaining timeout.
 
     The top-level result keeps the FIRST attempt's verdict, so pass@1 is
     reported unchanged; each round's verdict/cost is appended to
@@ -2612,12 +2855,14 @@ def _run_continuations(
     agent_check_file = os.path.join(workspace, name_no_ext + ".result")
     rounds: list[dict] = result.setdefault("continuations", [])
     retry_round = None
+    retry_attempt: dict[str, object] | None = None
     if rounds and is_non_genuine(rounds[-1]):
         interrupted = rounds.pop()
         retry_round = interrupted.get("round")
         if type(retry_round) is not int or retry_round <= 0:
             raise ModuleCheckpointError("interrupted continuation has no valid round number")
         result.setdefault("interrupted_continuations", []).append(interrupted)
+        retry_attempt = copy.deepcopy(interrupted)
     first_round = retry_round if retry_round is not None else len(rounds) + 1
     for rnd in range(first_round, item.max_continuations + 1):
         prev_verdict = rounds[-1]["check_verdict"] if rounds else result["check_verdict"]
@@ -2631,23 +2876,40 @@ def _run_continuations(
             f.write(prompt)
         agent_jsonl = os.path.join(round_dir, "output.jsonl")
         agent_stderr = os.path.join(round_dir, "stderr.txt")
-        round_result = {
-            "round": rnd,
-            "agent_exit": -1,
-            "check_verdict": "ERROR",
-            "agent_time_secs": 0,
-            "grading_time_secs": 0.0,
-            "time_secs": 0,
-            "error": "",
-            "termination_reason": TerminationReason.OK,
-        }
+        previous_logical_attempt = retry_attempt if retry_attempt is not None and retry_round == rnd else None
+        execution_item = item
+        if previous_logical_attempt is not None:
+            round_result = copy.deepcopy(previous_logical_attempt)
+            maybe_item = _logical_attempt_execution_item(item, round_result)
+            if maybe_item is None:
+                _mark_logical_attempt_timeout(round_result)
+                rounds.append(round_result)
+                if item.module_checkpoint_identity is not None:
+                    _persist_work_item_result(item, result_dir, result)
+                break
+            execution_item = maybe_item
+            _reset_logical_attempt_segment(round_result, item.backend)
+            retry_attempt = None
+        else:
+            round_result = {
+                "round": rnd,
+                "agent_exit": -1,
+                "check_verdict": "ERROR",
+                "agent_time_secs": 0,
+                "grading_time_secs": 0.0,
+                "logical_timeout_used_secs": 0.0,
+                "time_secs": 0,
+                "logical_timeout_secs": item.timeout,
+                "error": "",
+                "termination_reason": TerminationReason.OK,
+            }
         # The in-workspace self-check file survives from the previous round (the
         # agent may want to read what failed), so note its state to copy it as
         # this round's evidence only if this round's agent (re)wrote it.
         check_mtime_before = os.stat(agent_check_file).st_mtime_ns if os.path.isfile(agent_check_file) else None
 
         run = _run_backend_with_retries(
-            item,
+            execution_item,
             prompt,
             round_dir,
             agent_jsonl,
@@ -2664,6 +2926,10 @@ def _run_continuations(
             round_result["usage"] = round_usage.to_dict()
             round_result["input_tokens"] = round_usage.legacy_input_tokens
             round_result["output_tokens"] = round_usage.legacy_output_tokens
+            segment_agent_time = round_result.get("agent_time_secs")
+            segment_grading_time = round_result.get("grading_time_secs")
+            segment_equivalent_cost = round_result.get("equivalent_cost_usd")
+            segment_tool_calls = copy.deepcopy(round_result.get("tool_calls"))
             if run.quota_exhausted:
                 round_result["agent_exit"] = -3
                 round_result["error"] = (
@@ -2678,6 +2944,16 @@ def _run_continuations(
             round_interrupted = (
                 run.quota_exhausted or round_result.get("termination_reason") == TerminationReason.INFRA_ERROR
             )
+            if previous_logical_attempt is not None:
+                _merge_logical_attempt_accounting(
+                    round_result,
+                    previous_logical_attempt,
+                    round_usage,
+                    include_segment=run.model_work_observed or not round_interrupted,
+                    backend=item.backend,
+                )
+            else:
+                _refresh_logical_timeout_remaining(round_result)
 
             formal_round = not round_interrupted or (
                 item.module_checkpoint_identity is not None and run.model_work_observed
@@ -2688,22 +2964,22 @@ def _run_continuations(
                 if "tool_calls" in result or "tool_calls" in round_result:
                     result["tool_calls"] = (
                         toolcalls.ToolCallSummary.from_dict(result.get("tool_calls"))
-                        .merge(toolcalls.ToolCallSummary.from_dict(round_result.get("tool_calls")))
+                        .merge(toolcalls.ToolCallSummary.from_dict(segment_tool_calls))
                         .to_dict()
                     )
                 result["agent_time_secs"] = _sum_accounting_values(
                     result.get("agent_time_secs"),
-                    round_result.get("agent_time_secs"),
+                    segment_agent_time,
                 )
                 result["grading_time_secs"] = _sum_accounting_values(
                     result.get("grading_time_secs"),
-                    round_result.get("grading_time_secs"),
+                    segment_grading_time,
                 )
                 _recompute_task_time(result)
                 if _supports_cost_time(item.backend):
                     result["equivalent_cost_usd"] = _sum_accounting_values(
                         result.get("equivalent_cost_usd"),
-                        round_result.get("equivalent_cost_usd"),
+                        segment_equivalent_cost,
                     )
                 result["input_tokens"] = aggregate_usage.legacy_input_tokens
                 result["output_tokens"] = aggregate_usage.legacy_output_tokens

--- a/src/evaluator/runner.py
+++ b/src/evaluator/runner.py
@@ -2407,13 +2407,17 @@ def run_single_benchmark(item: WorkItem):
         result["agent_skills"] = current_agent_skills
 
     logical_execution_item = item
+    first_attempt_timeout_exhausted = False
     if retrying_first_attempt:
         maybe_item = _logical_attempt_execution_item(item, result)
         if maybe_item is None:
             _mark_logical_attempt_timeout(result)
-            _persist_work_item_result(item, result_dir, result)
-            return result
-        logical_execution_item = maybe_item
+            if item.max_continuations <= 0:
+                _persist_work_item_result(item, result_dir, result)
+                return result
+            first_attempt_timeout_exhausted = True
+        else:
+            logical_execution_item = maybe_item
 
     grading_only_resume = control_flow_resume and module_resume.action == MODULE_RESUME_GRADE_SAVED
     quota_available = grading_only_resume or quota.wait_for_quota(
@@ -2450,6 +2454,30 @@ def run_single_benchmark(item: WorkItem):
         canonical_inputs.materialize(input_dir, target_name="benchmark.tla")
         if module_resume is not None and module_resume.submission is not None:
             _write_bytes(os.path.join(input_dir, "resume.tla"), module_resume.submission)
+
+        if first_attempt_timeout_exhausted:
+            workspace = _make_workspace(
+                backend.name,
+                name_no_ext,
+                canonical_inputs,
+                skills_snapshot_dir=skills_snapshot_dir,
+                project_skills_dir=backend.project_skills_dir,
+                read_only_dependencies=getattr(mode, "read_only_dependencies", False),
+                initial_target_bytes=module_resume.submission,
+            )
+            if not _persist_work_item_result(item, result_dir, result):
+                return result
+            _run_continuations(
+                item,
+                workspace,
+                result,
+                result_dir,
+                basename,
+                name_no_ext,
+                canonical_inputs,
+                checker_bin,
+            )
+            return result
 
         if control_flow_resume:
             workspace = _make_workspace(
@@ -2599,7 +2627,8 @@ def run_single_benchmark(item: WorkItem):
                 elif module_submission_failure is not None and interrupted_after_model_work:
                     # Missing/empty output after observed model work has no new
                     # bytes to grade. Keep the marker so resume retains its
-                    # accounting while continuing the same logical pass@1.
+                    # accounting while continuing the same logical pass@1; an
+                    # existing module_artifact remains the durable fallback.
                     result.pop("graded_after_interruption", None)
                     result["invalid_submission_after_interruption"] = True
             except (OSError, ModuleArtifactError) as exc:
@@ -2885,8 +2914,10 @@ def _run_continuations(
                 _mark_logical_attempt_timeout(round_result)
                 rounds.append(round_result)
                 if item.module_checkpoint_identity is not None:
-                    _persist_work_item_result(item, result_dir, result)
-                break
+                    if not _persist_work_item_result(item, result_dir, result):
+                        break
+                retry_attempt = None
+                continue
             execution_item = maybe_item
             _reset_logical_attempt_segment(round_result, item.backend)
             retry_attempt = None

--- a/src/evaluator/score.py
+++ b/src/evaluator/score.py
@@ -712,10 +712,7 @@ def comparison_md(
             if unit_score.excluded_modules:
                 unit_cell += f" (+{unit_score.excluded_modules} excluded)"
             score_cells = f"{unit_cell} | {score_cells}"
-        row = (
-            f"| {run['id']} | {run['backend']} | {run['mode']} | {score_cells} | "
-            f"{format_token_usage(tokens)} | "
-        )
+        row = f"| {run['id']} | {run['backend']} | {run['mode']} | {score_cells} | {format_token_usage(tokens)} | "
         if show_equivalent_cost:
             time_text = _format_time(secs)
             row += f"{time_text} | {_format_cost(equivalent_cost_usd)} |"

--- a/src/evaluator/score.py
+++ b/src/evaluator/score.py
@@ -6,8 +6,9 @@ offline — no network, no API keys — so metrics can be (re)computed cheaply
 without re-running the (expensive) agents.
 
 PASS/FAIL: a task counts as passed iff its ``check_verdict`` is exactly
-``"PASS"``. Every other verdict — FAIL, CHEATING, TIMEOUT, ERROR — counts as
-not passed. CHEATING is not a separate category here: a cheat is just a failure.
+``"PASS"``. FAIL, CHEATING, and TIMEOUT count as not passed. ERROR means the
+grader or its infrastructure did not produce a capability result, so it is
+excluded and must be retried.
 
 SKIP is one exception: an operator marks a benchmark ``SKIP`` to exclude it from
 scoring (e.g. a theorem known to time out for reasons outside the agent's
@@ -15,12 +16,11 @@ control). A skipped task is in neither the numerator nor the denominator — it 
 dropped from the pass rate entirely, not counted as a failure — and the count is
 reported separately so nothing is hidden.
 
-Non-genuine runs are the other exception: a result whose ``termination_reason``
-is ``INFRA_ERROR`` or ``QUOTA_EXHAUSTED`` was cut short by infrastructure or a
-provider cap, so the verdict is not a capability signal. These are excluded from
-the numerator and denominator — like SKIP — and reported separately as needing a
-re-run. TIMEOUT is a limit, not infrastructure: the agent worked and is graded on
-what it left in the workspace, so it stays scored.
+Non-genuine runs are the other exception: ERROR and an unresolved result whose
+``termination_reason`` is ``INFRA_ERROR`` or ``QUOTA_EXHAUSTED`` are not
+capability signals. These are excluded from the numerator and denominator and
+reported as needing a re-run. A verified PASS after an interruption still
+counts. Declared agent/checker TIMEOUT is a benchmark limit, so it stays scored.
 
 Continuations (``tlaps-bench run --max-continuations``) are a separate metric,
 never a replacement: ``check_verdict`` always holds the FIRST attempt's verdict,
@@ -29,7 +29,7 @@ so the pass rate above stays pass@1. When a run recorded continuation rounds
 rate is reported (with the run's ≤N budget), counting a task as passed if any
 round reached PASS — the gap between the two is how often a first-attempt
 failure was an early stop rather than an inability. A chain cut short by
-infra/quota before resolving is interrupted, not failed: like a non-genuine
+infrastructure/provider interruption before resolving is not failed: like a non-genuine
 first attempt it is excluded from the continuation rate and reported separately
 (see ``continuation_interrupted``).
 
@@ -63,6 +63,7 @@ from pathlib import Path
 from common.proof_from_scratch_manifest import load_module_task_manifest
 from common.task_contract import load_manifest_specification_ids
 from evaluator.proof_module_result import ModuleResultError, validate_module_result
+from evaluator.usage import TokenUsage, aggregate_token_usage, format_token_usage
 
 PASS_VERDICT = "PASS"
 SKIP_VERDICT = "SKIP"
@@ -121,16 +122,12 @@ def is_skipped(result: dict) -> bool:
 
 
 def is_non_genuine(result: dict) -> bool:
-    """A run cut short by infra/quota. Missing termination_reason means legacy
-    result files stay scored. A last-saved module that was successfully graded
-    after model work remains a genuine capability result despite the external
-    interruption that ended its agent process."""
-    interrupted = result.get("termination_reason") in NON_GENUINE_TERMINATIONS
-    graded_progress = result.get("graded_after_interruption") is True and isinstance(result.get("module_result"), dict)
-    invalid_submission = (
-        result.get("invalid_submission_after_interruption") is True and result.get("check_verdict") == "FAIL"
-    )
-    return interrupted and not (graded_progress or invalid_submission)
+    """Whether a result lacks a benchmark capability verdict and needs retry."""
+
+    verdict = result.get("check_verdict")
+    if verdict == "ERROR":
+        return True
+    return result.get("termination_reason") in NON_GENUINE_TERMINATIONS and verdict != PASS_VERDICT
 
 
 def continuation_passed(result: dict) -> bool:
@@ -183,7 +180,7 @@ def continuation_rate_line(results: list[dict], weight: Callable[[dict], float],
     )
     n_cut = sum(1 for r in results if continuation_interrupted(r))
     if n_cut:
-        line += f" · {n_cut} chain(s) infra/quota-cut (excluded — re-run)"
+        line += f" · {n_cut} chain(s) interrupted (excluded — re-run)"
     return line
 
 
@@ -300,7 +297,7 @@ def specification_equal_score(
     active versioned manifest. Results for tasks removed from a later manifest
     are excluded and counted as non-applicable. Active manifest entries without
     a specification identity are invalid and fail before any score is returned.
-    SKIP and infra/quota-cut results are excluded by the existing score policy.
+    SKIP and non-genuine results are excluded by the existing score policy.
     """
 
     _validate_specification_ids(specification_ids)
@@ -367,7 +364,7 @@ def specification_score_lines(
     if skipped:
         task_line += f" · {skipped} skipped"
     if non_genuine:
-        task_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
+        task_line += f" · {non_genuine} error/interrupted (excluded — re-run)"
 
     specification_word = "specification" if score.represented_specifications == 1 else "specifications"
     lines = [
@@ -482,15 +479,16 @@ def _has_equivalent_cost(results: list[dict]) -> bool:
     return any("equivalent_cost_usd" in result for result in results)
 
 
-def _totals(results: list[dict]) -> tuple[int, int, float | None, float | None]:
-    in_tok = sum(r.get("input_tokens", 0) for r in results)
-    out_tok = sum(r.get("output_tokens", 0) for r in results)
-    if not _has_equivalent_cost(results):
-        return in_tok, out_tok, sum(r.get("time_secs", 0) for r in results), None
+def _totals(
+    results: list[dict],
+) -> tuple[TokenUsage, float | None, float | None, float | None, float | None]:
+    tokens = aggregate_token_usage(results)
     formal = [result for result in results if not is_skipped(result) and not is_non_genuine(result)]
-    secs = _sum_metric(formal, "time_secs")
-    equivalent_cost_usd = _sum_metric(formal, "equivalent_cost_usd")
-    return in_tok, out_tok, secs, equivalent_cost_usd
+    agent_secs = _sum_metric(formal, "agent_time_secs")
+    grading_secs = _sum_metric(formal, "grading_time_secs")
+    total_secs = _sum_metric(formal, "time_secs")
+    equivalent_cost_usd = _sum_metric(formal, "equivalent_cost_usd") if _has_equivalent_cost(results) else None
+    return tokens, agent_secs, grading_secs, total_secs, equivalent_cost_usd
 
 
 def _cost_warnings(results: list[dict]) -> list[tuple[str, str]]:
@@ -533,7 +531,7 @@ def scorecard_md(
     results = run["results"]
     scoring_results = results if specification_ids is None else applicable_manifest_results(results, specification_ids)
     pct, n_pass, n_total = weighted_score(scoring_results, weight)
-    in_tok, out_tok, secs, equivalent_cost_usd = _totals(results)
+    tokens, agent_secs, grading_secs, secs, equivalent_cost_usd = _totals(results)
     has_equivalent_cost = _has_equivalent_cost(results)
 
     lines = [
@@ -553,7 +551,7 @@ def scorecard_md(
         if skipped:
             pass_line += f" · {skipped} skipped"
         if non_genuine:
-            pass_line += f" · {non_genuine} infra/quota-cut (excluded — re-run)"
+            pass_line += f" · {non_genuine} error/interrupted (excluded — re-run)"
         lines.append(pass_line)
     else:
         score_lines, specification_score = specification_score_lines(results, specification_ids)
@@ -567,12 +565,12 @@ def scorecard_md(
     continuation_unit_line = proof_unit_rate_line(scoring_results, with_continuations=True)
     if continuation_unit_line and any(result.get("continuations") for result in scoring_results):
         lines.append(continuation_unit_line)
+    lines.append(f"**Tokens**: {format_token_usage(tokens, verbose=True)}")
+    lines.append(f"**Total agent time**: {_format_time(agent_secs)}")
+    lines.append(f"**Total grading time**: {_format_time(grading_secs)}")
+    lines.append(f"**Total task time**: {_format_time(secs)}")
     if has_equivalent_cost:
-        lines.append(f"**Tokens**: {in_tok:,} in / {out_tok:,} out")
-        lines.append(f"**Total task time**: {_format_time(secs)}")
         lines.append(f"**Equivalent cost**: {_format_cost(equivalent_cost_usd)}")
-    else:
-        lines.append(f"**Cost**: {in_tok:,} in / {out_tok:,} out tokens · {secs:,.0f}s total")
     if scoring_name not in {"equal", SPECIFICATION_EQUAL}:
         lines.append(f"**Scoring**: {scoring_name} (weighted)")
 
@@ -667,7 +665,7 @@ def comparison_md(
         pct, n_pass, n_total = weighted_score(scoring_results, weight)
         if specification_ids is not None:
             specification_score = specification_equal_score(results, specification_ids)
-        in_tok, out_tok, secs, equivalent_cost_usd = _totals(run["results"])
+        tokens, _agent_secs, _grading_secs, secs, equivalent_cost_usd = _totals(run["results"])
         run_has_equivalent_cost = _has_equivalent_cost(run["results"])
         if show_equivalent_cost and not run_has_equivalent_cost and run["backend"] in COST_TIME_BACKENDS:
             formal = [result for result in run["results"] if not is_skipped(result) and not is_non_genuine(result)]
@@ -678,7 +676,7 @@ def comparison_md(
             score_notes += f" (+{skipped} skipped)"
         non_genuine = n_non_genuine(scoring_results)
         if non_genuine:
-            score_notes += f" (+{non_genuine} infra-cut)"
+            score_notes += f" (+{non_genuine} error/interrupted)"
         if any(r.get("continuations") for r in scoring_results):
             _, cn_pass, _ = weighted_score(scoring_results, weight, passed=is_pass_with_continuations)
             # Name the budget: +1 recovery out of ≤1 round and out of ≤10 are
@@ -714,16 +712,15 @@ def comparison_md(
             if unit_score.excluded_modules:
                 unit_cell += f" (+{unit_score.excluded_modules} excluded)"
             score_cells = f"{unit_cell} | {score_cells}"
-        row = f"| {run['id']} | {run['backend']} | {run['mode']} | {score_cells} | {in_tok:,}/{out_tok:,} | "
+        row = (
+            f"| {run['id']} | {run['backend']} | {run['mode']} | {score_cells} | "
+            f"{format_token_usage(tokens)} | "
+        )
         if show_equivalent_cost:
-            time_text = (
-                _format_time(secs)
-                if run_has_equivalent_cost or run["backend"] in COST_TIME_BACKENDS
-                else f"{secs:,.0f}s"
-            )
+            time_text = _format_time(secs)
             row += f"{time_text} | {_format_cost(equivalent_cost_usd)} |"
         else:
-            row += f"{secs:,.0f}s |"
+            row += f"{_format_time(secs)} |"
         lines.append(row)
     lines.append("")
     warnings = [

--- a/src/evaluator/score.py
+++ b/src/evaluator/score.py
@@ -93,8 +93,15 @@ class SpecificationScore:
     tasks_passed: int
     applicable_tasks: int
     complete_specifications: int
+    failed_specifications: int
+    unresolved_specifications: int
+    error_affected_specifications: int
     represented_specifications: int
     non_applicable_results: int
+
+    @property
+    def resolved_specifications(self) -> int:
+        return self.complete_specifications + self.failed_specifications
 
 
 @dataclass(frozen=True)
@@ -309,27 +316,39 @@ def specification_equal_score(
         if key is None or key not in specification_ids:
             non_applicable += 1
             continue
-        if is_skipped(result) or is_non_genuine(result):
+        if is_skipped(result):
             continue
         by_specification[(key[0], specification_ids[key])].append(result)
 
-    applicable = [result for grouped in by_specification.values() for result in grouped]
+    applicable = [result for grouped in by_specification.values() for result in grouped if not is_non_genuine(result)]
     tasks_passed = sum(1 for result in applicable if passed(result))
     applicable_tasks = len(applicable)
     task_micro_pct = 100.0 * tasks_passed / applicable_tasks if applicable_tasks else 0.0
 
-    spec_fractions = [
-        sum(1 for result in grouped if passed(result)) / len(grouped) for grouped in by_specification.values()
-    ]
-    represented_specifications = len(spec_fractions)
-    specification_macro_pct = (
-        100.0 * sum(spec_fractions) / represented_specifications if represented_specifications else 0.0
-    )
-    complete_specifications = sum(
-        1 for grouped in by_specification.values() if all(passed(result) for result in grouped)
-    )
+    complete_specifications = 0
+    failed_specifications = 0
+    unresolved_specifications = 0
+    error_affected_specifications = 0
+    spec_fractions: list[float] = []
+    for grouped in by_specification.values():
+        resolved = [result for result in grouped if not is_non_genuine(result)]
+        affected = len(resolved) != len(grouped)
+        if affected:
+            error_affected_specifications += 1
+        if any(not passed(result) for result in resolved):
+            failed_specifications += 1
+            spec_fractions.append(sum(1 for result in resolved if passed(result)) / len(resolved))
+        elif affected:
+            unresolved_specifications += 1
+        else:
+            complete_specifications += 1
+            spec_fractions.append(1.0)
+
+    represented_specifications = len(by_specification)
+    resolved_specifications = complete_specifications + failed_specifications
+    specification_macro_pct = 100.0 * sum(spec_fractions) / resolved_specifications if resolved_specifications else 0.0
     specification_pass_pct = (
-        100.0 * complete_specifications / represented_specifications if represented_specifications else 0.0
+        100.0 * complete_specifications / resolved_specifications if resolved_specifications else 0.0
     )
     return SpecificationScore(
         specification_pass_pct=specification_pass_pct,
@@ -338,6 +357,9 @@ def specification_equal_score(
         tasks_passed=tasks_passed,
         applicable_tasks=applicable_tasks,
         complete_specifications=complete_specifications,
+        failed_specifications=failed_specifications,
+        unresolved_specifications=unresolved_specifications,
+        error_affected_specifications=error_affected_specifications,
         represented_specifications=represented_specifications,
         non_applicable_results=non_applicable,
     )
@@ -366,15 +388,24 @@ def specification_score_lines(
     if non_genuine:
         task_line += f" · {non_genuine} error/interrupted (excluded — re-run)"
 
-    specification_word = "specification" if score.represented_specifications == 1 else "specifications"
+    resolved_word = "specification" if score.resolved_specifications == 1 else "specifications"
     lines = [
         f"**Specification pass rate (all leaves complete)**: "
-        f"{score.complete_specifications}/{score.represented_specifications} "
-        f"{specification_word} ({score.specification_pass_pct:.1f}%)",
+        f"{score.complete_specifications}/{score.resolved_specifications} resolved "
+        f"{resolved_word} ({score.specification_pass_pct:.1f}%)",
         task_line,
         f"**Specification-macro pass rate**: {score.specification_macro_pct:.1f}% "
-        f"across {score.represented_specifications} {specification_word}",
+        f"across {score.resolved_specifications} resolved {resolved_word}",
     ]
+    if score.unresolved_specifications:
+        lines.append(
+            f"**Unresolved specifications**: {score.unresolved_specifications} excluded until their errors are retried"
+        )
+    if score.error_affected_specifications:
+        lines.append(
+            f"**Specifications affected by errors**: {score.error_affected_specifications} contain excluded "
+            "ERROR/interrupted leaves"
+        )
     if score.non_applicable_results:
         lines.append(
             f"**Non-applicable results**: {score.non_applicable_results} not present in the active manifest (excluded)"
@@ -697,11 +728,13 @@ def comparison_md(
                 score_notes += f" (+{specification_score.non_applicable_results} non-applicable)"
             score_cells = (
                 f"{specification_score.complete_specifications}/"
-                f"{specification_score.represented_specifications} "
+                f"{specification_score.resolved_specifications} "
                 f"({specification_score.specification_pass_pct:.1f}%) | "
                 f"{n_pass}/{n_total} ({specification_score.task_micro_pct:.1f}%){score_notes} | "
                 f"{specification_score.specification_macro_pct:.1f}%"
             )
+            if specification_score.unresolved_specifications:
+                score_cells += f" (+{specification_score.unresolved_specifications} unresolved specification(s))"
         if show_proof_units:
             unit_score = proof_unit_score(scoring_results)
             unit_cell = (

--- a/src/evaluator/usage.py
+++ b/src/evaluator/usage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -513,3 +514,57 @@ class UsageSummary:
             "requests": [request.to_dict() for request in self.requests],
             "warnings": list(self.warnings),
         }
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    """Display-safe core token totals without converting unknown data to zero."""
+
+    input_tokens: int | None
+    output_tokens: int | None
+    is_lower_bound: bool = False
+
+    @property
+    def available(self) -> bool:
+        return self.input_tokens is not None and self.output_tokens is not None
+
+
+def result_token_usage(result: Mapping[str, object]) -> TokenUsage:
+    """Read structured usage when present, falling back to legacy result fields."""
+
+    raw_usage = result.get("usage")
+    if isinstance(raw_usage, dict) and any(
+        field in raw_usage for field in ("status", "available", "input_tokens", "output_tokens")
+    ):
+        usage = UsageSummary.from_dict(raw_usage)
+        if not usage.available or usage.input_tokens is None or usage.output_tokens is None:
+            return TokenUsage(None, None)
+        return TokenUsage(usage.input_tokens, usage.output_tokens, usage.is_lower_bound)
+
+    input_tokens = nonnegative_int(result.get("input_tokens"))
+    output_tokens = nonnegative_int(result.get("output_tokens"))
+    return TokenUsage(input_tokens, output_tokens)
+
+
+def aggregate_token_usage(results: list[Mapping[str, object]]) -> TokenUsage:
+    """Sum token usage only when every result has usable core-token evidence."""
+
+    usages = [result_token_usage(result) for result in results]
+    if any(not usage.available for usage in usages):
+        return TokenUsage(None, None)
+    return TokenUsage(
+        sum(usage.input_tokens for usage in usages if usage.input_tokens is not None),
+        sum(usage.output_tokens for usage in usages if usage.output_tokens is not None),
+        any(usage.is_lower_bound for usage in usages),
+    )
+
+
+def format_token_usage(usage: TokenUsage, *, verbose: bool = False) -> str:
+    """Format exact, lower-bound, and unavailable usage without ambiguity."""
+
+    if not usage.available:
+        return "unavailable"
+    prefix = "at least " if verbose and usage.is_lower_bound else "≥" if usage.is_lower_bound else ""
+    if verbose:
+        return f"{prefix}{usage.input_tokens:,} input / {usage.output_tokens:,} output"
+    return f"{prefix}{usage.input_tokens:,}/{usage.output_tokens:,}"

--- a/tests/common/test_check_proof_module_task.py
+++ b/tests/common/test_check_proof_module_task.py
@@ -153,6 +153,11 @@ def test_module_check_reports_raw_results_and_dependency_closed_trust(tmp_path, 
         HELPER: "PASS",
     }
     assert all(unit["trusted"] for unit in units.values())
+    assert {unit_id: unit["obligations"] for unit_id, unit in units.items()} == {
+        UNIT_A: 1,
+        UNIT_B: 1,
+        HELPER: 1,
+    }
     validate_module_result(report, (UNIT_A, UNIT_B))
 
 

--- a/tests/evaluator/test_continuation.py
+++ b/tests/evaluator/test_continuation.py
@@ -383,6 +383,19 @@ def test_round_quota_exhaustion_stops_chain(tmp_path, monkeypatch):
     assert len(result["continuations"]) == 1
 
 
+def test_round_grader_error_stops_chain_instead_of_consuming_more_budget(tmp_path, monkeypatch):
+    backend = _ScriptedBackend()
+    agent = _install_agent(monkeypatch, backend, [GENUINE, GENUINE])
+    grader = _install_grader(monkeypatch, ["FAIL", "ERROR"])
+
+    result = runner.run_single_benchmark(_work_item(tmp_path, backend, max_continuations=3))
+
+    assert agent["n"] == 2
+    assert grader["n"] == 2
+    assert [round_result["check_verdict"] for round_result in result["continuations"]] == ["ERROR"]
+    assert result["continuations"][0]["grader_error_time_secs"] > 0
+
+
 def test_stale_agent_check_not_copied_into_round(tmp_path, monkeypatch):
     # The in-workspace self-check file survives across rounds (useful context
     # for the agent), but a round's agent_check.result artifact must only
@@ -638,6 +651,6 @@ def test_summary_excludes_interrupted_chains_from_continuation_rate(tmp_path):
     assert "**Pass rate**: 0/3 (0.0%)" in summary  # cut-chain's genuine first FAIL stays scored
     assert (
         "**Task-micro pass rate with continuations (≤3)**: 1/2 (50.0%) — 1 recovered by continuation "
-        "(pass@1 above is first-attempt only) · 1 chain(s) infra/quota-cut (excluded — re-run)"
+        "(pass@1 above is first-attempt only) · 1 chain(s) interrupted (excluded — re-run)"
     ) in summary
     assert "continuation chain cut at round 1 (excluded — re-run)" in summary  # per-row note discloses too

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -240,9 +240,9 @@ def test_summary_uses_strict_specification_pass_rate_as_primary_for_manifest_sui
     )
 
     summary = (tmp_path / "summary.md").read_text()
-    primary = "**Specification pass rate (all leaves complete)**: 1/2 specifications (50.0%)"
+    primary = "**Specification pass rate (all leaves complete)**: 1/2 resolved specifications (50.0%)"
     task_level = "**Task-micro pass rate**: 2/3 (66.7%)"
-    specification_macro = "**Specification-macro pass rate**: 75.0% across 2 specifications"
+    specification_macro = "**Specification-macro pass rate**: 75.0% across 2 resolved specifications"
     assert primary in summary
     assert task_level in summary
     assert specification_macro in summary

--- a/tests/evaluator/test_infra_retry.py
+++ b/tests/evaluator/test_infra_retry.py
@@ -187,12 +187,16 @@ def _result(benchmark, verdict, termination_reason="OK", **kw):
     out = {
         "benchmark": benchmark,
         "check_verdict": verdict,
+        "agent_time_secs": 0,
+        "grading_time_secs": 0,
         "time_secs": 0,
         "input_tokens": 0,
         "output_tokens": 0,
         "termination_reason": termination_reason,
     }
     out.update(kw)
+    if "time_secs" in kw and "agent_time_secs" not in kw and "grading_time_secs" not in kw:
+        out["agent_time_secs"] = kw["time_secs"]
     return out
 
 
@@ -208,9 +212,9 @@ def test_summary_excludes_non_genuine_results_from_pass_rate(tmp_path):
         results, str(tmp_path), total_benchmarks=5, backend_name="copilot", mode_name="proof-completion"
     )
     summary = (tmp_path / "summary.md").read_text()
-    assert "**Pass rate**: 1/2 (50.0%) · 1 skipped · 2 infra/quota-cut (excluded — re-run)" in summary
+    assert "**Pass rate**: 2/3 (66.7%) · 1 skipped · 1 error/interrupted (excluded — re-run)" in summary
     assert "`infra-pass.tla` | ✅ PASS" in summary
-    assert "INFRA_ERROR (excluded — re-run)" in summary
+    assert "`quota-error.tla`" in summary and "QUOTA_EXHAUSTED (excluded — re-run)" in summary
 
 
 def test_summary_uses_strict_specification_pass_rate_as_primary_for_manifest_suites(tmp_path):
@@ -285,8 +289,8 @@ def test_summary_reports_time_and_equivalent_cost_without_zero_filling(tmp_path)
     summary = (tmp_path / "summary.md").read_text()
     assert "**Total task time**: 4.0s" in summary
     assert "**Equivalent cost**: unavailable" in summary
-    assert "`priced.tla` | ✅ PASS | 1.2s | $0.125000" in summary
-    assert "`legacy.tla` | ❌ FAIL | 2.8s | unavailable" in summary
+    assert "`priced.tla` | ✅ PASS | 1.2s | 0.0s | 1.2s | $0.125000" in summary
+    assert "`legacy.tla` | ❌ FAIL | 2.8s | 0.0s | 2.8s | unavailable" in summary
 
 
 def test_cursor_summary_uses_cost_time_format(tmp_path):
@@ -303,8 +307,8 @@ def test_cursor_summary_uses_cost_time_format(tmp_path):
     summary = (tmp_path / "summary.md").read_text()
     assert "**Equivalent cost**: unavailable" in summary
     assert "**Total task time**: 1.2s" in summary
-    assert "| Benchmark | Verdict | Time | Equivalent cost | Obligations |" in summary
-    assert "`cursor.tla` | ✅ PASS | 1.2s | unavailable |" in summary
+    assert "| Benchmark | Verdict | Agent | Grading | Total | Equivalent cost | Obligations |" in summary
+    assert "`cursor.tla` | ✅ PASS | 1.2s | 0.0s | 1.2s | unavailable |" in summary
 
 
 def test_summary_reports_cost_warning_and_excludes_infra_accounting(tmp_path):
@@ -402,7 +406,7 @@ def test_codex_container_pricing_ignores_unmounted_host_service_tier(tmp_path, m
     )
 
 
-def test_resume_does_not_skip_non_genuine_pass_results():
+def test_resume_skips_verified_pass_results_even_after_interruption():
     results = [
         _result("genuine-pass.tla", "PASS"),
         _result("legacy-pass.tla", "PASS", termination_reason=None),
@@ -411,7 +415,13 @@ def test_resume_does_not_skip_non_genuine_pass_results():
         _result("skipped.tla", "SKIP"),
         _result("failed.tla", "FAIL"),
     ]
-    assert runner._resume_done_benchmarks(results) == {"genuine-pass.tla", "legacy-pass.tla", "skipped.tla"}
+    assert runner._resume_done_benchmarks(results) == {
+        "genuine-pass.tla",
+        "legacy-pass.tla",
+        "infra-pass.tla",
+        "quota-pass.tla",
+        "skipped.tla",
+    }
 
 
 def test_resumed_result_replaces_non_genuine_attempt(tmp_path):
@@ -557,12 +567,14 @@ def test_retry_time_keeps_only_formal_attempt_and_separates_infra_time(tmp_path,
     _install_agent(monkeypatch, backend, [STARTUP, GENUINE_FAIL])
     _install_grader(monkeypatch, verdict="FAIL")
     _no_sleep(monkeypatch)
-    clock = iter((10.0, 12.0, 20.0, 25.0))
+    clock = iter((10.0, 12.0, 20.0, 25.0, 30.0, 31.0))
     monkeypatch.setattr(runner.time, "monotonic", lambda: next(clock))
 
     result = runner.run_single_benchmark(_work_item(tmp_path, backend, infra_retries=1))
 
-    assert result["time_secs"] == 5.0
+    assert result["agent_time_secs"] == 5.0
+    assert result["grading_time_secs"] == 1.0
+    assert result["time_secs"] == 6.0
     diagnostic = json.loads(
         (tmp_path / "out" / "Foo" / "Bar" / "agent" / "attempts" / "attempt-0" / "accounting.json").read_text()
     )

--- a/tests/evaluator/test_proof_module_result.py
+++ b/tests/evaluator/test_proof_module_result.py
@@ -296,6 +296,16 @@ def test_parser_records_complete_report_and_derived_totals() -> None:
     assert result["obligations_complete"] is True
 
 
+def test_parser_does_not_overwrite_module_obligation_sum_with_last_text_summary() -> None:
+    report = _complete_report()
+    output = _machine_output(report) + "[INFO]: All 2 obligations proved.\n"
+
+    result = _parse(report, 0, output=output)
+
+    assert result["obligations"] == 9
+    assert result["obligations_complete"] is True
+
+
 def test_parser_records_partial_report_as_fail_with_derived_totals() -> None:
     result = _parse(_partial_report(), 1)
 

--- a/tests/evaluator/test_proof_module_result.py
+++ b/tests/evaluator/test_proof_module_result.py
@@ -30,6 +30,7 @@ def _unit(
     tlapm_exit: int | None = 0,
     missing_proofs: int | None = 0,
     obligation_failed: bool | None = False,
+    obligations: int | None = 3,
     trusted: bool = True,
 ) -> dict[str, object]:
     kind = "helper" if unit_id.startswith("helper:") else "target"
@@ -44,6 +45,7 @@ def _unit(
         "tlapm_exit": tlapm_exit,
         "missing_proofs": missing_proofs,
         "obligation_failed": obligation_failed,
+        "obligations": obligations,
         "trusted": trusted,
     }
 
@@ -74,6 +76,7 @@ def _partial_report() -> dict[str, object]:
             tlapm_exit=11,
             missing_proofs=1,
             obligation_failed=False,
+            obligations=2,
             trusted=False,
         ),
     ]
@@ -102,6 +105,15 @@ def test_accepts_a_complete_dependency_closed_report() -> None:
 
 def test_accepts_a_partial_report_with_only_the_first_target_trusted() -> None:
     report = _partial_report()
+
+    assert validate_module_result(report, EXPECTED_UNITS) == report
+
+
+def test_accepts_a_legacy_v1_report_without_obligation_counts() -> None:
+    report = _partial_report()
+    report["schema_version"] = 1
+    for unit in report["units"]:
+        unit.pop("obligations")
 
     assert validate_module_result(report, EXPECTED_UNITS) == report
 
@@ -280,6 +292,8 @@ def test_parser_records_complete_report_and_derived_totals() -> None:
     assert result["proof_unit_count"] == 2
     assert result["trusted_proof_unit_count"] == 2
     assert result["trusted_proof_unit_ids"] == list(EXPECTED_UNITS)
+    assert result["obligations"] == 9
+    assert result["obligations_complete"] is True
 
 
 def test_parser_records_partial_report_as_fail_with_derived_totals() -> None:
@@ -289,6 +303,50 @@ def test_parser_records_partial_report_as_fail_with_derived_totals() -> None:
     assert result["proof_unit_count"] == 2
     assert result["trusted_proof_unit_count"] == 1
     assert result["trusted_proof_unit_ids"] == [UNIT_A]
+
+
+def test_parser_reports_known_obligations_as_a_lower_bound_after_unit_timeout() -> None:
+    report = _partial_report()
+    report["units"][1].update(
+        raw_verdict="TIMEOUT",
+        tlapm_exit=None,
+        missing_proofs=None,
+        obligation_failed=None,
+        obligations=None,
+    )
+
+    result = _parse(report, 3)
+
+    assert result["check_verdict"] == "TIMEOUT"
+    assert result["obligations"] == 3
+    assert result["obligations_complete"] is False
+
+
+def test_parser_classifies_an_explicit_pre_result_checker_timeout() -> None:
+    result: dict[str, object] = {}
+
+    _parse_grader_result(
+        3,
+        "SANY-STATUS: unavailable\nCHECK-TIMEOUT: checker budget exhausted\n",
+        result,
+        expected_module_unit_ids=EXPECTED_UNITS,
+    )
+
+    assert result["check_verdict"] == "TIMEOUT"
+    assert result["sany_status"] == "unavailable"
+
+
+def test_parser_keeps_unavailable_sany_without_a_timeout_marker_as_error() -> None:
+    result: dict[str, object] = {}
+
+    _parse_grader_result(
+        3,
+        "SANY-STATUS: unavailable\nERROR: SANY executable missing\n",
+        result,
+        expected_module_unit_ids=EXPECTED_UNITS,
+    )
+
+    assert result["check_verdict"] == "ERROR"
 
 
 @pytest.mark.parametrize(

--- a/tests/evaluator/test_proof_module_resume_regressions.py
+++ b/tests/evaluator/test_proof_module_resume_regressions.py
@@ -277,7 +277,11 @@ def test_pending_first_attempt_grades_saved_bytes_without_agent_and_preserves_ac
     assert recovered["check_verdict"] == "PASS"
     assert recovered["input_tokens"] == 123
     assert recovered["output_tokens"] == 456
-    assert recovered["time_secs"] == 3.25
+    assert recovered["agent_time_secs"] == 3.25
+    assert recovered["grading_time_secs"] > 0
+    assert recovered["time_secs"] == pytest.approx(
+        recovered["agent_time_secs"] + recovered["grading_time_secs"]
+    )
     assert recovered["equivalent_cost_usd"] == 0.012
     assert recovered["usage"] == {"input_tokens": 123, "output_tokens": 456, "model_requests": 1}
 
@@ -303,8 +307,16 @@ def test_failed_regrade_keeps_pending_artifact_until_the_same_bytes_are_graded(t
         grader_calls += 1
         assert Path(workspace, basename).read_bytes() == saved
         if grader_calls == 1:
-            result["check_verdict"] = "ERROR"
-            result["error"] = "checker unavailable"
+            result.update(
+                {
+                    "check_verdict": "ERROR",
+                    "error": "checker unavailable",
+                    "module_result": _module_result(complete=False),
+                    "proof_unit_count": 1,
+                    "trusted_proof_unit_count": 0,
+                    "trusted_proof_unit_ids": [],
+                }
+            )
         else:
             _complete_grading(result)
 
@@ -322,6 +334,8 @@ def test_failed_regrade_keeps_pending_artifact_until_the_same_bytes_are_graded(t
 
     assert first["module_grading_pending"] == 0
     assert first["module_artifact"] == artifact
+    assert first["grading_time_secs"] == 0
+    assert first["grader_error_time_secs"] > 0
     assert runner._module_resume_action(first, max_continuations=1) == runner.MODULE_RESUME_GRADE_SAVED
     checkpoint = load_module_checkpoint(output_dir, identity)
     assert checkpoint.result["module_grading_pending"] == 0
@@ -340,6 +354,11 @@ def test_failed_regrade_keeps_pending_artifact_until_the_same_bytes_are_graded(t
     assert second["check_verdict"] == "PASS"
     assert "module_grading_pending" not in second
     assert second["module_artifact"] == artifact
+    assert second["grading_time_secs"] > 0
+    assert second["agent_time_secs"] is None
+    assert second["time_secs"] is None
+    assert second["error"] == ""
+    assert "grader_error" not in second
 
 
 def test_zero_work_quota_does_not_grade_canonical_input_or_consume_pass_at_one(tmp_path, monkeypatch):
@@ -532,7 +551,7 @@ def test_zero_work_nonretryable_infra_first_attempt_does_not_materialize_or_grad
     assert runner._module_resume_action(result, max_continuations=0) == runner.MODULE_RESUME_RETRY_FIRST
 
 
-def test_quota_after_model_work_grades_and_preserves_the_formal_first_attempt(tmp_path, monkeypatch):
+def test_quota_after_model_work_grades_for_diagnostics_but_retries_first_attempt(tmp_path, monkeypatch):
     benchmark_root = tmp_path / "benchmark"
     task = benchmark_root / TASK_ID
     task.parent.mkdir(parents=True)
@@ -613,10 +632,12 @@ def test_quota_after_model_work_grades_and_preserves_the_formal_first_attempt(tm
     assert result["graded_after_interruption"] is True
     assert result["input_tokens"] == 25
     assert result["output_tokens"] == 50
-    assert result["time_secs"] == 4.5
+    assert result["agent_time_secs"] == 4.5
+    assert result["grading_time_secs"] > 0
+    assert result["time_secs"] == pytest.approx(result["agent_time_secs"] + result["grading_time_secs"])
     assert result["equivalent_cost_usd"] == 0.02
     assert result["module_artifact"]["sha256"] == hashlib.sha256(submitted).hexdigest()
-    assert runner._module_resume_action(result, max_continuations=0) == runner.MODULE_RESUME_COMPLETE
+    assert runner._module_resume_action(result, max_continuations=0) == runner.MODULE_RESUME_RETRY_FIRST
 
 
 @pytest.mark.parametrize(
@@ -626,7 +647,7 @@ def test_quota_after_model_work_grades_and_preserves_the_formal_first_attempt(tm
         ("empty", False, "INFRA_ERROR", "module submission is empty"),
     ],
 )
-def test_interrupted_model_work_with_invalid_submission_consumes_pass_at_one(
+def test_interrupted_model_work_with_invalid_submission_requires_first_attempt_retry(
     tmp_path,
     monkeypatch,
     submission_state,
@@ -710,14 +731,14 @@ def test_interrupted_model_work_with_invalid_submission_consumes_pass_at_one(
     assert "module_result" not in result
     assert (result["input_tokens"], result["output_tokens"]) == (100, 50)
     assert result["equivalent_cost_usd"] == 0.25
-    assert not runner.is_non_genuine(result)
-    assert runner._module_resume_action(result, max_continuations=0) == runner.MODULE_RESUME_COMPLETE
+    assert runner.is_non_genuine(result)
+    assert runner._module_resume_action(result, max_continuations=0) == runner.MODULE_RESUME_RETRY_FIRST
     checkpoint = load_module_checkpoint(output_dir, _identity())
     assert checkpoint.result["invalid_submission_after_interruption"] is True
 
 
 @pytest.mark.parametrize("submission_state", ["missing", "empty"])
-def test_invalid_first_submission_uses_the_same_continuation_bytes_before_and_after_resume(
+def test_invalid_interrupted_first_submission_retries_pass_at_one_from_canonical_bytes(
     tmp_path,
     monkeypatch,
     submission_state,
@@ -811,27 +832,9 @@ def test_invalid_first_submission_uses_the_same_continuation_bytes_before_and_af
     assert completed == set()
     assert recovered[0]["check_verdict"] == "FAIL"
     resume = resumes[TASK_ID]
-    assert resume.action == runner.MODULE_RESUME_CONTINUE
+    assert resume.action == runner.MODULE_RESUME_RETRY_FIRST
     assert resume.submission is None
-
-    resumed_item = runner.WorkItem(
-        benchmark_path=str(task),
-        output_dir=str(output_dir),
-        timeout=10,
-        check_timeout=10,
-        backend=backend,
-        mode=mode,
-        tlapm_path="/opt/tlapm",
-        tlapm_lib="/opt/tlapm/lib",
-        infra_retries=0,
-        max_continuations=1,
-        canonical_inputs=canonical_inputs,
-        module_resume=resume,
-        module_checkpoint_identity=identity,
-    )
-    runner.run_single_benchmark(resumed_item)
-
-    assert continuation_inputs == [canonical_bytes, canonical_bytes]
+    assert continuation_inputs == []
 
 
 def test_first_attempt_checker_failure_keeps_artifact_pending_and_stops_continuations(tmp_path, monkeypatch):
@@ -962,7 +965,11 @@ def test_pending_continuation_grades_as_continuation_and_keeps_pass_at_one(tmp_p
     assert recovered["continuations"][0]["check_verdict"] == "PASS"
     assert recovered["input_tokens"] == 100
     assert recovered["output_tokens"] == 200
-    assert recovered["time_secs"] == 4.0
+    assert recovered["agent_time_secs"] == 4.0
+    assert recovered["grading_time_secs"] > 0
+    assert recovered["time_secs"] == pytest.approx(
+        recovered["agent_time_secs"] + recovered["grading_time_secs"]
+    )
     assert recovered["equivalent_cost_usd"] == 0.02
 
 
@@ -1020,7 +1027,7 @@ def test_recover_retries_interrupted_continuation_at_same_round_without_losing_h
     assert recovered[0]["equivalent_cost_usd"] == 0.03
 
 
-def test_recover_keeps_graded_interrupted_model_work_as_first_attempt_and_continues(tmp_path):
+def test_recover_retries_graded_but_interrupted_first_attempt(tmp_path):
     identity, result = _checkpoint_result(tmp_path, max_continuations=1)
     result.update(
         {
@@ -1043,7 +1050,7 @@ def test_recover_keeps_graded_interrupted_model_work_as_first_attempt_and_contin
     )
 
     assert completed == set()
-    assert resumes[TASK_ID].action == runner.MODULE_RESUME_CONTINUE
+    assert resumes[TASK_ID].action == runner.MODULE_RESUME_RETRY_FIRST
     assert recovered[0]["check_verdict"] == "FAIL"
     assert recovered[0]["graded_after_interruption"] is True
     assert recovered[0]["input_tokens"] == 100
@@ -1472,7 +1479,7 @@ def test_interrupted_worked_continuation_regrade_consumes_the_same_round(tmp_pat
     )
 
     assert "module_grading_pending" not in result
-    assert not runner.is_non_genuine(result["continuations"][0])
+    assert runner.is_non_genuine(result["continuations"][0])
     assert runner._module_resume_action(result, max_continuations=2) == runner.MODULE_RESUME_CONTINUE
 
     selected_rounds: list[int] = []
@@ -1494,8 +1501,8 @@ def test_interrupted_worked_continuation_regrade_consumes_the_same_round(tmp_pat
             "/checker",
         )
 
-    assert selected_rounds == [2]
-    assert "interrupted_continuations" not in result
+    assert selected_rounds == [1]
+    assert len(result["interrupted_continuations"]) == 1
 
 
 def test_interrupted_worked_continuation_with_missing_submission_consumes_the_round(tmp_path, monkeypatch):
@@ -1590,7 +1597,7 @@ def test_interrupted_worked_continuation_with_missing_submission_consumes_the_ro
     assert failed_round["invalid_submission_after_interruption"] is True
     assert "module_artifact" not in failed_round
     assert "module_result" not in failed_round
-    assert not runner.is_non_genuine(failed_round)
+    assert runner.is_non_genuine(failed_round)
     assert (workspace / "Task.tla").read_bytes() == prior_submission
     assert (result["input_tokens"], result["output_tokens"]) == (13, 24)
     assert result["equivalent_cost_usd"] == pytest.approx(0.11)
@@ -1618,8 +1625,8 @@ def test_interrupted_worked_continuation_with_missing_submission_consumes_the_ro
             "/checker",
         )
 
-    assert selected_rounds == [2]
-    assert "interrupted_continuations" not in result
+    assert selected_rounds == [1]
+    assert len(result["interrupted_continuations"]) == 1
 
 
 def test_checkpoint_rejects_graded_result_without_artifact(tmp_path):
@@ -1711,9 +1718,10 @@ def test_checkpoint_rejects_round_after_passing_continuation(tmp_path):
                 proof_unit_count=1,
                 trusted_proof_unit_count=0,
                 trusted_proof_unit_ids=[],
+                check_verdict="FAIL",
                 module_grading_pending=0,
             ),
-            "already graded",
+            "successfully graded",
         ),
     ],
 )

--- a/tests/evaluator/test_proof_module_resume_regressions.py
+++ b/tests/evaluator/test_proof_module_resume_regressions.py
@@ -767,6 +767,184 @@ def test_exhausted_first_attempt_timeout_is_not_reset_on_resume(tmp_path, monkey
     assert recovered["time_secs"] == 11.0
 
 
+def test_exhausted_first_attempt_starts_first_continuation_with_fresh_round_timeout(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    partial = b"partial module after exhausted first attempt"
+    identity, result = _checkpoint_result(output_dir, first_content=partial, max_continuations=1)
+    result.update(
+        {
+            "termination_reason": "INFRA_ERROR",
+            "graded_after_interruption": True,
+            "agent_time_secs": 10.0,
+            "grading_time_secs": 1.0,
+            "logical_timeout_used_secs": 10.0,
+            "time_secs": 11.0,
+            "logical_timeout_secs": 10,
+            "max_continuations": 1,
+        }
+    )
+    write_module_checkpoint(output_dir, identity, result)
+    item = _resume_item(
+        tmp_path,
+        result,
+        partial,
+        action=runner.MODULE_RESUME_RETRY_FIRST,
+        max_continuations=1,
+    )
+    continuation_usage = UsageSummary(
+        input_tokens=2,
+        output_tokens=3,
+        model_requests=1,
+        available=True,
+        complete=True,
+    )
+    observed: list[tuple[float, int, bytes]] = []
+
+    def continuation_segment(execution_item, _prompt, *_args, **kwargs):
+        workspace = Path(kwargs["fixed_workspace"])
+        round_result = _args[3]
+        observed.append((execution_item.timeout, round_result["round"], (workspace / "Task.tla").read_bytes()))
+        (workspace / "Task.tla").write_bytes(b"completed by continuation")
+        canonical = tmp_path / "first-timeout-continuation-canonical"
+        canonical.mkdir()
+        round_result.update(
+            {
+                "agent_exit": 0,
+                "termination_reason": "OK",
+                "agent_time_secs": 1.0,
+                "grading_time_secs": 0.0,
+                "logical_timeout_used_secs": 1.0,
+                "time_secs": 1.0,
+                "usage": continuation_usage.to_dict(),
+                "input_tokens": 2,
+                "output_tokens": 3,
+                "equivalent_cost_usd": 0.01,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical),
+            "continuation model work",
+            False,
+            False,
+            False,
+            True,
+            [],
+            continuation_usage,
+        )
+
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(runner, "_run_backend_with_retries", continuation_segment)
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args, **_kwargs: _complete_grading(args[5]))
+
+    recovered = runner.run_single_benchmark(item)
+
+    assert observed == [(10, 1, partial)]
+    assert recovered["check_verdict"] == "TIMEOUT"
+    assert [round_result["check_verdict"] for round_result in recovered["continuations"]] == ["PASS"]
+    assert recovered["continuations"][0]["round"] == 1
+
+
+def test_repeated_interruption_with_invalid_submission_keeps_fallback_artifact_and_accounting(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    partial = b"durable partial module"
+    identity, result = _checkpoint_result(output_dir, first_content=partial)
+    artifact = result["module_artifact"]
+    result.update(
+        {
+            "termination_reason": "INFRA_ERROR",
+            "graded_after_interruption": True,
+            "agent_time_secs": 3.0,
+            "grading_time_secs": 0.5,
+            "logical_timeout_used_secs": 3.0,
+            "time_secs": 3.5,
+            "logical_timeout_secs": 10,
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "usage": UsageSummary(
+                input_tokens=10,
+                output_tokens=20,
+                model_requests=1,
+                available=True,
+                complete=True,
+            ).to_dict(),
+            "equivalent_cost_usd": 0.1,
+        }
+    )
+    write_module_checkpoint(output_dir, identity, result)
+    item = _resume_item(tmp_path, result, partial, action=runner.MODULE_RESUME_RETRY_FIRST)
+    interrupted_usage = UsageSummary(
+        input_tokens=3,
+        output_tokens=4,
+        model_requests=1,
+        available=True,
+        complete=True,
+    )
+
+    def interrupted_invalid_segment(execution_item, _prompt, *_args, **_kwargs):
+        workspace = tmp_path / "repeated-interruption-workspace"
+        canonical = tmp_path / "repeated-interruption-canonical"
+        workspace.mkdir()
+        canonical.mkdir()
+        item.canonical_inputs.materialize(str(workspace))
+        item.canonical_inputs.materialize(str(canonical))
+        (workspace / "Task.tla").write_bytes(execution_item.module_resume.submission)
+        (workspace / "Task.tla").unlink()
+        segment_result = _args[3]
+        segment_result.update(
+            {
+                "agent_exit": -1,
+                "termination_reason": "OK",
+                "agent_time_secs": 2.0,
+                "grading_time_secs": 0.0,
+                "logical_timeout_used_secs": 2.0,
+                "time_secs": 2.0,
+                "usage": interrupted_usage.to_dict(),
+                "input_tokens": 3,
+                "output_tokens": 4,
+                "equivalent_cost_usd": 0.02,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical),
+            "model deleted its submission before interruption",
+            True,
+            True,
+            False,
+            True,
+            [],
+            interrupted_usage,
+        )
+
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(runner, "_run_backend_with_retries", interrupted_invalid_segment)
+    monkeypatch.setattr(
+        runner,
+        "_run_grader_local",
+        lambda *_args, **_kwargs: pytest.fail("an invalid segment must not reach the grader"),
+    )
+
+    recovered = runner.run_single_benchmark(item)
+
+    assert recovered["check_verdict"] == "FAIL"
+    assert recovered["termination_reason"] == "QUOTA_EXHAUSTED"
+    assert recovered["invalid_submission_after_interruption"] is True
+    assert recovered["module_artifact"] == artifact
+    assert "module_result" not in recovered
+    assert recovered["agent_time_secs"] == 5.0
+    assert recovered["logical_timeout_used_secs"] == 5.0
+    assert (recovered["input_tokens"], recovered["output_tokens"]) == (13, 24)
+    assert recovered["equivalent_cost_usd"] == pytest.approx(0.12)
+    assert "cannot checkpoint module progress" not in recovered["error"]
+    checkpoint = load_module_checkpoint(output_dir, identity)
+    assert checkpoint.result["invalid_submission_after_interruption"] is True
+    assert checkpoint.result["module_artifact"] == artifact
+    assert checkpoint.result["agent_time_secs"] == 5.0
+
+
 @pytest.mark.parametrize(
     ("submission_state", "quota_exhausted", "expected_termination", "expected_error"),
     [
@@ -1774,6 +1952,105 @@ def test_interrupted_continuation_resume_keeps_round_accounting_and_remaining_ti
     assert result["grading_time_secs"] > 1.5
     assert (result["input_tokens"], result["output_tokens"]) == (18, 30)
     assert result["equivalent_cost_usd"] == pytest.approx(0.17)
+
+
+def test_exhausted_interrupted_continuation_consumes_round_and_starts_next_round(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    first_submission = b"first partial module"
+    interrupted_submission = b"round one partial module"
+    identity, result = _checkpoint_result(
+        output_dir,
+        first_content=first_submission,
+        continuation_contents=(interrupted_submission,),
+        continuation_verdicts=("FAIL",),
+        continuation_termination_reasons=("INFRA_ERROR",),
+        max_continuations=2,
+    )
+    interrupted_round = result["continuations"][0]
+    interrupted_round.update(
+        {
+            "graded_after_interruption": True,
+            "agent_time_secs": 10.0,
+            "grading_time_secs": 0.5,
+            "logical_timeout_used_secs": 10.0,
+            "time_secs": 10.5,
+            "logical_timeout_secs": 10,
+        }
+    )
+    write_module_checkpoint(output_dir, identity, result)
+    item = _resume_item(
+        tmp_path,
+        result,
+        interrupted_submission,
+        action=runner.MODULE_RESUME_CONTINUE,
+        max_continuations=2,
+    )
+    workspace = tmp_path / "exhausted-continuation-workspace"
+    workspace.mkdir()
+    (workspace / "Task.tla").write_bytes(interrupted_submission)
+    next_usage = UsageSummary(
+        input_tokens=2,
+        output_tokens=3,
+        model_requests=1,
+        available=True,
+        complete=True,
+    )
+    observed: list[tuple[float, int]] = []
+
+    def next_round_segment(execution_item, _prompt, *_args, **_kwargs):
+        round_result = _args[3]
+        observed.append((execution_item.timeout, round_result["round"]))
+        (workspace / "Task.tla").write_bytes(b"completed in round two")
+        canonical = tmp_path / "next-round-canonical"
+        canonical.mkdir()
+        round_result.update(
+            {
+                "agent_exit": 0,
+                "termination_reason": "OK",
+                "agent_time_secs": 1.0,
+                "grading_time_secs": 0.0,
+                "logical_timeout_used_secs": 1.0,
+                "time_secs": 1.0,
+                "usage": next_usage.to_dict(),
+                "input_tokens": 2,
+                "output_tokens": 3,
+                "equivalent_cost_usd": 0.01,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical),
+            "round two model work",
+            False,
+            False,
+            False,
+            True,
+            [],
+            next_usage,
+        )
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", next_round_segment)
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args, **_kwargs: _complete_grading(args[5]))
+
+    runner._run_continuations(
+        item,
+        str(workspace),
+        result,
+        str(tmp_path / "task-result"),
+        "Task.tla",
+        "Task",
+        item.canonical_inputs,
+        "/checker",
+    )
+
+    assert observed == [(10, 2)]
+    assert [(round_result["round"], round_result["check_verdict"]) for round_result in result["continuations"]] == [
+        (1, "TIMEOUT"),
+        (2, "PASS"),
+    ]
+    assert result["continuations"][0]["logical_timeout_remaining_secs"] == 0.0
+    assert result["continuations"][1]["logical_timeout_secs"] == 10
 
 
 def test_interrupted_worked_continuation_with_missing_submission_consumes_the_round(tmp_path, monkeypatch):

--- a/tests/evaluator/test_proof_module_resume_regressions.py
+++ b/tests/evaluator/test_proof_module_resume_regressions.py
@@ -279,9 +279,7 @@ def test_pending_first_attempt_grades_saved_bytes_without_agent_and_preserves_ac
     assert recovered["output_tokens"] == 456
     assert recovered["agent_time_secs"] == 3.25
     assert recovered["grading_time_secs"] > 0
-    assert recovered["time_secs"] == pytest.approx(
-        recovered["agent_time_secs"] + recovered["grading_time_secs"]
-    )
+    assert recovered["time_secs"] == pytest.approx(recovered["agent_time_secs"] + recovered["grading_time_secs"])
     assert recovered["equivalent_cost_usd"] == 0.012
     assert recovered["usage"] == {"input_tokens": 123, "output_tokens": 456, "model_requests": 1}
 
@@ -967,9 +965,7 @@ def test_pending_continuation_grades_as_continuation_and_keeps_pass_at_one(tmp_p
     assert recovered["output_tokens"] == 200
     assert recovered["agent_time_secs"] == 4.0
     assert recovered["grading_time_secs"] > 0
-    assert recovered["time_secs"] == pytest.approx(
-        recovered["agent_time_secs"] + recovered["grading_time_secs"]
-    )
+    assert recovered["time_secs"] == pytest.approx(recovered["agent_time_secs"] + recovered["grading_time_secs"])
     assert recovered["equivalent_cost_usd"] == 0.02
 
 

--- a/tests/evaluator/test_proof_module_resume_regressions.py
+++ b/tests/evaluator/test_proof_module_resume_regressions.py
@@ -638,6 +638,135 @@ def test_quota_after_model_work_grades_for_diagnostics_but_retries_first_attempt
     assert runner._module_resume_action(result, max_continuations=0) == runner.MODULE_RESUME_RETRY_FIRST
 
 
+def test_interrupted_first_attempt_resume_keeps_accounting_and_uses_only_remaining_timeout(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    partial = b"partial first-attempt module"
+    identity, result = _checkpoint_result(output_dir, first_content=partial)
+    result.update(
+        {
+            "termination_reason": "INFRA_ERROR",
+            "graded_after_interruption": True,
+            "agent_time_secs": 3.0,
+            "grading_time_secs": 1.0,
+            "logical_timeout_used_secs": 4.0,
+            "time_secs": 4.0,
+            "logical_timeout_secs": 10,
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "usage": UsageSummary(
+                input_tokens=10,
+                output_tokens=20,
+                model_requests=1,
+                available=True,
+                complete=True,
+            ).to_dict(),
+            "equivalent_cost_usd": 0.1,
+        }
+    )
+    write_module_checkpoint(output_dir, identity, result)
+    item = _resume_item(tmp_path, result, partial, action=runner.MODULE_RESUME_RETRY_FIRST)
+    resumed_usage = UsageSummary(
+        input_tokens=3,
+        output_tokens=4,
+        model_requests=1,
+        available=True,
+        complete=True,
+    )
+    observed_timeouts: list[float] = []
+    observed_inputs: list[bytes] = []
+
+    def resumed_segment(execution_item, _prompt, *_args, **_kwargs):
+        observed_timeouts.append(execution_item.timeout)
+        workspace = tmp_path / "resumed-first-workspace"
+        canonical = tmp_path / "resumed-first-canonical"
+        workspace.mkdir()
+        canonical.mkdir()
+        item.canonical_inputs.materialize(str(workspace))
+        item.canonical_inputs.materialize(str(canonical))
+        (workspace / "Task.tla").write_bytes(execution_item.module_resume.submission)
+        observed_inputs.append((workspace / "Task.tla").read_bytes())
+        (workspace / "Task.tla").write_bytes(b"completed first-attempt module")
+        segment_result = _args[3]
+        segment_result.update(
+            {
+                "agent_exit": 0,
+                "termination_reason": "OK",
+                "agent_time_secs": 2.0,
+                "grading_time_secs": 0.0,
+                "logical_timeout_used_secs": 2.0,
+                "time_secs": 2.0,
+                "usage": resumed_usage.to_dict(),
+                "input_tokens": 3,
+                "output_tokens": 4,
+                "equivalent_cost_usd": 0.05,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical),
+            "resumed model work",
+            False,
+            False,
+            False,
+            True,
+            [],
+            resumed_usage,
+        )
+
+    monkeypatch.setattr(runner.quota, "wait_for_quota", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(runner, "_run_backend_with_retries", resumed_segment)
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args, **_kwargs: _complete_grading(args[5]))
+
+    recovered = runner.run_single_benchmark(item)
+
+    assert observed_timeouts == [6.0]
+    assert observed_inputs == [partial]
+    assert recovered["check_verdict"] == "PASS"
+    assert recovered["logical_resume_count"] == 1
+    assert recovered["agent_time_secs"] == 5.0
+    assert recovered["logical_timeout_used_secs"] == 6.0
+    assert recovered["logical_timeout_remaining_secs"] == 4.0
+    assert recovered["grading_time_secs"] > 1.0
+    assert recovered["time_secs"] == pytest.approx(recovered["agent_time_secs"] + recovered["grading_time_secs"])
+    assert (recovered["input_tokens"], recovered["output_tokens"]) == (13, 24)
+    assert recovered["equivalent_cost_usd"] == pytest.approx(0.15)
+
+
+def test_exhausted_first_attempt_timeout_is_not_reset_on_resume(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    partial = b"partial module at timeout boundary"
+    identity, result = _checkpoint_result(output_dir, first_content=partial)
+    result.update(
+        {
+            "termination_reason": "INFRA_ERROR",
+            "graded_after_interruption": True,
+            "agent_time_secs": 10.0,
+            "grading_time_secs": 1.0,
+            "logical_timeout_used_secs": 10.0,
+            "time_secs": 11.0,
+            "logical_timeout_secs": 10,
+        }
+    )
+    write_module_checkpoint(output_dir, identity, result)
+    item = _resume_item(tmp_path, result, partial, action=runner.MODULE_RESUME_RETRY_FIRST)
+
+    monkeypatch.setattr(
+        runner,
+        "_run_backend_with_retries",
+        lambda *_args, **_kwargs: pytest.fail("an exhausted logical attempt must not launch the agent"),
+    )
+
+    recovered = runner.run_single_benchmark(item)
+
+    assert recovered["check_verdict"] == "TIMEOUT"
+    assert recovered["termination_reason"] == "TIMEOUT"
+    assert recovered["logical_timeout_remaining_secs"] == 0.0
+    assert recovered["agent_time_secs"] == 10.0
+    assert recovered["time_secs"] == 11.0
+
+
 @pytest.mark.parametrize(
     ("submission_state", "quota_exhausted", "expected_termination", "expected_error"),
     [
@@ -1011,7 +1140,6 @@ def test_recover_retries_interrupted_continuation_at_same_round_without_losing_h
         {TASK_ID: checkpoint},
         max_continuations=2,
     )
-
     assert completed == set()
     assert resumes[TASK_ID].action == runner.MODULE_RESUME_CONTINUE
     assert recovered[0]["check_verdict"] == "FAIL"
@@ -1062,6 +1190,13 @@ def test_interrupted_continuation_is_archived_when_same_formal_round_restarts(tm
         continuation_verdicts=("ERROR",),
         continuation_termination_reasons=("INFRA_ERROR",),
         max_continuations=2,
+    )
+    result["continuations"][0].update(
+        agent_time_secs=1.0,
+        grading_time_secs=0.0,
+        logical_timeout_used_secs=1.0,
+        time_secs=1.0,
+        logical_timeout_secs=10,
     )
     item = _resume_item(
         tmp_path,
@@ -1499,6 +1634,146 @@ def test_interrupted_worked_continuation_regrade_consumes_the_same_round(tmp_pat
 
     assert selected_rounds == [1]
     assert len(result["interrupted_continuations"]) == 1
+
+
+def test_interrupted_continuation_resume_keeps_round_accounting_and_remaining_timeout(tmp_path, monkeypatch):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    first_submission = b"first partial module"
+    interrupted_submission = b"interrupted continuation module"
+    identity, result = _checkpoint_result(
+        output_dir,
+        first_content=first_submission,
+        continuation_contents=(interrupted_submission,),
+        continuation_verdicts=("FAIL",),
+        continuation_termination_reasons=("INFRA_ERROR",),
+        max_continuations=2,
+    )
+    first_usage = UsageSummary(
+        input_tokens=10,
+        output_tokens=20,
+        model_requests=1,
+        available=True,
+        complete=True,
+    )
+    interrupted_usage = UsageSummary(
+        input_tokens=3,
+        output_tokens=4,
+        model_requests=1,
+        available=True,
+        complete=True,
+    )
+    interrupted_round = result["continuations"][0]
+    interrupted_round.update(
+        {
+            "graded_after_interruption": True,
+            "agent_time_secs": 4.0,
+            "grading_time_secs": 0.5,
+            "logical_timeout_used_secs": 4.0,
+            "time_secs": 4.5,
+            "logical_timeout_secs": 10,
+            "input_tokens": 3,
+            "output_tokens": 4,
+            "usage": interrupted_usage.to_dict(),
+            "equivalent_cost_usd": 0.05,
+        }
+    )
+    result.update(
+        {
+            "agent_time_secs": 6.0,
+            "grading_time_secs": 1.5,
+            "time_secs": 7.5,
+            "input_tokens": 13,
+            "output_tokens": 24,
+            "usage": first_usage.merge(interrupted_usage).to_dict(),
+            "equivalent_cost_usd": 0.15,
+        }
+    )
+    write_module_checkpoint(output_dir, identity, result)
+    item = _resume_item(
+        tmp_path,
+        result,
+        interrupted_submission,
+        action=runner.MODULE_RESUME_CONTINUE,
+        max_continuations=2,
+    )
+    workspace = tmp_path / "continuation-resume-workspace"
+    workspace.mkdir()
+    (workspace / "Task.tla").write_bytes(interrupted_submission)
+    resumed_usage = UsageSummary(
+        input_tokens=5,
+        output_tokens=6,
+        model_requests=1,
+        available=True,
+        complete=True,
+    )
+    observed_timeouts: list[float] = []
+    observed_rounds: list[int] = []
+
+    def resumed_segment(execution_item, _prompt, *_args, **_kwargs):
+        observed_timeouts.append(execution_item.timeout)
+        round_result = _args[3]
+        observed_rounds.append(round_result["round"])
+        (workspace / "Task.tla").write_bytes(b"completed continuation module")
+        canonical = tmp_path / "continuation-resume-canonical"
+        canonical.mkdir()
+        round_result.update(
+            {
+                "agent_exit": 0,
+                "termination_reason": "OK",
+                "agent_time_secs": 2.0,
+                "grading_time_secs": 0.0,
+                "logical_timeout_used_secs": 2.0,
+                "time_secs": 2.0,
+                "input_tokens": 5,
+                "output_tokens": 6,
+                "usage": resumed_usage.to_dict(),
+                "equivalent_cost_usd": 0.02,
+            }
+        )
+        return runner.ExecutionOutcome(
+            str(workspace),
+            str(canonical),
+            "resumed continuation work",
+            False,
+            False,
+            False,
+            True,
+            [],
+            resumed_usage,
+        )
+
+    monkeypatch.setattr(runner, "_run_backend_with_retries", resumed_segment)
+    monkeypatch.setattr(runner, "_run_grader_local", lambda *args, **_kwargs: _complete_grading(args[5]))
+
+    runner._run_continuations(
+        item,
+        str(workspace),
+        result,
+        str(tmp_path / "task-result"),
+        "Task.tla",
+        "Task",
+        item.canonical_inputs,
+        "/checker",
+    )
+
+    assert observed_timeouts == [6.0]
+    assert observed_rounds == [1]
+    assert len(result["continuations"]) == 1
+    recovered_round = result["continuations"][0]
+    assert recovered_round["round"] == 1
+    assert recovered_round["check_verdict"] == "PASS"
+    assert recovered_round["logical_resume_count"] == 1
+    assert recovered_round["agent_time_secs"] == 6.0
+    assert recovered_round["logical_timeout_used_secs"] == 6.0
+    assert recovered_round["logical_timeout_remaining_secs"] == 4.0
+    assert recovered_round["grading_time_secs"] > 0.5
+    assert (recovered_round["input_tokens"], recovered_round["output_tokens"]) == (8, 10)
+    assert recovered_round["equivalent_cost_usd"] == pytest.approx(0.07)
+    assert result["agent_time_secs"] == 8.0
+    assert result["grading_time_secs"] > 1.5
+    assert (result["input_tokens"], result["output_tokens"]) == (18, 30)
+    assert result["equivalent_cost_usd"] == pytest.approx(0.17)
 
 
 def test_interrupted_worked_continuation_with_missing_submission_consumes_the_round(tmp_path, monkeypatch):

--- a/tests/evaluator/test_proof_unit_scoring.py
+++ b/tests/evaluator/test_proof_unit_scoring.py
@@ -139,7 +139,7 @@ def test_with_continuations_keeps_the_first_passing_report() -> None:
     assert (score.trusted_units, score.total_units) == (2, 2)
 
 
-def test_skipped_and_non_genuine_modules_are_excluded_but_genuine_errors_keep_the_denominator() -> None:
+def test_errors_and_skips_are_excluded_but_verified_pass_after_interruption_counts() -> None:
     results = [
         _result(
             "Suite/Good.tla",
@@ -168,9 +168,10 @@ def test_skipped_and_non_genuine_modules_are_excluded_but_genuine_errors_keep_th
 
     score = proof_unit_score(results)
 
-    assert (score.trusted_units, score.total_units) == (1, 4)
+    assert (score.trusted_units, score.total_units) == (3, 4)
+    assert score.excluded_modules == 2
     continuation_score = proof_unit_score(results, with_continuations=True)
-    assert (continuation_score.trusted_units, continuation_score.total_units) == (1, 4)
+    assert (continuation_score.trusted_units, continuation_score.total_units) == (3, 4)
 
 
 def test_non_module_results_do_not_contribute_to_proof_unit_score() -> None:

--- a/tests/evaluator/test_score.py
+++ b/tests/evaluator/test_score.py
@@ -410,8 +410,7 @@ def test_mixed_comparison_excludes_cursor_infra_accounting():
     md = comparison_md(runs, EQUAL, "equal")
 
     assert (
-        "| deferred | cursor | proof-completion | 100.0% | "
-        "1/1 (+1 error/interrupted) | 0/0 | 2.0s | unavailable |"
+        "| deferred | cursor | proof-completion | 100.0% | 1/1 (+1 error/interrupted) | 0/0 | 2.0s | unavailable |"
     ) in md
 
 

--- a/tests/evaluator/test_score.py
+++ b/tests/evaluator/test_score.py
@@ -1,7 +1,7 @@
 """Scoring from results.json.
 
-A task passes iff check_verdict == "PASS"; CHEATING/FAIL/TIMEOUT/ERROR all count
-as not passed, and CHEATING is never shown as its own category. Strict
+A task passes iff check_verdict == "PASS"; CHEATING/FAIL/TIMEOUT count as not
+passed, while ERROR is excluded for retry. CHEATING is never shown as its own category. Strict
 specification pass rate is primary; task-level and specification-macro scores
 remain diagnostics. SKIP is dropped from scoring entirely (neither passed nor
 failed) and only reported as a side count.
@@ -39,8 +39,18 @@ EQUAL = SCORERS["equal"]
 
 
 def _r(verdict, module="M", **kw):
-    d = {"check_verdict": verdict, "module": module, "input_tokens": 0, "output_tokens": 0, "time_secs": 0}
+    d = {
+        "check_verdict": verdict,
+        "module": module,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "agent_time_secs": 0,
+        "grading_time_secs": 0,
+        "time_secs": 0,
+    }
     d.update(kw)
+    if "time_secs" in kw and "agent_time_secs" not in kw and "grading_time_secs" not in kw:
+        d["agent_time_secs"] = kw["time_secs"]
     return d
 
 
@@ -221,18 +231,23 @@ def test_scorecard_separates_tokens_time_and_equivalent_cost():
     md = scorecard_md(run, EQUAL, "equal")
 
     assert "**Cost**:" not in md
-    assert "**Tokens**: 5 in / 7 out" in md
+    assert "**Tokens**: 5 input / 7 output" in md
+    assert "**Total agent time**: 4.0s" in md
+    assert "**Total grading time**: 0.0s" in md
     assert "**Total task time**: 4.0s" in md
     assert "**Equivalent cost**: $0.375000" in md
 
 
-def test_scorecard_preserves_legacy_format_without_equivalent_cost():
+def test_scorecard_reports_split_time_without_equivalent_cost():
     results = [_r("PASS", input_tokens=1, output_tokens=2, time_secs=1.25)]
     run = {"path": "x/results.json", "id": "x", "backend": "cursor", "mode": "proof-completion", "results": results}
 
     md = scorecard_md(run, EQUAL, "equal")
 
-    assert "**Cost**: 1 in / 2 out tokens · 1s total" in md
+    assert "**Tokens**: 1 input / 2 output" in md
+    assert "**Total agent time**: 1.2s" in md
+    assert "**Total grading time**: 0.0s" in md
+    assert "**Total task time**: 1.2s" in md
     assert "**Equivalent cost**:" not in md
 
 
@@ -245,6 +260,22 @@ def test_scorecard_does_not_turn_missing_metrics_into_zero():
 
     assert "**Total task time**: unavailable" in md
     assert "**Equivalent cost**: unavailable" in md
+
+
+def test_scorecard_does_not_render_unavailable_structured_tokens_as_zero():
+    result = _r(
+        "PASS",
+        usage={
+            "available": False,
+            "complete": False,
+            "is_lower_bound": False,
+            "input_tokens": None,
+            "output_tokens": None,
+        },
+    )
+    run = {"path": "x/results.json", "id": "x", "backend": "codex", "mode": "proof-completion", "results": [result]}
+
+    assert "**Tokens**: unavailable" in scorecard_md(run, EQUAL, "equal")
 
 
 def test_scorecard_preserves_known_exact_zero_metrics():
@@ -298,7 +329,7 @@ def test_scorecard_excludes_non_genuine_time_and_cost_and_reports_cost_warning()
     md = scorecard_md(run, EQUAL, "equal")
 
     # Preserve the legacy token summary; only time and cost use formal rows.
-    assert "**Tokens**: 2,008 in / 2,000 out" in md
+    assert "**Tokens**: 2,008 input / 2,000 output" in md
     assert "**Total task time**: 1.5s" in md
     assert "**Equivalent cost**: $0.150000" in md
     assert "## Cost warnings" in md
@@ -354,7 +385,7 @@ def test_comparison_preserves_legacy_columns_without_equivalent_cost():
 
     assert "| Time |" in md
     assert "Equivalent cost" not in md
-    assert "| legacy | cursor | proof-completion | 100.0% | 1/1 | 0/0 | 1s |" in md
+    assert "| legacy | cursor | proof-completion | 100.0% | 1/1 | 0/0 | 1.2s |" in md
 
 
 def test_mixed_comparison_excludes_cursor_infra_accounting():
@@ -378,7 +409,10 @@ def test_mixed_comparison_excludes_cursor_infra_accounting():
 
     md = comparison_md(runs, EQUAL, "equal")
 
-    assert "| deferred | cursor | proof-completion | 100.0% | 1/1 (+1 infra-cut) | 0/0 | 2.0s | unavailable |" in md
+    assert (
+        "| deferred | cursor | proof-completion | 100.0% | "
+        "1/1 (+1 error/interrupted) | 0/0 | 2.0s | unavailable |"
+    ) in md
 
 
 def test_load_run_from_dir(tmp_path):
@@ -414,10 +448,7 @@ def test_all_skip_is_zero_not_crash():
     assert n_skipped(results) == 2
 
 
-def test_non_genuine_terminations_are_excluded_either_verdict():
-    # A startup failure can leave a no-op workspace that grades PASS on a
-    # defective task. INFRA_ERROR / QUOTA_EXHAUSTED results must count neither
-    # as passes nor failures; they need a rerun.
+def test_verified_pass_after_interruption_counts_but_unresolved_results_do_not():
     results = [
         _r("PASS"),
         _r("FAIL"),
@@ -426,8 +457,8 @@ def test_non_genuine_terminations_are_excluded_either_verdict():
         _r("ERROR", termination_reason="QUOTA_EXHAUSTED"),
     ]
     pct, n_pass, n_total = weighted_score(results, EQUAL)
-    assert (n_pass, n_total, pct) == (1, 2, 50.0)
-    assert n_non_genuine(results) == 3
+    assert (n_pass, n_total, pct) == (2, 3, pytest.approx(200 / 3))
+    assert n_non_genuine(results) == 2
 
 
 def test_ok_timeout_and_legacy_results_stay_scored():
@@ -444,11 +475,11 @@ def test_ok_timeout_and_legacy_results_stay_scored():
 
 
 def test_scorecard_reports_non_genuine_count():
-    results = [_r("PASS"), _r("PASS", termination_reason="INFRA_ERROR")]
+    results = [_r("PASS"), _r("ERROR")]
     run = {"path": "x", "id": "r", "backend": "copilot", "mode": "proof-completion", "results": results}
     card = scorecard_md(run, EQUAL, "equal")
     assert "**Pass rate**: 1/1 (100.0%)" in card
-    assert "1 infra/quota-cut (excluded — re-run)" in card
+    assert "1 error/interrupted (excluded — re-run)" in card
 
 
 def test_scorecard_with_no_formal_results_reports_accounting_unavailable():
@@ -539,7 +570,7 @@ def test_continuation_interrupted_only_for_unresolved_cut_chains():
     assert not continuation_interrupted(_r("FAIL"))  # no rounds recorded
 
 
-def test_graded_module_progress_after_interruption_remains_a_genuine_result():
+def test_partial_module_progress_after_interruption_requires_retry():
     result = _r(
         "FAIL",
         termination_reason="QUOTA_EXHAUSTED",
@@ -547,18 +578,18 @@ def test_graded_module_progress_after_interruption_remains_a_genuine_result():
         module_result={"complete": False},
     )
 
-    assert not is_non_genuine(result)
+    assert is_non_genuine(result)
 
 
-def test_invalid_module_submission_after_model_work_remains_a_genuine_failure():
+def test_invalid_module_submission_after_interruption_requires_retry():
     result = _r(
         "FAIL",
         termination_reason="INFRA_ERROR",
         invalid_submission_after_interruption=True,
     )
 
-    assert not is_non_genuine(result)
-    assert not continuation_interrupted(_r("FAIL", continuations=[{"round": 1, **result}]))
+    assert is_non_genuine(result)
+    assert continuation_interrupted(_r("FAIL", continuations=[{"round": 1, **result}]))
 
 
 def test_continuation_budget_uniform_or_none():
@@ -588,7 +619,7 @@ def test_scorecard_labels_continuation_budget_and_excludes_cut_chains():
     assert "**Pass rate**: 0/3 (0.0%)" in md  # the cut chain's genuine first FAIL stays scored
     assert (
         "**Task-micro pass rate with continuations (≤3)**: 1/2 (50.0%) — 1 recovered by continuation "
-        "(pass@1 above is first-attempt only) · 1 chain(s) infra/quota-cut (excluded — re-run)"
+        "(pass@1 above is first-attempt only) · 1 chain(s) interrupted (excluded — re-run)"
     ) in md
 
 

--- a/tests/evaluator/test_score.py
+++ b/tests/evaluator/test_score.py
@@ -128,8 +128,56 @@ def test_specification_equal_excludes_non_applicable_and_unscored_results():
 
     assert score.specification_macro_pct == 100.0
     assert (score.tasks_passed, score.applicable_tasks) == (1, 1)
-    assert (score.complete_specifications, score.represented_specifications) == (1, 1)
+    assert (score.complete_specifications, score.represented_specifications) == (1, 2)
+    assert score.unresolved_specifications == 1
+    assert score.error_affected_specifications == 1
     assert score.non_applicable_results == 1
+
+
+@pytest.mark.parametrize(
+    ("verdicts", "complete", "failed", "unresolved", "resolved", "pass_pct"),
+    [
+        (("PASS", "ERROR"), 0, 0, 1, 0, 0.0),
+        (("FAIL", "ERROR"), 0, 1, 0, 1, 0.0),
+        (("PASS", "PASS"), 1, 0, 0, 1, 100.0),
+    ],
+)
+def test_specification_state_is_tristate(verdicts, complete, failed, unresolved, resolved, pass_pct):
+    specification_ids = scope_specification_ids(
+        "proof-completion",
+        {"A/One.tla": "A/A.tla", "A/Two.tla": "A/A.tla"},
+    )
+    results = [
+        _r(verdict, mode="proof-completion", benchmark=task)
+        for verdict, task in zip(verdicts, ("A/One.tla", "A/Two.tla"), strict=True)
+    ]
+
+    score = specification_equal_score(results, specification_ids)
+
+    assert score.complete_specifications == complete
+    assert score.failed_specifications == failed
+    assert score.unresolved_specifications == unresolved
+    assert score.resolved_specifications == resolved
+    assert score.specification_pass_pct == pass_pct
+    assert score.error_affected_specifications == (1 if "ERROR" in verdicts else 0)
+
+
+def test_scorecard_reports_unresolved_and_error_affected_specifications():
+    specification_ids = scope_specification_ids(
+        "proof-completion",
+        {"A/One.tla": "A/A.tla", "A/Two.tla": "A/A.tla"},
+    )
+    results = [
+        _r("PASS", mode="proof-completion", benchmark="A/One.tla"),
+        _r("ERROR", mode="proof-completion", benchmark="A/Two.tla"),
+    ]
+    run = {"path": "x", "id": "x", "backend": "codex", "mode": "proof-completion", "results": results}
+
+    card = scorecard_md(run, EQUAL, SPECIFICATION_EQUAL, specification_ids)
+
+    assert "**Specification pass rate (all leaves complete)**: 0/0 resolved specifications (0.0%)" in card
+    assert "**Unresolved specifications**: 1 excluded until their errors are retried" in card
+    assert "**Specifications affected by errors**: 1 contain excluded ERROR/interrupted leaves" in card
 
 
 def test_specification_scorecard_shows_strict_primary_before_secondary_diagnostics():
@@ -150,9 +198,9 @@ def test_specification_scorecard_shows_strict_primary_before_secondary_diagnosti
 
     md = scorecard_md(run, EQUAL, SPECIFICATION_EQUAL, specification_ids)
 
-    primary = "**Specification pass rate (all leaves complete)**: 1/2 specifications (50.0%)"
+    primary = "**Specification pass rate (all leaves complete)**: 1/2 resolved specifications (50.0%)"
     task_level = "**Task-micro pass rate**: 2/3 (66.7%)"
-    specification_macro = "**Specification-macro pass rate**: 75.0% across 2 specifications"
+    specification_macro = "**Specification-macro pass rate**: 75.0% across 2 resolved specifications"
     assert primary in md
     assert task_level in md
     assert specification_macro in md
@@ -699,8 +747,8 @@ def test_main_single_prints_scorecard(tmp_path, monkeypatch, capsys):
     assert main() == 0
     out = capsys.readouterr().out
     assert "# Scorecard" in out
-    assert "**Specification pass rate (all leaves complete)**: 0/1 specification (0.0%)" in out
-    assert "**Specification-macro pass rate**: 50.0% across 1 specification" in out
+    assert "**Specification pass rate (all leaves complete)**: 0/1 resolved specification (0.0%)" in out
+    assert "**Specification-macro pass rate**: 50.0% across 1 resolved specification" in out
     assert "**Task-micro pass rate**: 1/2 (50.0%)" in out
 
 

--- a/tests/evaluator/test_usage.py
+++ b/tests/evaluator/test_usage.py
@@ -1,6 +1,13 @@
 """Provider-neutral structured usage schema."""
 
-from evaluator.usage import RequestUsage, UsageCost, UsageSummary
+from evaluator.usage import (
+    RequestUsage,
+    UsageCost,
+    UsageSummary,
+    aggregate_token_usage,
+    format_token_usage,
+    result_token_usage,
+)
 
 
 def test_legacy_adapter_preserves_old_totals_and_marks_unknown_buckets():
@@ -26,6 +33,25 @@ def test_legacy_adapter_preserves_old_totals_and_marks_unknown_buckets():
         "requests": [],
         "warnings": [],
     }
+
+
+def test_unavailable_structured_usage_is_not_rendered_as_legacy_zero() -> None:
+    result = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "usage": UsageSummary(available=False).to_dict(),
+    }
+
+    assert format_token_usage(result_token_usage(result)) == "unavailable"
+    assert format_token_usage(aggregate_token_usage([result]), verbose=True) == "unavailable"
+
+
+def test_lower_bound_token_usage_is_labeled() -> None:
+    usage = UsageSummary(input_tokens=12, output_tokens=3, available=True, is_lower_bound=True)
+    result = {"usage": usage.to_dict()}
+
+    assert format_token_usage(result_token_usage(result)) == "≥12/3"
+    assert format_token_usage(aggregate_token_usage([result]), verbose=True) == "at least 12 input / 3 output"
 
 
 def test_request_totals_do_not_double_count_cache_or_reasoning():


### PR DESCRIPTION
## Summary

- distinguish scored timeouts from retriable grader and infrastructure errors
- aggregate specifications as PASS, FAIL, or UNRESOLVED without promoting excluded ERROR leaves
- resume interrupted logical attempts from saved proofs with cumulative accounting and only the original timeout remainder
- aggregate per-unit module obligations and report agent, grading, and total time separately
- preserve unavailable and lower-bound token usage instead of rendering it as zero